### PR TITLE
Create less `Array` objects by using `Sequence`

### DIFF
--- a/src/nl/hannahsten/texifyidea/action/analysis/WordCountAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/analysis/WordCountAction.kt
@@ -102,14 +102,16 @@ open class WordCountAction : AnAction(
      * Counts all the words in the given base file.
      */
     private fun countWords(baseFile: PsiFile): Pair<Int, Int> {
-        val fileSet = baseFile.referencedFileSet()
+        val allNormalText = baseFile
+                .referencedFileSet()
+                .asSequence()
                 .filter { it.name.endsWith(".tex", ignoreCase = true) }
-        val allNormalText = fileSet.flatMap { it.childrenOfType(LatexNormalText::class) }
+                .flatMap { it.childrenOfType(LatexNormalText::class) }
 
         val bibliographies = baseFile.childrenOfType(LatexEnvironment::class)
                 .filter {
                     val children = it.childrenOfType(LatexBeginCommand::class)
-                    if (children.isEmpty()) {
+                    if (children.none()) {
                         return@filter false
                     }
 
@@ -133,7 +135,7 @@ open class WordCountAction : AnAction(
      *
      * @return A pair of the total amount of words, and the amount of characters that make up the words.
      */
-    private fun countWords(latexNormalText: List<LatexNormalText>): Pair<Int, Int> {
+    private fun countWords(latexNormalText: Sequence<LatexNormalText>): Pair<Int, Int> {
         // separate all latex words.
         val latexWords: MutableSet<PsiElement> = HashSet()
         var characters = 0

--- a/src/nl/hannahsten/texifyidea/action/analysis/WordCountAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/analysis/WordCountAction.kt
@@ -106,23 +106,20 @@ open class WordCountAction : AnAction(
                 .referencedFileSet()
                 .asSequence()
                 .filter { it.name.endsWith(".tex", ignoreCase = true) }
-                .flatMap { it.childrenOfType(LatexNormalText::class) }
+                .flatMap { it.childrenOfType<LatexNormalText>() }
 
-        val bibliographies = baseFile.childrenOfType(LatexEnvironment::class)
+        val bibliographies = baseFile.childrenOfType<LatexEnvironment>()
                 .filter {
-                    val children = it.childrenOfType(LatexBeginCommand::class)
-                    if (children.none()) {
-                        return@filter false
-                    }
+                    val children = it.childrenOfType<LatexBeginCommand>()
 
-                    val parameters = children.first().parameterList
-                    if (parameters.isEmpty()) {
-                        return@filter false
-                    }
+                    val parameters = children
+                            .firstOrNull()
+                            ?.childrenOfType<LatexParameter>()
+                            ?: return@filter false
 
-                    return@filter parameters[0].text == "{thebibliography}"
+                    return@filter parameters.firstOrNull()?.text == "{thebibliography}"
                 }
-        val bibliography = bibliographies.flatMap { it.childrenOfType(LatexNormalText::class) }
+        val bibliography = bibliographies.flatMap { it.childrenOfType<LatexNormalText>() }
 
         val (wordsNormal, charsNormal) = countWords(allNormalText)
         val (wordsBib, charsBib) = countWords(bibliography)

--- a/src/nl/hannahsten/texifyidea/completion/BibtexStringProvider.kt
+++ b/src/nl/hannahsten/texifyidea/completion/BibtexStringProvider.kt
@@ -20,23 +20,22 @@ object BibtexStringProvider : CompletionProvider<CompletionParameters>() {
 
     override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
         val psiFile = parameters.originalFile
-        val strings: List<Triple<String, String, BibtexEntry>?> = psiFile.childrenOfType(BibtexEntry::class).asSequence()
+        val strings: Sequence<Triple<String, String, BibtexEntry>> = psiFile.childrenOfType(BibtexEntry::class).asSequence()
                 .filter { it.tokenType() == "@string" }
-                .map {
-                    val tag = it.firstChildOfType(BibtexTag::class) ?: return@map null
+                .mapNotNull {
+                    val tag = it.firstChildOfType(BibtexTag::class) ?: return@mapNotNull null
                     val key = tag.key
                     val content = tag.content
                     Triple(key.text, content.text, it)
                 }
-                .toList()
 
-        result.addAllElements(ContainerUtil.map2List(strings) {
-            LookupElementBuilder.create(StringDescription(it!!.third), it.first)
+        result.addAllElements(strings.map {
+            LookupElementBuilder.create(StringDescription(it.third), it.first)
                     .withPresentableText(it.first)
                     .bold()
                     .withTypeText(it.second, true)
                     .withIcon(TexifyIcons.STRING)
-        })
+        }.toList())
     }
 
     class StringDescription(entry: BibtexEntry?) : Described {

--- a/src/nl/hannahsten/texifyidea/editor/InsertEnumerationItem.kt
+++ b/src/nl/hannahsten/texifyidea/editor/InsertEnumerationItem.kt
@@ -78,11 +78,7 @@ class InsertEnumerationItem : EnterHandlerDelegate {
      */
     private fun getLastLabel(environment: PsiElement): LatexCommands? {
         val commands = environment.childrenOfType(LatexCommands::class).filter { it.name == "\\item" }
-        if (commands.isEmpty()) {
-            return null
-        }
-
-        return commands.last()
+        return commands.lastOrNull()
     }
 
     /**

--- a/src/nl/hannahsten/texifyidea/gutter/LatexCompileGutter.kt
+++ b/src/nl/hannahsten/texifyidea/gutter/LatexCompileGutter.kt
@@ -16,7 +16,7 @@ import nl.hannahsten.texifyidea.util.isEntryPoint
  */
 class LatexCompileGutter : RunLineMarkerContributor() {
 
-    override fun getInfo(element: PsiElement): RunLineMarkerContributor.Info? {
+    override fun getInfo(element: PsiElement): Info? {
         if (element !is LatexBeginCommand) return null
 
         // Break when not a valid command: don't show icon.
@@ -30,9 +30,9 @@ class LatexCompileGutter : RunLineMarkerContributor() {
         val actions = ExecutorAction.getActions(0)
 
         // Create icon.
-        return RunLineMarkerContributor.Info(
+        return Info(
                 TexifyIcons.BUILD,
-                Function { _ -> "Compile document" },
+                Function { "Compile document" },
                 actions[0],
                 editConfigs
         )

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexNonBreakingSpaceInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexNonBreakingSpaceInspection.kt
@@ -14,10 +14,7 @@ import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexContent
 import nl.hannahsten.texifyidea.psi.LatexNormalText
-import nl.hannahsten.texifyidea.util.Magic
-import nl.hannahsten.texifyidea.util.childrenOfType
-import nl.hannahsten.texifyidea.util.document
-import nl.hannahsten.texifyidea.util.parentOfType
+import nl.hannahsten.texifyidea.util.*
 import java.util.*
 
 /**
@@ -92,10 +89,12 @@ open class LatexNonBreakingSpaceInspection : TexifyInspectionBase() {
             var replacement = "~"
 
             // First check if there already is a tilde in the normal text before.
-            val texts = whitespace.prevSibling.childrenOfType(LatexNormalText::class)
-            if (!texts.isEmpty()) {
-                val text = texts.reversed().iterator().next()
-
+            val text = whitespace
+                    .prevSibling
+                    .childrenReversedWithLeaves()
+                    .filterIsInstance<LatexNormalText>()
+                    .firstOrNull()
+            if (text != null) {
                 // When there is a tilde, destroy the whitespace.
                 if (Magic.Pattern.endsWithNonBreakingSpace.matcher(text.text).find()) {
                     replacement = ""

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexTooLargeSectionInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexTooLargeSectionInspection.kt
@@ -73,8 +73,8 @@ open class LatexTooLargeSectionInspection : TexifyInspectionBase() {
             }
 
             // If no command was found, find the end of the document.
-            val children = command.containingFile.childrenOfType(LatexEndCommand::class)
-            return if (children.isEmpty()) null else children.last()
+            val children = command.containingFile.childrenOfType<LatexEndCommand>()
+            return children.lastOrNull()
         }
     }
 
@@ -191,7 +191,7 @@ open class LatexTooLargeSectionInspection : TexifyInspectionBase() {
 
             val startIndex = label?.endOffset() ?: cmd.endOffset()
             val cmdIndent = document.lineIndentation(document.getLineNumber(nextCmd?.textOffset ?: 0))
-            val endIndex = (nextCmd?.textOffset ?: document.textLength ?: return) - cmdIndent.length
+            val endIndex = (nextCmd?.textOffset ?: document.textLength) - cmdIndent.length
             val text = document.getText(TextRange(startIndex, endIndex)).trimEnd().removeIndents()
 
 

--- a/src/nl/hannahsten/texifyidea/psi/LatexPsiUtil.java
+++ b/src/nl/hannahsten/texifyidea/psi/LatexPsiUtil.java
@@ -84,36 +84,6 @@ public class LatexPsiUtil {
     }
 
     /**
-     * Get all the elements of the subtree starting at the given Latex {@link PsiElement}.
-     * <p>
-     * This method uses a depth-first traversal.
-     *
-     * @param element
-     *         The {@link PsiElement} contained in {@link nl.hannahsten.texifyidea.psi} of which you
-     *         want to get all the elements of the subtree of.
-     * @return A list of all elements in the subtree starting at, and including, the given element
-     * at index 0. The list will be empty when the element has no children or when the element is
-     * not a Latex element.
-     */
-    public static List<PsiElement> getAllChildren(PsiElement element) {
-        return getAllChildren(new ArrayList<>(), element);
-    }
-
-    /**
-     * See {@link LatexPsiUtil#getAllChildren(PsiElement)}, but appends all children to the given
-     * list.
-     */
-    private static List<PsiElement> getAllChildren(List<PsiElement> result, PsiElement element) {
-        result.add(element);
-
-        for (PsiElement child : getChildren(element)) {
-            getAllChildren(result, child);
-        }
-
-        return result;
-    }
-
-    /**
      * Get all the Latex children of the given Latex {@link PsiElement}s.
      *
      * @param element

--- a/src/nl/hannahsten/texifyidea/reference/BibtexStringReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/BibtexStringReference.kt
@@ -23,8 +23,8 @@ open class BibtexStringReference(
         return string.containingFile.childrenOfType(BibtexEntry::class).asSequence()
                 .filter { it.tokenName()?.toLowerCase() == "string" }
                 .map { it.tags() }
-                .filter { !it.isEmpty() }
-                .map { it.first().key }
+                .mapNotNull { it.firstOrNull() }
+                .map { it.key }
                 .filter { it.text == string.text }
                 .map { PsiElementResolveResult(it) }
                 .toList()

--- a/src/nl/hannahsten/texifyidea/run/RunConfigurationSelectionDialog.kt
+++ b/src/nl/hannahsten/texifyidea/run/RunConfigurationSelectionDialog.kt
@@ -57,7 +57,7 @@ class RunConfigurationSelectionDialog(
         list = JBList(settings).apply {
             selectionMode = ListSelectionModel.SINGLE_SELECTION
 
-            selectionModel.addListSelectionListener { _ ->
+            selectionModel.addListSelectionListener {
                 selected = list.selectedValue
                 isOKActionEnabled = list.selectedValue != null
             }

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraConversation.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraConversation.kt
@@ -124,7 +124,7 @@ object SumatraConversation {
             throw TeXception("Connection to SumatraPDF was disrupted.", e)
         }
         finally {
-            conversation.disconnect()
+            conversation!!.disconnect()
         }
     }
 

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraConversation.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraConversation.kt
@@ -124,7 +124,7 @@ object SumatraConversation {
             throw TeXception("Connection to SumatraPDF was disrupted.", e)
         }
         finally {
-            conversation?.disconnect()
+            conversation.disconnect()
         }
     }
 

--- a/src/nl/hannahsten/texifyidea/structure/bibtex/BibtexStructureViewEntriesElement.kt
+++ b/src/nl/hannahsten/texifyidea/structure/bibtex/BibtexStructureViewEntriesElement.kt
@@ -18,7 +18,7 @@ open class BibtexStructureViewEntriesElement(val file: PsiFile) : StructureViewT
 
     val entriesPresentation: ItemPresentation = object : ItemPresentation {
 
-        override fun getLocationString() = file.childrenOfType(BibtexEntry::class).size.toString()
+        override fun getLocationString() = file.childrenOfType<BibtexEntry>().count().toString()
 
         override fun getPresentableText() = "entries"
 
@@ -41,6 +41,7 @@ open class BibtexStructureViewEntriesElement(val file: PsiFile) : StructureViewT
         val entries = file.childrenOfType(BibtexEntry::class)
         return entries
                 .map { BibtexStructureViewEntryElement(it) }
+                .toList()
                 .toTypedArray()
     }
 }

--- a/src/nl/hannahsten/texifyidea/structure/bibtex/BibtexStructureViewEntryElement.kt
+++ b/src/nl/hannahsten/texifyidea/structure/bibtex/BibtexStructureViewEntryElement.kt
@@ -61,6 +61,6 @@ open class BibtexStructureViewEntryElement(val entry: BibtexEntry) : StructureVi
             return emptyArray()
         }
 
-        return entry.tags().map { BibtexStructureViewTagElement(it) }.toTypedArray()
+        return entry.tags().map { BibtexStructureViewTagElement(it) }.toList().toTypedArray()
     }
 }

--- a/src/nl/hannahsten/texifyidea/util/Bibtex.kt
+++ b/src/nl/hannahsten/texifyidea/util/Bibtex.kt
@@ -20,28 +20,22 @@ fun BibtexEntry.identifier(): String? = firstChildOfType(BibtexId::class)?.text?
 /**
  * Get all the tags in the entry.
  */
-fun BibtexEntry.tags(): Collection<BibtexTag> = childrenOfType(BibtexTag::class)
+fun BibtexEntry.tags(): Sequence<BibtexTag> = childrenOfType(BibtexTag::class)
 
 /**
  * Get all the key objects in the entry.
  */
-fun BibtexEntry.keys(): Collection<BibtexKey> = childrenOfType(BibtexKey::class)
+fun BibtexEntry.keys(): Sequence<BibtexKey> = childrenOfType(BibtexKey::class)
 
 /**
  * Get the first key in the entry, or `null` when there are no keys in the entry.
  */
-fun BibtexEntry.firstKey(): BibtexKey? {
-    val keys = keys()
-    if (keys.isEmpty()) {
-        return null
-    }
-    return keys.first()
-}
+fun BibtexEntry.firstKey(): BibtexKey? = keys().firstOrNull()
 
 /**
  * Get all the names of all entry's keys.
  */
-fun BibtexEntry.keyNames(): Collection<String> = keys().map { it.text }
+fun BibtexEntry.keyNames(): Sequence<String> = keys().map { it.text }
 
 /**
  * Checks if the entry is a @string.
@@ -86,14 +80,10 @@ fun BibtexContent.evaluate(): String {
         val quoted = string.quotedString
         val defined = string.definedString
 
-        if (braced != null) {
-            result.append(braced.evaluate())
-        }
-        else if (quoted != null) {
-            result.append(quoted.evaluate())
-        }
-        else if (defined != null) {
-            result.append(defined.evaluate())
+        when {
+            braced != null -> result.append(braced.evaluate())
+            quoted != null -> result.append(quoted.evaluate())
+            defined != null -> result.append(defined.evaluate())
         }
     }
 
@@ -127,11 +117,8 @@ fun BibtexDefinedString.evaluate(): String {
         }
 
         val tags = entry.tags()
-        if (tags.isEmpty()) {
-            continue
-        }
 
-        val tag = tags.first()
+        val tag = tags.firstOrNull() ?: continue
         val key = tag.keyName() ?: continue
         if (key != stringName) {
             continue

--- a/src/nl/hannahsten/texifyidea/util/Psi.kt
+++ b/src/nl/hannahsten/texifyidea/util/Psi.kt
@@ -1,9 +1,6 @@
 package nl.hannahsten.texifyidea.util
 
-import com.intellij.psi.PsiComment
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.*
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import nl.hannahsten.texifyidea.lang.DefaultEnvironment
@@ -195,10 +192,7 @@ fun <T : PsiElement> PsiElement.previousSiblingOfType(clazz: KClass<T>): T? {
     return null
 }
 
-/**
- * @see LatexPsiUtil.getAllChildren
- */
-fun PsiElement.allChildren(): List<PsiElement> = LatexPsiUtil.getAllChildren(this)
+fun PsiElement.allChildren(): Sequence<PsiElement> = SyntaxTraverser.psiTraverser().withRoot(this).asSequence()
 
 /**
  * @see LatexPsiUtil.getChildren


### PR DESCRIPTION
#### Backwards incompatible changes

The `Psi.kt` APIs now returns `Sequence` instead of `Collection`.

This code may not compile because I failed to install a dev env locally, but I can fix compilation issues according to CI build.