### PR TITLE
Do not create a problem descriptor for commands in other files (LatexDuplicateLabelInspection)

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexDuplicateLabelInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexDuplicateLabelInspection.kt
@@ -9,12 +9,22 @@ import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
-import nl.hannahsten.texifyidea.util.*
-import java.util.*
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexParameter
 import nl.hannahsten.texifyidea.settings.TexifySettings
+import nl.hannahsten.texifyidea.util.findBibitemCommands
+import nl.hannahsten.texifyidea.util.findLabelingCommandsSequence
+import nl.hannahsten.texifyidea.util.parentOfType
+import nl.hannahsten.texifyidea.util.requiredParameter
 import java.lang.Integer.max
+import java.util.*
+import kotlin.collections.List
+import kotlin.collections.contains
+import kotlin.collections.map
+import kotlin.collections.mutableMapOf
+import kotlin.collections.set
+import kotlin.collections.sum
+import kotlin.collections.toList
 
 /**
  * @author Hannah Schellekens, Sten Wessel
@@ -37,18 +47,15 @@ open class LatexDuplicateLabelInspection : TexifyInspectionBase() {
         // save all labels defined by label commands
         val definedLabels = mutableMapOf<String, LatexCommands>()
 
-        // save all labels defined by bibitem commands
-        val definedBibitems = mutableMapOf<String, LatexCommands>()
-
         // store the markers identified by the marked command to prevent to mark a command twice
         val markedCommands = mutableMapOf<PsiElement, ProblemDescriptor>()
 
         // list of defined commands
         val commands = TexifySettings.getInstance().labelCommands
 
-        // nearly same code twice, one time for labeling commands and one time for \bibitem
-        file.findLabelsInFileSetSequence().forEach {
-            // when label is defined in \newcommand ignore it, because there could be mor than one with #1 as parameter
+        // Treat LaTeX and BibTeX separately because only the first parameter of \bibitem commands counts
+        file.findLabelingCommandsSequence().forEach {
+            // when label is defined in \newcommand ignore it, because there could be more than one with #1 as parameter
             val parent = it.parentOfType(LatexCommands::class)
             if (parent != null && parent.name == "\\newcommand") {
                 return@forEach
@@ -58,36 +65,51 @@ open class LatexDuplicateLabelInspection : TexifyInspectionBase() {
 
             val position = commands[name]?.position ?: return@forEach
             val label = it.requiredParameter(position - 1) ?: return@forEach
-            // when the label is already in the list, mark both, the older and the actual command
-            if (definedLabels.contains(label)) {
-                markedCommands[it] = problemDescriptor(it, label, isOntheFly, manager)
-                val oldCommand = definedLabels[label] ?: return@forEach
-                // to prevent marking a command twice, check if the command is allready marked
-                if (!markedCommands.containsKey(oldCommand)) {
-                    markedCommands[oldCommand] = problemDescriptor(oldCommand, label, isOntheFly, manager)
-                }
-            }
-            // store the new label with defining command
-            else {
-                definedLabels[label] = it
-            }
+            markCommand(it, label, definedLabels, file, markedCommands, isOntheFly, manager)
         }
+
+        // save all labels defined by bibitem commands
+        val definedBibitems = mutableMapOf<String, LatexCommands>()
+
         file.findBibitemCommands().forEach {
             val label = it.requiredParameter(0) ?: return@forEach
-            if (definedBibitems.contains(label)) {
-                markedCommands[it] = problemDescriptor(it, label, isOntheFly, manager)
-                val oldCommand = definedBibitems[label] ?: return@forEach
-                if (!markedCommands.containsKey(oldCommand)) {
-                    markedCommands[oldCommand] = problemDescriptor(oldCommand, label, isOntheFly, manager)
-                }
-            }
-            else {
-                definedBibitems[label] = it
-            }
+            markCommand(it, label, definedBibitems, file, markedCommands, isOntheFly, manager)
         }
 
         // remove the identifier of the map and return as list
         return markedCommands.map { it.value }.toList()
+    }
+
+    /**
+     * Mark a command as duplicate when applicable.
+     */
+    private fun markCommand(command: LatexCommands,
+                    label: String,
+                    definedLabels: MutableMap<String, LatexCommands>,
+                    file: PsiFile,
+                    markedCommands: MutableMap<PsiElement, ProblemDescriptor>,
+                    isOntheFly: Boolean,
+                    manager: InspectionManager) {
+
+        if (definedLabels.contains(label)) {
+            // We cannot mark commands which are not in the file we are currently inspecting
+            // If the second one we found is not in the current file
+            if (command.containingFile != file) {
+                // Mark the old one
+                val oldCommand = definedLabels[label] ?: return
+                // To prevent marking a command twice, check if the command is already marked
+                if (!markedCommands.containsKey(oldCommand)) {
+                    markedCommands[oldCommand] = problemDescriptor(oldCommand, label, isOntheFly, manager)
+                }
+            } else {
+                // The first one we found is in the current file, so mark it
+                markedCommands[command] = problemDescriptor(command, label, isOntheFly, manager)
+            }
+        }
+        // store the new label with defining command
+        else {
+            definedLabels[label] = command
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #1104

```latex
\documentclass{article}
\begin{document}
    \label{dupe}
    \input{included}
\end{document}
```

```latex
\label{dupe}
```