### PR TITLE
Added caching for referenced file sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,6 @@ when you do not recognize the file.
 * <kbd>Ctrl</kbd>+<kbd>K</kbd> Commit and push changes.
 * <kbd>Ctrl</kbd>+<kbd>T</kbd> Pull changes.
 
-
 Any suggestions for improvements of the installation instructions, however small? Please let us know at [gitter](https://gitter.im/TeXiFy-IDEA)!
 
 ## <a name="equation-preview">Equation preview and TikZ Preview</a>

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexCommandsImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexCommandsImpl.java
@@ -18,6 +18,7 @@ import nl.hannahsten.texifyidea.psi.LatexVisitor;
 import nl.hannahsten.texifyidea.reference.LatexLabelReference;
 import nl.hannahsten.texifyidea.util.Magic;
 import nl.hannahsten.texifyidea.util.PsiCommandsKt;
+import nl.hannahsten.texifyidea.util.files.ReferencedFileSetService;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -93,5 +94,12 @@ public class LatexCommandsImpl extends StubBasedPsiElementBase<LatexCommandsStub
     @Override
     public String toString() {
         return "LatexCommandsImpl(COMMANDS)[STUB]{" + getName() + "}";
+    }
+
+    @Override
+    public void subtreeChanged() {
+        ReferencedFileSetService setService = ReferencedFileSetService.getInstance(getProject());
+        setService.dropCaches(getContainingFile());
+        super.subtreeChanged();
     }
 }

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -396,6 +396,10 @@
         <lang.documentationProvider language="Latex" implementationClass="nl.hannahsten.texifyidea.documentation.LatexDocumentationProvider"/>
         <lang.documentationProvider language="Bibtex" implementationClass="nl.hannahsten.texifyidea.documentation.BibtexDocumentationProvider"/>
 
+        <!-- Other Services -->
+        <projectService serviceInterface="nl.hannahsten.texifyidea.util.files.ReferencedFileSetService"
+                        serviceImplementation="nl.hannahsten.texifyidea.util.files.impl.ReferencedFileSetServiceImpl"/>
+
         <!-- Inspections -->
         <spellchecker.support language="Latex" implementationClass="nl.hannahsten.texifyidea.inspections.LatexSpellcheckingStrategy"/>
 

--- a/src/nl/hannahsten/texifyidea/action/NewLatexFileAction.java
+++ b/src/nl/hannahsten/texifyidea/action/NewLatexFileAction.java
@@ -13,7 +13,7 @@ import com.intellij.psi.PsiFile;
 import nl.hannahsten.texifyidea.TexifyIcons;
 import nl.hannahsten.texifyidea.file.*;
 import nl.hannahsten.texifyidea.templates.LatexTemplatesFactory;
-import nl.hannahsten.texifyidea.util.FileUtil;
+import nl.hannahsten.texifyidea.util.files.FileUtil;
 import nl.hannahsten.texifyidea.util.Magic;
 import nl.hannahsten.texifyidea.util.StringsKt;
 import org.jetbrains.annotations.NotNull;

--- a/src/nl/hannahsten/texifyidea/action/analysis/WordCountAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/analysis/WordCountAction.kt
@@ -11,6 +11,8 @@ import com.intellij.psi.PsiWhiteSpace
 import nl.hannahsten.texifyidea.TexifyIcons
 import nl.hannahsten.texifyidea.psi.*
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.psiFile
+import nl.hannahsten.texifyidea.util.files.referencedFileSet
 import java.util.regex.Pattern
 import javax.swing.JLabel
 import javax.swing.SwingConstants

--- a/src/nl/hannahsten/texifyidea/action/group/LatexAnalyzeMenuGroup.kt
+++ b/src/nl/hannahsten/texifyidea/action/group/LatexAnalyzeMenuGroup.kt
@@ -3,7 +3,7 @@ package nl.hannahsten.texifyidea.action.group
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DefaultActionGroup
-import nl.hannahsten.texifyidea.util.isLatexFile
+import nl.hannahsten.texifyidea.util.files.isLatexFile
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/action/group/LatexEditMenuGroup.kt
+++ b/src/nl/hannahsten/texifyidea/action/group/LatexEditMenuGroup.kt
@@ -3,7 +3,7 @@ package nl.hannahsten.texifyidea.action.group
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DefaultActionGroup
-import nl.hannahsten.texifyidea.util.isLatexFile
+import nl.hannahsten.texifyidea.util.files.isLatexFile
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/action/group/LatexToolsMenuGroup.kt
+++ b/src/nl/hannahsten/texifyidea/action/group/LatexToolsMenuGroup.kt
@@ -3,7 +3,7 @@ package nl.hannahsten.texifyidea.action.group
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DefaultActionGroup
-import nl.hannahsten.texifyidea.util.isLatexFile
+import nl.hannahsten.texifyidea.util.files.isLatexFile
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/completion/InsertBibtexTag.kt
+++ b/src/nl/hannahsten/texifyidea/completion/InsertBibtexTag.kt
@@ -15,6 +15,7 @@ import nl.hannahsten.texifyidea.editor.ShiftTracker
 import nl.hannahsten.texifyidea.file.BibtexFileType
 import nl.hannahsten.texifyidea.psi.*
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.document
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/completion/LatexCommandProvider.java
+++ b/src/nl/hannahsten/texifyidea/completion/LatexCommandProvider.java
@@ -23,6 +23,8 @@ import nl.hannahsten.texifyidea.index.LatexDefinitionIndex;
 import nl.hannahsten.texifyidea.lang.*;
 import nl.hannahsten.texifyidea.psi.LatexCommands;
 import nl.hannahsten.texifyidea.util.*;
+import nl.hannahsten.texifyidea.util.files.FileSetKt;
+import nl.hannahsten.texifyidea.util.files.FilesKt;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/nl/hannahsten/texifyidea/completion/LatexFileProvider.kt
+++ b/src/nl/hannahsten/texifyidea/completion/LatexFileProvider.kt
@@ -15,6 +15,9 @@ import nl.hannahsten.texifyidea.completion.handlers.CompositeHandler
 import nl.hannahsten.texifyidea.completion.handlers.FileNameInsertionHandler
 import nl.hannahsten.texifyidea.completion.handlers.LatexReferenceInsertHandler
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.commandsInFileSet
+import nl.hannahsten.texifyidea.util.files.findRootFile
+import nl.hannahsten.texifyidea.util.files.isLatexFile
 import java.util.*
 import java.util.regex.Pattern
 

--- a/src/nl/hannahsten/texifyidea/completion/handlers/FileNameInsertionHandler.kt
+++ b/src/nl/hannahsten/texifyidea/completion/handlers/FileNameInsertionHandler.kt
@@ -6,6 +6,8 @@ import com.intellij.codeInsight.lookup.LookupElement
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexRequiredParam
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.document
+import nl.hannahsten.texifyidea.util.files.removeFileExtension
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/completion/handlers/LatexNoMathInsertHandler.kt
+++ b/src/nl/hannahsten/texifyidea/completion/handlers/LatexNoMathInsertHandler.kt
@@ -11,6 +11,7 @@ import com.intellij.codeInsight.template.impl.TemplateState
 import nl.hannahsten.texifyidea.lang.Environment
 import nl.hannahsten.texifyidea.lang.LatexCommand
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.definitionsAndRedefinitionsInFileSet
 
 /**
  * @author Hannah Schellekens, Sten Wessel

--- a/src/nl/hannahsten/texifyidea/editor/LatexSoftWrapEditorListener.kt
+++ b/src/nl/hannahsten/texifyidea/editor/LatexSoftWrapEditorListener.kt
@@ -3,8 +3,8 @@ package nl.hannahsten.texifyidea.editor
 import com.intellij.openapi.editor.event.EditorFactoryEvent
 import com.intellij.openapi.editor.event.EditorFactoryListener
 import nl.hannahsten.texifyidea.settings.TexifySettings
-import nl.hannahsten.texifyidea.util.isLatexFile
-import nl.hannahsten.texifyidea.util.psiFile
+import nl.hannahsten.texifyidea.util.files.isLatexFile
+import nl.hannahsten.texifyidea.util.files.psiFile
 
 /**
  * Enables automatic soft wrap when a LaTeX file is opened.

--- a/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.java
+++ b/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.java
@@ -14,8 +14,8 @@ import nl.hannahsten.texifyidea.lang.LatexRegularCommand;
 import nl.hannahsten.texifyidea.lang.RequiredFileArgument;
 import nl.hannahsten.texifyidea.psi.LatexCommands;
 import nl.hannahsten.texifyidea.psi.LatexRequiredParam;
-import nl.hannahsten.texifyidea.util.FilesKt;
 import nl.hannahsten.texifyidea.util.PsiCommandsKt;
+import nl.hannahsten.texifyidea.util.files.FilesKt;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/nl/hannahsten/texifyidea/highlighting/LatexAnnotator.kt
+++ b/src/nl/hannahsten/texifyidea/highlighting/LatexAnnotator.kt
@@ -10,6 +10,7 @@ import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.lang.Environment
 import nl.hannahsten.texifyidea.psi.*
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.definitionsAndRedefinitionsInFileSet
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/index/BibtexIdIndex.kt
+++ b/src/nl/hannahsten/texifyidea/index/BibtexIdIndex.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.stubs.StringStubIndexExtension
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.util.ArrayUtil
 import nl.hannahsten.texifyidea.psi.BibtexId
-import nl.hannahsten.texifyidea.util.referencedFileSet
+import nl.hannahsten.texifyidea.util.files.referencedFileSet
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/index/IndexUtilBase.kt
+++ b/src/nl/hannahsten/texifyidea/index/IndexUtilBase.kt
@@ -6,9 +6,9 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
-import nl.hannahsten.texifyidea.util.documentClassFile
-import nl.hannahsten.texifyidea.util.findRootFile
-import nl.hannahsten.texifyidea.util.referencedFileSet
+import nl.hannahsten.texifyidea.util.files.documentClassFile
+import nl.hannahsten.texifyidea.util.files.findRootFile
+import nl.hannahsten.texifyidea.util.files.referencedFileSet
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/inspections/TexifyRegexInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/TexifyRegexInspection.kt
@@ -10,6 +10,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.document
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 

--- a/src/nl/hannahsten/texifyidea/inspections/bibtex/BibtexDuplicateBibliographyInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/bibtex/BibtexDuplicateBibliographyInspection.kt
@@ -11,7 +11,7 @@ import nl.hannahsten.texifyidea.index.LatexIncludesIndex
 import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.psi.LatexCommands
-import nl.hannahsten.texifyidea.util.commandsInFileSet
+import nl.hannahsten.texifyidea.util.files.commandsInFileSet
 import nl.hannahsten.texifyidea.util.requiredParameter
 
 /**

--- a/src/nl/hannahsten/texifyidea/inspections/bibtex/BibtexDuplicateBibliographystyleInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/bibtex/BibtexDuplicateBibliographystyleInspection.kt
@@ -10,8 +10,8 @@ import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.psi.LatexCommands
-import nl.hannahsten.texifyidea.util.commandsInFile
-import nl.hannahsten.texifyidea.util.commandsInFileSet
+import nl.hannahsten.texifyidea.util.files.commandsInFile
+import nl.hannahsten.texifyidea.util.files.commandsInFileSet
 import nl.hannahsten.texifyidea.util.findAtLeast
 
 /**

--- a/src/nl/hannahsten/texifyidea/inspections/bibtex/BibtexDuplicateIdInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/bibtex/BibtexDuplicateIdInspection.kt
@@ -11,6 +11,7 @@ import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.psi.BibtexId
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.commandsInFileSet
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/inspections/bibtex/BibtexMissingBibliographystyleInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/bibtex/BibtexMissingBibliographystyleInspection.kt
@@ -10,7 +10,11 @@ import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.psi.LatexCommands
-import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.endOffset
+import nl.hannahsten.texifyidea.util.files.commandsInFileSet
+import nl.hannahsten.texifyidea.util.files.document
+import nl.hannahsten.texifyidea.util.files.openedEditor
+import nl.hannahsten.texifyidea.util.lineIndentationByOffset
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexAvoidEqnarrayInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexAvoidEqnarrayInspection.kt
@@ -13,6 +13,7 @@ import nl.hannahsten.texifyidea.lang.Package.Companion.AMSMATH
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexEnvironment
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.document
 import java.util.*
 
 /**

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexCiteBeforePeriodInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexCiteBeforePeriodInspection.kt
@@ -4,6 +4,7 @@ import com.intellij.codeInspection.ProblemDescriptor
 import nl.hannahsten.texifyidea.inspections.TexifyRegexInspection
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.document
 import java.util.regex.Pattern
 
 /**

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexCollapseCiteInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexCollapseCiteInspection.kt
@@ -14,6 +14,7 @@ import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexContent
 import nl.hannahsten.texifyidea.psi.LatexNormalText
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.document
 import java.util.*
 import kotlin.collections.ArrayList
 

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexCommandAlreadyDefinedInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexCommandAlreadyDefinedInspection.kt
@@ -11,7 +11,7 @@ import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexCommands
-import nl.hannahsten.texifyidea.util.document
+import nl.hannahsten.texifyidea.util.files.document
 import nl.hannahsten.texifyidea.util.forcedFirstRequiredParameterAsCommand
 import nl.hannahsten.texifyidea.util.isKnown
 import nl.hannahsten.texifyidea.util.replaceString

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexDiscouragedUseOfDefInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexDiscouragedUseOfDefInspection.kt
@@ -14,7 +14,7 @@ import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexPsiUtil
-import nl.hannahsten.texifyidea.util.document
+import nl.hannahsten.texifyidea.util.files.document
 import java.util.*
 
 /**

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexDuplicateDefinitionInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexDuplicateDefinitionInspection.kt
@@ -8,8 +8,8 @@ import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.util.definedCommandName
-import nl.hannahsten.texifyidea.util.definitions
-import nl.hannahsten.texifyidea.util.definitionsInFileSet
+import nl.hannahsten.texifyidea.util.files.definitions
+import nl.hannahsten.texifyidea.util.files.definitionsInFileSet
 import nl.hannahsten.texifyidea.util.isCommandDefinition
 
 /**

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexDuplicateLabelInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexDuplicateLabelInspection.kt
@@ -9,6 +9,9 @@ import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.bibtexIdsInFileSet
+import nl.hannahsten.texifyidea.util.files.commandsInFile
+import nl.hannahsten.texifyidea.util.files.commandsInFileSet
 import java.util.*
 
 /**

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexEnDashInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexEnDashInspection.kt
@@ -4,7 +4,7 @@ import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.inspections.TexifyRegexInspection
 import nl.hannahsten.texifyidea.util.Magic
-import nl.hannahsten.texifyidea.util.document
+import nl.hannahsten.texifyidea.util.files.document
 import nl.hannahsten.texifyidea.util.length
 import nl.hannahsten.texifyidea.util.toTextRange
 import java.util.regex.Pattern

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexEncloseWithLeftRightInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexEncloseWithLeftRightInspection.kt
@@ -16,6 +16,7 @@ import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexDisplayMath
 import nl.hannahsten.texifyidea.psi.LatexInlineMath
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.document
 import java.util.*
 
 /**

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexEquationReferenceInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexEquationReferenceInspection.kt
@@ -4,7 +4,7 @@ import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.inspections.TexifyRegexInspection
 import nl.hannahsten.texifyidea.lang.Package
-import nl.hannahsten.texifyidea.util.document
+import nl.hannahsten.texifyidea.util.files.document
 import nl.hannahsten.texifyidea.util.findLabels
 import nl.hannahsten.texifyidea.util.findOuterMathEnvironment
 import nl.hannahsten.texifyidea.util.insertUsepackage

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexFigureNotReferencedInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexFigureNotReferencedInspection.kt
@@ -9,6 +9,7 @@ import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.commandsInFile
 import java.util.*
 
 open class LatexFigureNotReferencedInspection : TexifyInspectionBase() {

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexFileNotFoundInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexFileNotFoundInspection.kt
@@ -15,8 +15,8 @@ import nl.hannahsten.texifyidea.lang.RequiredArgument
 import nl.hannahsten.texifyidea.lang.RequiredFileArgument
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexNormalText
-import nl.hannahsten.texifyidea.util.findFile
-import nl.hannahsten.texifyidea.util.findRootFile
+import nl.hannahsten.texifyidea.util.files.findFile
+import nl.hannahsten.texifyidea.util.files.findRootFile
 import nl.hannahsten.texifyidea.util.firstChildOfType
 import java.util.*
 

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexGatherEquationsInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexGatherEquationsInspection.kt
@@ -11,6 +11,7 @@ import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.lang.Package.Companion.AMSMATH
 import nl.hannahsten.texifyidea.psi.LatexContent
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.document
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexInclusionLoopInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexInclusionLoopInspection.kt
@@ -9,9 +9,9 @@ import nl.hannahsten.texifyidea.algorithm.BFS
 import nl.hannahsten.texifyidea.index.LatexCommandsIndex
 import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
-import nl.hannahsten.texifyidea.util.findInclusions
-import nl.hannahsten.texifyidea.util.findRelativeFile
-import nl.hannahsten.texifyidea.util.findRootFile
+import nl.hannahsten.texifyidea.util.files.findInclusions
+import nl.hannahsten.texifyidea.util.files.findRelativeFile
+import nl.hannahsten.texifyidea.util.files.findRootFile
 import nl.hannahsten.texifyidea.util.requiredParameter
 
 /**

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexLabelConventionInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexLabelConventionInspection.kt
@@ -11,6 +11,9 @@ import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.*
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.commandsInFile
+import nl.hannahsten.texifyidea.util.files.commandsInFileSet
+import nl.hannahsten.texifyidea.util.files.document
 import java.util.*
 import kotlin.Comparator
 import kotlin.collections.ArrayList

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexLineBreakInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexLineBreakInspection.kt
@@ -12,6 +12,7 @@ import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.psi.LatexComment
 import nl.hannahsten.texifyidea.psi.LatexNormalText
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.document
 import kotlin.math.min
 
 /**

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingDocumentEnvironmentInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingDocumentEnvironmentInspection.kt
@@ -13,7 +13,7 @@ import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexBeginCommand
 import nl.hannahsten.texifyidea.util.childrenOfType
-import nl.hannahsten.texifyidea.util.referencedFileSet
+import nl.hannahsten.texifyidea.util.files.referencedFileSet
 import java.util.*
 
 /**

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingImportInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingImportInspection.kt
@@ -20,6 +20,8 @@ import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexEnvironment
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.commandsInFile
+import nl.hannahsten.texifyidea.util.files.definitionsAndRedefinitionsInFileSet
 import java.util.*
 
 /**

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingLabelInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingLabelInspection.kt
@@ -11,6 +11,9 @@ import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.commandsInFile
+import nl.hannahsten.texifyidea.util.files.document
+import nl.hannahsten.texifyidea.util.files.openedEditor
 import java.util.*
 
 /**

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexMultipleIncludesInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexMultipleIncludesInspection.kt
@@ -10,7 +10,7 @@ import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexRequiredParam
 import nl.hannahsten.texifyidea.util.PackageUtils
-import nl.hannahsten.texifyidea.util.commandsInFile
+import nl.hannahsten.texifyidea.util.files.commandsInFile
 import nl.hannahsten.texifyidea.util.firstChildOfType
 import nl.hannahsten.texifyidea.util.requiredParameter
 import java.util.*

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexNestedIncludesInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexNestedIncludesInspection.kt
@@ -14,6 +14,9 @@ import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.document
+import nl.hannahsten.texifyidea.util.files.findRelativeFile
+import nl.hannahsten.texifyidea.util.files.findRootFile
 import java.util.*
 
 /**

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexNoExtensionInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexNoExtensionInspection.kt
@@ -13,7 +13,7 @@ import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.util.Magic
-import nl.hannahsten.texifyidea.util.document
+import nl.hannahsten.texifyidea.util.files.document
 import nl.hannahsten.texifyidea.util.replaceString
 import nl.hannahsten.texifyidea.util.requiredParameter
 import java.util.*

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexNonBreakingSpaceInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexNonBreakingSpaceInspection.kt
@@ -16,7 +16,7 @@ import nl.hannahsten.texifyidea.psi.LatexContent
 import nl.hannahsten.texifyidea.psi.LatexNormalText
 import nl.hannahsten.texifyidea.util.Magic
 import nl.hannahsten.texifyidea.util.childrenOfType
-import nl.hannahsten.texifyidea.util.document
+import nl.hannahsten.texifyidea.util.files.document
 import nl.hannahsten.texifyidea.util.parentOfType
 import java.util.*
 

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexNonMatchingEnvironmentInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexNonMatchingEnvironmentInspection.kt
@@ -12,6 +12,7 @@ import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexBeginCommand
 import nl.hannahsten.texifyidea.psi.LatexEndCommand
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.document
 import java.util.*
 
 /**

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexNonMatchingIfInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexNonMatchingIfInspection.kt
@@ -8,7 +8,7 @@ import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.util.Magic
-import nl.hannahsten.texifyidea.util.commandsInFile
+import nl.hannahsten.texifyidea.util.files.commandsInFile
 import nl.hannahsten.texifyidea.util.matches
 import java.util.*
 

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexPrimitiveEquationInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexPrimitiveEquationInspection.kt
@@ -4,7 +4,7 @@ import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.inspections.TexifyRegexInspection
-import nl.hannahsten.texifyidea.util.document
+import nl.hannahsten.texifyidea.util.files.document
 import nl.hannahsten.texifyidea.util.toTextRange
 import java.util.regex.Matcher
 import java.util.regex.Pattern

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexSpaceAfterAbbreviationInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexSpaceAfterAbbreviationInspection.kt
@@ -14,7 +14,7 @@ import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.psi.LatexNormalText
 import nl.hannahsten.texifyidea.util.Magic
 import nl.hannahsten.texifyidea.util.childrenOfType
-import nl.hannahsten.texifyidea.util.document
+import nl.hannahsten.texifyidea.util.files.document
 import nl.hannahsten.texifyidea.util.inMathContext
 
 /**

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexTooLargeSectionInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexTooLargeSectionInspection.kt
@@ -19,6 +19,9 @@ import nl.hannahsten.texifyidea.psi.LatexEndCommand
 import nl.hannahsten.texifyidea.psi.LatexPsiUtil
 import nl.hannahsten.texifyidea.ui.CreateFileDialog
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.commandsInFile
+import nl.hannahsten.texifyidea.util.files.createFile
+import nl.hannahsten.texifyidea.util.files.findRootFile
 import org.intellij.lang.annotations.Language
 import java.io.File
 import java.util.*

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexTrimWhitespaceInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexTrimWhitespaceInspection.kt
@@ -13,6 +13,8 @@ import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexRequiredParam
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.commandsInFile
+import nl.hannahsten.texifyidea.util.files.document
 import java.util.*
 
 /**

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexUnresolvedReferenceInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexUnresolvedReferenceInspection.kt
@@ -9,7 +9,7 @@ import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.util.Magic
-import nl.hannahsten.texifyidea.util.commandsInFile
+import nl.hannahsten.texifyidea.util.files.commandsInFile
 import nl.hannahsten.texifyidea.util.findLabelsInFileSet
 import nl.hannahsten.texifyidea.util.hasStar
 import java.util.*

--- a/src/nl/hannahsten/texifyidea/intentions/LatexDisplayMathIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexDisplayMathIntention.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.psi.LatexBeginCommand
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.isLatexFile
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/intentions/LatexInlineDisplayToggle.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexInlineDisplayToggle.kt
@@ -8,6 +8,7 @@ import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.psi.LatexDisplayMath
 import nl.hannahsten.texifyidea.psi.LatexInlineMath
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.isLatexFile
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/intentions/LatexLeftRightParenthesesIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexLeftRightParenthesesIntention.kt
@@ -9,6 +9,8 @@ import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.document
+import nl.hannahsten.texifyidea.util.files.isLatexFile
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/intentions/LatexMathToggle.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexMathToggle.kt
@@ -9,6 +9,7 @@ import nl.hannahsten.texifyidea.psi.LatexBeginCommand
 import nl.hannahsten.texifyidea.psi.LatexDisplayMath
 import nl.hannahsten.texifyidea.psi.LatexInlineMath
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.isLatexFile
 
 /**
  * @author Hannah Schellekens, Abby Berkers

--- a/src/nl/hannahsten/texifyidea/intentions/LatexMoveSectionToFileIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexMoveSectionToFileIntention.kt
@@ -9,6 +9,10 @@ import nl.hannahsten.texifyidea.inspections.latex.LatexTooLargeSectionInspection
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.ui.CreateFileDialog
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.createFile
+import nl.hannahsten.texifyidea.util.files.document
+import nl.hannahsten.texifyidea.util.files.findRootFile
+import nl.hannahsten.texifyidea.util.files.isLatexFile
 import java.io.File
 
 /**

--- a/src/nl/hannahsten/texifyidea/intentions/LatexMoveSelectionToFileIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexMoveSelectionToFileIntention.kt
@@ -6,9 +6,9 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.ui.CreateFileDialog
-import nl.hannahsten.texifyidea.util.createFile
-import nl.hannahsten.texifyidea.util.findRootFile
-import nl.hannahsten.texifyidea.util.isLatexFile
+import nl.hannahsten.texifyidea.util.files.createFile
+import nl.hannahsten.texifyidea.util.files.findRootFile
+import nl.hannahsten.texifyidea.util.files.isLatexFile
 import nl.hannahsten.texifyidea.util.removeIndents
 import org.intellij.lang.annotations.Language
 import java.io.File

--- a/src/nl/hannahsten/texifyidea/intentions/LatexUnpackUsepackageIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexUnpackUsepackageIntention.kt
@@ -7,6 +7,8 @@ import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexRequiredParam
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.document
+import nl.hannahsten.texifyidea.util.files.isLatexFile
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/lang/magic/MagicComments.kt
+++ b/src/nl/hannahsten/texifyidea/lang/magic/MagicComments.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.psi.*
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.document
 import java.util.*
 
 /**

--- a/src/nl/hannahsten/texifyidea/reference/LatexLabelReference.java
+++ b/src/nl/hannahsten/texifyidea/reference/LatexLabelReference.java
@@ -10,10 +10,10 @@ import nl.hannahsten.texifyidea.completion.handlers.LatexReferenceInsertHandler;
 import nl.hannahsten.texifyidea.psi.BibtexId;
 import nl.hannahsten.texifyidea.psi.LatexCommands;
 import nl.hannahsten.texifyidea.psi.LatexRequiredParam;
-import nl.hannahsten.texifyidea.util.FileSetKt;
 import nl.hannahsten.texifyidea.util.LabelsKt;
 import nl.hannahsten.texifyidea.util.Magic;
 import nl.hannahsten.texifyidea.util.StringsKt;
+import nl.hannahsten.texifyidea.util.files.FileSetKt;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/nl/hannahsten/texifyidea/run/LatexCommandLineState.kt
+++ b/src/nl/hannahsten/texifyidea/run/LatexCommandLineState.kt
@@ -16,7 +16,10 @@ import nl.hannahsten.texifyidea.run.evince.EvinceForwardSearch
 import nl.hannahsten.texifyidea.run.evince.isEvinceAvailable
 import nl.hannahsten.texifyidea.run.sumatra.SumatraForwardSearch
 import nl.hannahsten.texifyidea.run.sumatra.isSumatraAvailable
-import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.FileUtil
+import nl.hannahsten.texifyidea.util.files.createExcludedDir
+import nl.hannahsten.texifyidea.util.files.psiFile
+import nl.hannahsten.texifyidea.util.files.referencedFileSet
 import java.io.File
 
 /**

--- a/src/nl/hannahsten/texifyidea/run/evince/EvinceForwardSearch.kt
+++ b/src/nl/hannahsten/texifyidea/run/evince/EvinceForwardSearch.kt
@@ -4,8 +4,8 @@ import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
 import nl.hannahsten.texifyidea.run.LatexRunConfiguration
 import nl.hannahsten.texifyidea.util.caretOffset
-import nl.hannahsten.texifyidea.util.openedEditor
-import nl.hannahsten.texifyidea.util.psiFile
+import nl.hannahsten.texifyidea.util.files.openedEditor
+import nl.hannahsten.texifyidea.util.files.psiFile
 
 /**
  * Provides forward search for Evince.

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraForwardSearch.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraForwardSearch.kt
@@ -6,6 +6,10 @@ import nl.hannahsten.texifyidea.TeXception
 import nl.hannahsten.texifyidea.psi.LatexEnvironment
 import nl.hannahsten.texifyidea.run.LatexRunConfiguration
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.document
+import nl.hannahsten.texifyidea.util.files.isRoot
+import nl.hannahsten.texifyidea.util.files.openedEditor
+import nl.hannahsten.texifyidea.util.files.psiFile
 import org.jetbrains.concurrency.runAsync
 
 /**

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexStructureViewElement.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexStructureViewElement.kt
@@ -21,6 +21,9 @@ import nl.hannahsten.texifyidea.psi.LatexTypes
 import nl.hannahsten.texifyidea.structure.bibtex.BibtexStructureViewElement
 import nl.hannahsten.texifyidea.structure.latex.SectionNumbering.DocumentClass
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.documentClassFile
+import nl.hannahsten.texifyidea.util.files.findFile
+import nl.hannahsten.texifyidea.util.files.findRootFile
 import java.util.*
 
 /**

--- a/src/nl/hannahsten/texifyidea/util/Packages.kt
+++ b/src/nl/hannahsten/texifyidea/util/Packages.kt
@@ -6,6 +6,9 @@ import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.index.LatexCommandsIndex
 import nl.hannahsten.texifyidea.lang.Package
 import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.util.files.document
+import nl.hannahsten.texifyidea.util.files.isClassFile
+import nl.hannahsten.texifyidea.util.files.isStyleFile
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/util/Projects.kt
+++ b/src/nl/hannahsten/texifyidea/util/Projects.kt
@@ -1,9 +1,13 @@
 package nl.hannahsten.texifyidea.util
 
+import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.search.FileTypeIndex
 import com.intellij.psi.search.GlobalSearchScope
 import nl.hannahsten.texifyidea.index.LatexDefinitionIndex
+import nl.hannahsten.texifyidea.util.files.allChildFiles
 
 /**
  * Get a project [GlobalSearchScope] for this project.
@@ -33,4 +37,12 @@ fun Project.findAvailableDocumentClasses(): Set<String> {
             .filter { it.isNotEmpty() }
             .mapNotNull { it.firstOrNull() }
             .toSet()
+}
+
+/**
+ * Get all the virtual files that are in the project of a given file type.
+ */
+fun Project.allFiles(type: FileType): Collection<VirtualFile> {
+    val scope = GlobalSearchScope.projectScope(this)
+    return FileTypeIndex.getFiles(type, scope)
 }

--- a/src/nl/hannahsten/texifyidea/util/Psi.kt
+++ b/src/nl/hannahsten/texifyidea/util/Psi.kt
@@ -10,6 +10,7 @@ import nl.hannahsten.texifyidea.lang.DefaultEnvironment
 import nl.hannahsten.texifyidea.lang.Environment
 import nl.hannahsten.texifyidea.lang.magic.TextBasedMagicCommentParser
 import nl.hannahsten.texifyidea.psi.*
+import nl.hannahsten.texifyidea.util.files.commandsInFileSet
 import kotlin.reflect.KClass
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/nl/hannahsten/texifyidea/util/PsiCommands.kt
+++ b/src/nl/hannahsten/texifyidea/util/PsiCommands.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.util.PsiTreeUtil
 import nl.hannahsten.texifyidea.lang.LatexMathCommand
 import nl.hannahsten.texifyidea.lang.LatexRegularCommand
 import nl.hannahsten.texifyidea.psi.*
+import nl.hannahsten.texifyidea.util.files.document
 
 /**
  * Checks whether the given LaTeX commands is a definition or not.

--- a/src/nl/hannahsten/texifyidea/util/files/FileSet.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/FileSet.kt
@@ -1,4 +1,4 @@
-package nl.hannahsten.texifyidea.util
+package nl.hannahsten.texifyidea.util.files
 
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.index.BibtexIdIndex
@@ -6,11 +6,15 @@ import nl.hannahsten.texifyidea.index.LatexCommandsIndex
 import nl.hannahsten.texifyidea.index.LatexDefinitionIndex
 import nl.hannahsten.texifyidea.index.LatexIncludesIndex
 import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.util.isDefinition
 
 /**
  * Finds all the files in the project that are somehow related using includes.
- * <p>
+ *
  * When A includes B and B includes C then A, B & C will all return a set containing A, B & C.
+ *
+ * Be careful when using this function directly over something like [ReferencedFileSetService] where the result
+ * values are cached.
  *
  * @param baseFile
  *         The file to find the reference set of.
@@ -57,7 +61,9 @@ fun findReferencedFileSet(baseFile: PsiFile): Set<PsiFile> {
  *
  * @return All the files that are cross referenced between each other.
  */
-fun PsiFile.referencedFileSet(): Set<PsiFile> = findReferencedFileSet(this)
+fun PsiFile.referencedFileSet(): Set<PsiFile> {
+    return ReferencedFileSetService.getInstance(project).referencedFileSetOf(this)
+}
 
 /**
  * @see [BibtexIdIndex.getIndexedIdsInFileSet]

--- a/src/nl/hannahsten/texifyidea/util/files/Files.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/Files.kt
@@ -1,4 +1,4 @@
-package nl.hannahsten.texifyidea.util
+package nl.hannahsten.texifyidea.util.files
 
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.FileEditorManager
@@ -23,6 +23,7 @@ import nl.hannahsten.texifyidea.index.LatexCommandsIndex
 import nl.hannahsten.texifyidea.index.LatexDefinitionIndex
 import nl.hannahsten.texifyidea.lang.Package
 import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.util.*
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.util.*

--- a/src/nl/hannahsten/texifyidea/util/files/ReferencedFileSetCache.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/ReferencedFileSetCache.kt
@@ -18,7 +18,7 @@ class ReferencedFileSetCache(val project: Project) {
     private val valueManager = CachedValuesManager.getManager(project)
 
     /**
-     * Traks the modification counts for each base psi file.
+     * Tracks the modification counts for each base psi file.
      */
     private val modificationTracker = HashMap<PsiFile, MyModificationTracker>()
 

--- a/src/nl/hannahsten/texifyidea/util/files/ReferencedFileSetCache.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/ReferencedFileSetCache.kt
@@ -1,0 +1,101 @@
+package nl.hannahsten.texifyidea.util.files
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.ModificationTracker
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.CachedValue
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.psi.util.PsiModificationTracker
+
+/**
+ * Caches the values for [findReferencedFileSet] calls.
+ *
+ * @author Hannah Schellekens
+ */
+class ReferencedFileSetCache(val project: Project) {
+
+    private val valueManager = CachedValuesManager.getManager(project)
+
+    /**
+     * Traks the modification counts for each base psi file.
+     */
+    private val modificationTracker = HashMap<PsiFile, MyModificationTracker>()
+
+    /**
+     * The dependencies for the file set cache of the key file.
+     *
+     * @see CachedValueProvider.Result.getDependencyItems
+     */
+    private val dependencies = HashMap<PsiFile, Array<Any>>()
+
+    /**
+     * A cached file set value for each base file.
+     *
+     * The base file is the file from which the file set request came from.
+     * Meaning that a base file `A` is mapped to the file set with `A` as search root, `B` is mapped to the file set
+     * with `B` as search root etc.
+     * It could be that multiple values are equal.
+     */
+    private val fileSetCache = HashMap<PsiFile, CachedValue<Set<PsiFile>>>()
+
+    /**
+     * Creates a new cached value for the file set of base file `psiFile`.
+     * This will register the cache to the [CachedValuesManager] and store the cached value.
+     */
+    fun buildCacheFor(psiFile: PsiFile): CachedValue<Set<PsiFile>> {
+        val psiFileCache = valueManager.createCachedValue {
+            CachedValueProvider.Result.create(findReferencedFileSet(psiFile), dependenciesFor(psiFile))
+        }
+        fileSetCache[psiFile] = psiFileCache
+        return psiFileCache
+    }
+
+    /**
+     * Get the file set of base file `file`.
+     * When the cache is outdated, this will first update the cache.
+     */
+    fun fileSetFor(file: PsiFile): Set<PsiFile> {
+        val cache = fileSetCache[file] ?: buildCacheFor(file)
+        return cache.value ?: emptySet()
+    }
+
+    /**
+     * Clears the cache for base file `file`.
+     */
+    fun dropCaches(file: PsiFile) {
+        modificationTrackerFor(file).myModificationCount++
+    }
+
+    /**
+     * Also stores the dependencies if they didn't exist yet.
+     *
+     * @see dependencies
+     */
+    private fun dependenciesFor(psiFile: PsiFile): Array<Any> {
+        return dependencies.getOrPut(psiFile) {
+            arrayOf(PsiModificationTracker.MODIFICATION_COUNT, modificationTrackerFor(psiFile))
+        }
+    }
+
+    /**
+     * Also stores the created modification tracker if it didn't exist yet.
+     *
+     * @see modificationTracker
+     */
+    private fun modificationTrackerFor(psiFile: PsiFile): MyModificationTracker {
+        return modificationTracker.getOrPut(psiFile) { MyModificationTracker() }
+    }
+
+    /**
+     * Modification tracked used to invalidate the caches.
+     *
+     * @author Hannah Schellekens
+     */
+    private class MyModificationTracker : ModificationTracker {
+
+        var myModificationCount: Long = 0
+
+        override fun getModificationCount(): Long = myModificationCount
+    }
+}

--- a/src/nl/hannahsten/texifyidea/util/files/ReferencedFileSetService.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/ReferencedFileSetService.kt
@@ -1,0 +1,29 @@
+package nl.hannahsten.texifyidea.util.files
+
+import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+
+/**
+ * @author Hannah Schellekens
+ */
+interface ReferencedFileSetService {
+
+    companion object {
+
+        @JvmStatic
+        fun getInstance(project: Project): ReferencedFileSetService {
+            return ServiceManager.getService(project, ReferencedFileSetService::class.java)
+        }
+    }
+
+    /**
+     * [findReferencedFileSet], but then with cached values.
+     */
+    fun referencedFileSetOf(psiFile: PsiFile): Set<PsiFile>
+
+    /**
+     * Invalidates the caches for the given file.
+     */
+    fun dropCaches(psiFile: PsiFile)
+}

--- a/src/nl/hannahsten/texifyidea/util/files/impl/ReferencedFileSetServiceImpl.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/impl/ReferencedFileSetServiceImpl.kt
@@ -1,0 +1,18 @@
+package nl.hannahsten.texifyidea.util.files.impl
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import nl.hannahsten.texifyidea.util.files.ReferencedFileSetCache
+import nl.hannahsten.texifyidea.util.files.ReferencedFileSetService
+
+/**
+ * @author Hannah Schellekens
+ */
+class ReferencedFileSetServiceImpl(project: Project) : ReferencedFileSetService {
+
+    private val cache = ReferencedFileSetCache(project)
+
+    override fun referencedFileSetOf(psiFile: PsiFile) = cache.fileSetFor(psiFile)
+
+    override fun dropCaches(psiFile: PsiFile) = cache.dropCaches(psiFile)
+}


### PR DESCRIPTION
I added a caching mechanism for the infamous, relatively expensive `findReferencedFileSet` function. The quick (1-2 min) tests I've conducted result in approximately 0.6 times a many file set calls: before `95 ms` between each call on average, and after `169 ms` time between each call on average.

Where the old mechanism keeps on calling the function a lot when you type, the new mechanism will signifiacntly lessen the amount of calls over time.

I have not yet tested this on larger scaled documents.

#### Additions
- Added `ReferencedFileSetCache` that handles the cache for file sets.
- Added the project service `ReferencedFileSetService` (and impl) that act as accessor for the file set cache.

#### Changes
- Made the extension `PsiFile.referencedFileSet` use the said file set service.
- The cache gets rebuild on `LatexCommandsImpl.subtreeChanged()`.
