### PR TITLE
Table creation wizard ui improvements

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -33,7 +33,7 @@
     means that the first possible build is the next branch number after xyz, so e.g.
     a since build of 173.* is equal to 181
     -->
-    <idea-version since-build="191"/>
+    <idea-version since-build="192"/>
     <vendor url="https://hannah-sten.github.io/home/index.html">Hannah-Sten</vendor>
 
     <!-- Dependencies (must be defined to ensure compatibility with other IDEs) -->

--- a/src/nl/hannahsten/texifyidea/ui/tablecreationdialog/TableCreationDialogWrapper.kt
+++ b/src/nl/hannahsten/texifyidea/ui/tablecreationdialog/TableCreationDialogWrapper.kt
@@ -12,8 +12,7 @@ import com.intellij.ui.scale.JBUIScale
 import com.intellij.ui.table.JBTable
 import com.intellij.util.IconUtil
 import nl.hannahsten.texifyidea.action.tablewizard.TableInformation
-import java.awt.BorderLayout
-import java.awt.Dimension
+import java.awt.*
 import java.awt.event.ActionEvent
 import java.awt.event.KeyEvent
 import javax.swing.*
@@ -54,6 +53,7 @@ class TableCreationDialogWrapper(private val columnTypes: MutableList<ColumnType
      * @param title of the column.
      * @param columnType is the column type of the column.
      */
+    @Suppress("KDocUnresolvedReference")
     private val addColumnFun = fun(title: String, columnType: ColumnType, _: Int) {
         // Add the column to the table, with an empty cell for each row (instead of the default null).
         tableModel.addColumn(title, (0 until tableModel.rowCount).map { "" }.toTypedArray())
@@ -70,6 +70,7 @@ class TableCreationDialogWrapper(private val columnTypes: MutableList<ColumnType
      * @param columnType is the index of the column type.
      * @param columnIndex is the index of the edited column in the table, starting at 0.
      */
+    @Suppress("KDocUnresolvedReference", "KDocUnresolvedReference")
     private val editColumnFun = fun(title: String, columnType: ColumnType, columnIndex: Int) {
         tableModel.setHeaderName(title, columnIndex)
         // Edit the column type of the edited column.
@@ -77,7 +78,7 @@ class TableCreationDialogWrapper(private val columnTypes: MutableList<ColumnType
         tableModel.fireTableStructureChanged()
     }
 
-    private val editColumnActionButton: AnActionButton = object : AnActionButton("Edit column header", addText(IconUtil.getEditIcon(), "C")) {
+    private fun getEditColumnActionButton(): AnActionButton = object : AnActionButton("Edit column header", addText(IconUtil.getEditIcon(), "C")) {
 
         override fun actionPerformed(e: AnActionEvent) {
             if (table.selectedColumn >= 0) {
@@ -90,13 +91,13 @@ class TableCreationDialogWrapper(private val columnTypes: MutableList<ColumnType
         }
     }
 
-    private val addRowActionButton = object : AnActionButton("Add Row", addText(IconUtil.getAddIcon(), "R")) {
+    private fun getAddRowActionButton() = object : AnActionButton("Add Row", addText(IconUtil.getAddIcon(), "R")) {
         override fun actionPerformed(e: AnActionEvent) {
             tableModel.addEmptyRow()
         }
     }
 
-    private val removeRowActionButton = object : AnActionButton("Remove Row", addText(IconUtil.getRemoveIcon(), "R")) {
+    private fun getRemoveRowActionButton() = object : AnActionButton("Remove Row", addText(IconUtil.getRemoveIcon(), "R")) {
 
         override fun isEnabled() = table.selectedRow > -1
 
@@ -105,7 +106,7 @@ class TableCreationDialogWrapper(private val columnTypes: MutableList<ColumnType
         }
     }
 
-    private val removeColumnActionButton = object : AnActionButton("Remove Column", addText(IconUtil.getRemoveIcon(), "C")) {
+    private fun getRemoveColumnActionButton() = object : AnActionButton("Remove Column", addText(IconUtil.getRemoveIcon(), "C")) {
 
         override fun isEnabled() = table.selectedColumn > -1
 
@@ -123,10 +124,10 @@ class TableCreationDialogWrapper(private val columnTypes: MutableList<ColumnType
                 }
                 .setAddActionName("Add Column")
                 .setAddIcon(addText(IconUtil.getAddIcon(), "C"))
-                .addExtraAction(removeColumnActionButton)
-                .addExtraAction(editColumnActionButton)
-                .addExtraAction(addRowActionButton)
-                .addExtraAction(removeRowActionButton)
+                .addExtraAction(getRemoveColumnActionButton())
+                .addExtraAction(getEditColumnActionButton())
+                .addExtraAction(getAddRowActionButton())
+                .addExtraAction(getRemoveRowActionButton())
                 .createPanel()
 
 
@@ -154,6 +155,21 @@ class TableCreationDialogWrapper(private val columnTypes: MutableList<ColumnType
                 add(decorator, BorderLayout.EAST)
             }
 
+            // Help text
+            val helpText = JBLabel("<html>Press tab to go to the next cell or row, press enter to go to the next row.</html>")
+            helpText.foreground = Color.GRAY
+
+            // Put help text below table
+            val tablePanelContainer = JPanel(GridBagLayout())
+            val constraints = GridBagConstraints()
+            constraints.gridx = 0
+            constraints.gridy = GridBagConstraints.RELATIVE
+            tablePanelContainer.apply {
+                add(tablePanel, constraints)
+                add(helpText, constraints)
+            }
+            add(tablePanelContainer)
+
             // Create a panel for the caption box and its label.
             val captionPanel = JPanel()
             captionPanel.apply {
@@ -173,7 +189,6 @@ class TableCreationDialogWrapper(private val columnTypes: MutableList<ColumnType
             }
 
             // Actually add all the panels to the main panel.
-            add(tablePanel)
             // Add some air between components.
             add(Box.createRigidArea(Dimension(0, 8)))
             add(captionPanel)

--- a/src/nl/hannahsten/texifyidea/ui/tablecreationdialog/TableCreationDialogWrapper.kt
+++ b/src/nl/hannahsten/texifyidea/ui/tablecreationdialog/TableCreationDialogWrapper.kt
@@ -1,14 +1,14 @@
 package nl.hannahsten.texifyidea.ui.tablecreationdialog
 
-import com.intellij.openapi.actionSystem.ActionGroup
-import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.ui.AnActionButton
+import com.intellij.ui.LayeredIcon
 import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBTextField
+import com.intellij.ui.scale.JBUIScale
 import com.intellij.ui.table.JBTable
 import com.intellij.util.IconUtil
 import nl.hannahsten.texifyidea.action.tablewizard.TableInformation
@@ -77,35 +77,44 @@ class TableCreationDialogWrapper(private val columnTypes: MutableList<ColumnType
         tableModel.fireTableStructureChanged()
     }
 
+    private val editColumnActionButton: AnActionButton = object : AnActionButton("Edit column header", addText(IconUtil.getEditIcon(), "C")) {
+
+        override fun actionPerformed(e: AnActionEvent) {
+            if (table.selectedColumn >= 0) {
+                TableCreationEditColumnDialog(
+                        editColumnFun,
+                        table.selectedColumn,
+                        table.getColumnName(table.selectedColumn),
+                        columnTypes[table.selectedColumn])
+            }
+        }
+    }
+
+    private val addRowActionButton = object : AnActionButton("Add Row", addText(IconUtil.getAddIcon(), "R")) {
+        override fun actionPerformed(e: AnActionEvent) {
+            tableModel.addEmptyRow()
+        }
+    }
+
+    private val removeRowActionButton = object : AnActionButton("Remove Row", addText(IconUtil.getRemoveIcon(), "R")) {
+
+        override fun isEnabled() = table.selectedRow > -1
+
+        override fun actionPerformed(e: AnActionEvent) {
+            tableModel.removeRow(table.selectedRow)
+        }
+    }
+
+    private val removeColumnActionButton = object : AnActionButton("Remove Column", addText(IconUtil.getRemoveIcon(), "C")) {
+
+        override fun isEnabled() = table.selectedColumn > -1
+
+        override fun actionPerformed(e: AnActionEvent) {
+            tableModel.removeColumn(table.selectedColumn)
+        }
+    }
 
     override fun createCenterPanel(): JPanel {
-
-        // todo split up method
-
-        val editColumnActionButton: AnActionButton = object : AnActionButton("Edit column header", IconUtil.getEditIcon()) {
-
-            override fun actionPerformed(e: AnActionEvent) {
-                if (table.selectedColumn >= 0) {
-                    TableCreationEditColumnDialog(
-                            editColumnFun,
-                            table.selectedColumn,
-                            table.getColumnName(table.selectedColumn),
-                            columnTypes[table.selectedColumn])
-                }
-            }
-        }
-
-        val addRowActionButton = object : AnActionButton("Add row", IconUtil.getAddIcon()) {
-            override fun actionPerformed(e: AnActionEvent) {
-                tableModel.addEmptyRow()
-            }
-        }
-
-        val removeRowActionButton = object : AnActionButton("Remove row", IconUtil.getRemoveIcon()) {
-            override fun actionPerformed(e: AnActionEvent) {
-                tableModel.removeRow(table.selectedRow)
-            }
-        }
 
         // Decorator that contains the add/remove/edit buttons.
         val decorator = ToolbarDecorator.createDecorator(table)
@@ -113,8 +122,8 @@ class TableCreationDialogWrapper(private val columnTypes: MutableList<ColumnType
                     TableCreationEditColumnDialog(addColumnFun, tableModel.columnCount)
                 }
                 .setAddActionName("Add Column")
-                .setRemoveAction { tableModel.removeColumn(table.selectedColumn) }
-                .setRemoveActionName("Remove Column")
+                .setAddIcon(addText(IconUtil.getAddIcon(), "C"))
+                .addExtraAction(removeColumnActionButton)
                 .addExtraAction(editColumnActionButton)
                 .addExtraAction(addRowActionButton)
                 .addExtraAction(removeRowActionButton)
@@ -173,6 +182,16 @@ class TableCreationDialogWrapper(private val columnTypes: MutableList<ColumnType
         }
 
         return panel
+    }
+
+    /**
+     * See [IconUtil.addText].
+     */
+    fun addText(base: Icon, text: String, scale: Float = 7f): Icon? {
+        val icon = LayeredIcon(2)
+        icon.setIcon(base, 0, SwingConstants.NORTH_WEST)
+        icon.setIcon(IconUtil.textToIcon(text, JLabel(), JBUIScale.scale(scale)), 1, SwingConstants.SOUTH_EAST)
+        return icon
     }
 
     /**

--- a/src/nl/hannahsten/texifyidea/ui/tablecreationdialog/TableCreationDialogWrapper.kt
+++ b/src/nl/hannahsten/texifyidea/ui/tablecreationdialog/TableCreationDialogWrapper.kt
@@ -1,11 +1,16 @@
 package nl.hannahsten.texifyidea.ui.tablecreationdialog
 
+import com.intellij.openapi.actionSystem.ActionGroup
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.ui.AnActionButton
 import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBTextField
 import com.intellij.ui.table.JBTable
+import com.intellij.util.IconUtil
 import nl.hannahsten.texifyidea.action.tablewizard.TableInformation
 import java.awt.BorderLayout
 import java.awt.Dimension
@@ -32,7 +37,7 @@ import javax.swing.border.EmptyBorder
 class TableCreationDialogWrapper(private val columnTypes: MutableList<ColumnType> = emptyList<ColumnType>().toMutableList(),
                                  private val tableModel: TableCreationTableModel = TableCreationTableModel(),
                                  var tableInformation: TableInformation = TableInformation(tableModel, columnTypes, "", ""),
-                                 // Components that have to be validated when clicking the OK button.
+        // Components that have to be validated when clicking the OK button.
                                  private val table: JTable = JBTable(tableModel),
                                  private val caption: JBTextField = JBTextField(),
                                  private val reference: JBTextField = JBTextField("tab:"))
@@ -74,6 +79,34 @@ class TableCreationDialogWrapper(private val columnTypes: MutableList<ColumnType
 
 
     override fun createCenterPanel(): JPanel {
+
+        // todo split up method
+
+        val editColumnActionButton: AnActionButton = object : AnActionButton("Edit column header", IconUtil.getEditIcon()) {
+
+            override fun actionPerformed(e: AnActionEvent) {
+                if (table.selectedColumn >= 0) {
+                    TableCreationEditColumnDialog(
+                            editColumnFun,
+                            table.selectedColumn,
+                            table.getColumnName(table.selectedColumn),
+                            columnTypes[table.selectedColumn])
+                }
+            }
+        }
+
+        val addRowActionButton = object : AnActionButton("Add row", IconUtil.getAddIcon()) {
+            override fun actionPerformed(e: AnActionEvent) {
+                tableModel.addEmptyRow()
+            }
+        }
+
+        val removeRowActionButton = object : AnActionButton("Remove row", IconUtil.getRemoveIcon()) {
+            override fun actionPerformed(e: AnActionEvent) {
+                tableModel.removeRow(table.selectedRow)
+            }
+        }
+
         // Decorator that contains the add/remove/edit buttons.
         val decorator = ToolbarDecorator.createDecorator(table)
                 .setAddAction {
@@ -82,15 +115,11 @@ class TableCreationDialogWrapper(private val columnTypes: MutableList<ColumnType
                 .setAddActionName("Add Column")
                 .setRemoveAction { tableModel.removeColumn(table.selectedColumn) }
                 .setRemoveActionName("Remove Column")
-//                .setEditAction {
-//                    TableCreationEditColumnDialog(
-//                            editColumnFun,
-//                            table.selectedColumn,
-//                            table.getColumnName(table.selectedColumn),
-//                            columnTypes[table.selectedColumn])
-//                }
-//                .setEditActionName("Edit Column Type")
+                .addExtraAction(editColumnActionButton)
+                .addExtraAction(addRowActionButton)
+                .addExtraAction(removeRowActionButton)
                 .createPanel()
+
 
         table.addTabCreatesNewRowAction()
         table.addEnterCreatesNewRowAction()

--- a/src/nl/hannahsten/texifyidea/ui/tablecreationdialog/TableCreationDialogWrapper.kt
+++ b/src/nl/hannahsten/texifyidea/ui/tablecreationdialog/TableCreationDialogWrapper.kt
@@ -1,6 +1,8 @@
 package nl.hannahsten.texifyidea.ui.tablecreationdialog
 
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.KeyboardShortcut
+import com.intellij.openapi.actionSystem.ShortcutSet
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.ui.AnActionButton
@@ -8,7 +10,7 @@ import com.intellij.ui.LayeredIcon
 import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBTextField
-import com.intellij.ui.scale.JBUIScale
+import com.intellij.ui.scale.JBUIScale.scale
 import com.intellij.ui.table.JBTable
 import com.intellij.util.IconUtil
 import nl.hannahsten.texifyidea.action.tablewizard.TableInformation
@@ -80,6 +82,8 @@ class TableCreationDialogWrapper(private val columnTypes: MutableList<ColumnType
 
     private fun getEditColumnActionButton(): AnActionButton = object : AnActionButton("Edit column header", addText(IconUtil.getEditIcon(), "C")) {
 
+        override fun isEnabled() = table.columnCount > 0
+
         override fun actionPerformed(e: AnActionEvent) {
             if (table.selectedColumn >= 0) {
                 TableCreationEditColumnDialog(
@@ -92,6 +96,9 @@ class TableCreationDialogWrapper(private val columnTypes: MutableList<ColumnType
     }
 
     private fun getAddRowActionButton() = object : AnActionButton("Add Row", addText(IconUtil.getAddIcon(), "R")) {
+
+        override fun isEnabled() = table.columnCount > 0
+
         override fun actionPerformed(e: AnActionEvent) {
             tableModel.addEmptyRow()
         }
@@ -127,7 +134,7 @@ class TableCreationDialogWrapper(private val columnTypes: MutableList<ColumnType
                 .addExtraAction(getRemoveColumnActionButton())
                 .addExtraAction(getEditColumnActionButton())
                 .addExtraAction(getAddRowActionButton())
-                .addExtraAction(getRemoveRowActionButton())
+                .addExtraAction(getRemoveRowActionButton().apply { shortcut = ShortcutSet { arrayOf(KeyboardShortcut(KeyStroke.getKeyStroke("DELETE"), null)) } })
                 .createPanel()
 
 
@@ -205,7 +212,7 @@ class TableCreationDialogWrapper(private val columnTypes: MutableList<ColumnType
     fun addText(base: Icon, text: String, scale: Float = 7f): Icon? {
         val icon = LayeredIcon(2)
         icon.setIcon(base, 0, SwingConstants.NORTH_WEST)
-        icon.setIcon(IconUtil.textToIcon(text, JLabel(), JBUIScale.scale(scale)), 1, SwingConstants.SOUTH_EAST)
+        icon.setIcon(IconUtil.textToIcon(text, JLabel(), scale(scale)), 1, SwingConstants.SOUTH_EAST)
         return icon
     }
 

--- a/src/nl/hannahsten/texifyidea/ui/tablecreationdialog/TableCreationEditColumnDialog.kt
+++ b/src/nl/hannahsten/texifyidea/ui/tablecreationdialog/TableCreationEditColumnDialog.kt
@@ -54,6 +54,13 @@ class TableCreationEditColumnDialog(
                 dialogWrapper.close(0)
             }
 
+            if (columnName == "") {
+                title("Add column")
+            }
+            else {
+                title("Edit column")
+            }
+
             if (show() == DialogWrapper.OK_EXIT_CODE) {
                 onOkFunction(columnNameField.text, ColumnType.values()[columnTypeComboBox.selectedIndex], editingColumn)
             }


### PR DESCRIPTION
Fixes #1093 (list of changes is over there)

Note that when editing a cell, you first have to press enter to finish editing and then again to advance to the next row. Since I just registered a key handler for enter, the first step seems to be default behaviour which wants to stay that way.

The text next to the icons is also a bit small, but don't see an easy way to change that.
