### PR TITLE
Update to 2019.3 and update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,18 @@
 // Include the Gradle plugins which help building everything.
 // Supersedes the use of 'buildscript' block and 'apply plugin:'
 plugins {
-    id 'org.jetbrains.intellij' version '0.4.9'
-    id 'org.jetbrains.kotlin.jvm' version '1.3.41'
+    id 'org.jetbrains.intellij' version '0.4.14'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.61'
 
     // Plugin which can check for Gradle dependencies, use the help/dependencyUpdates task.
-    id 'com.github.ben-manes.versions' version '0.21.0'
+    id 'com.github.ben-manes.versions' version '0.27.0'
 
     // Plugin which can update Gradle dependencies, use the help/useLatestVersions task.
-    id 'se.patrikerdes.use-latest-versions' version '0.2.12'
+    id 'se.patrikerdes.use-latest-versions' version '0.2.13'
 
     // Used to debug in a different IDE
     id 'maven'
-    id 'de.undercouch.download' version '4.0.0'
+    id 'de.undercouch.download' version '4.0.2'
 }
 
 group 'nl.hannahsten'
@@ -72,24 +72,24 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect"
 
     // D-Bus Java bindings
-    compile "com.github.hypfvieh:dbus-java:3.0.2"
-    compile "org.slf4j:slf4j-simple:2.0.0-alpha0"
+    compile "com.github.hypfvieh:dbus-java:3.2.0"
+    compile "org.slf4j:slf4j-simple:2.0.0-alpha1"
 
     // Kotlin coroutines
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0-RC"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2"
 
     // Test dependencies
 
     // Also compile junit 4, just in case
-    testCompile("junit:junit:4.13-beta-3")
-    testRuntime("org.junit.vintage:junit-vintage-engine:5.5.1")
+    testCompile("junit:junit:4.13-rc-1")
+    testRuntime("org.junit.vintage:junit-vintage-engine:5.6.0-M1")
 
     // Use junit 5 for test cases
-    testCompile("org.junit.jupiter:junit-jupiter-api:5.5.1")
-    testRuntime("org.junit.jupiter:junit-jupiter-engine:5.5.1")
+    testCompile("org.junit.jupiter:junit-jupiter-api:5.6.0-M1")
+    testRuntime("org.junit.jupiter:junit-jupiter-engine:5.6.0-M1")
 
     // Enable use of the JUnitPlatform Runner within the IDE
-    testCompile("org.junit.platform:junit-platform-runner:1.5.1")
+    testCompile("org.junit.platform:junit-platform-runner:1.6.0-M1")
 
     // just in case
     testCompile "org.jetbrains.kotlin:kotlin-test"
@@ -151,7 +151,7 @@ intellij {
     sameSinceUntilBuild = true
 
     // Comment out to use the latest EAP snapshot
-    version '2019.2'
+    version '2019.3'
 }
 
 test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0-rc-3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      https://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -5,7 +5,7 @@
 @rem you may not use this file except in compliance with the License.
 @rem You may obtain a copy of the License at
 @rem
-@rem      https://www.apache.org/licenses/LICENSE-2.0
+@rem      http://www.apache.org/licenses/LICENSE-2.0
 @rem
 @rem Unless required by applicable law or agreed to in writing, software
 @rem distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Looks to be no breaking changes this time, as far as I tested.
