### PR TITLE
Add support of Grazie plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,18 +65,16 @@ dependencies {
     compile files("lib/JavaDDEx64.dll")
 
     // From Kotlin documentation
-    compile "org.jetbrains.kotlin:kotlin-stdlib"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-
-    // just in case, version number specified in buildscript is used by default
-    compile "org.jetbrains.kotlin:kotlin-reflect"
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib"
 
     // D-Bus Java bindings
     compile "com.github.hypfvieh:dbus-java:3.2.0"
     compile "org.slf4j:slf4j-simple:2.0.0-alpha1"
 
     // Kotlin coroutines
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2"
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2" ) {
+        exclude(group: "org.jetbrains.kotlin")
+    }
 
     // Test dependencies
 
@@ -144,6 +142,8 @@ intellij {
     if (project.hasProperty('usePycharm') && usePycharm == 'true') {
         alternativeIdePath ".gradle/ide/pycharm-${pycharmVersion}"
     }
+
+    plugins = ['tanvd.grazi:2019.3-6.2.stable']
 
     // Use the since build number from plugin.xml
     updateSinceUntilBuild = false

--- a/resources/META-INF/grazie.xml
+++ b/resources/META-INF/grazie.xml
@@ -1,0 +1,5 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij.grazie">
+        <grammar.strategy language="Latex" implementationClass="nl.hannahsten.texifyidea.inspections.LatexGrammarCheckingStrategy"/>
+    </extensions>
+</idea-plugin>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -38,6 +38,7 @@
 
     <!-- Dependencies (must be defined to ensure compatibility with other IDEs) -->
     <depends>com.intellij.modules.lang</depends>
+    <depends optional="true" config-file="grazie.xml">tanvd.grazi</depends>
 
     <description><![CDATA[
         <p>

--- a/src/nl/hannahsten/texifyidea/inspections/LatexGrammarCheckingStrategy.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/LatexGrammarCheckingStrategy.kt
@@ -1,0 +1,23 @@
+package nl.hannahsten.texifyidea.inspections
+
+import com.intellij.grazie.grammar.strategy.GrammarCheckingStrategy
+import com.intellij.grazie.grammar.strategy.StrategyUtils
+import com.intellij.grazie.grammar.strategy.impl.ReplaceCharRule
+import com.intellij.grazie.utils.*
+import com.intellij.psi.PsiElement
+import nl.hannahsten.texifyidea.psi.*
+
+class LatexGrammarCheckingStrategy : GrammarCheckingStrategy {
+    private fun PsiElement.isNotInMathEnvironment() = parents().none { it is LatexMathEnvironment }
+
+    private fun PsiElement.isNotInSquareBrackets() = parents().find { it is LatexGroup || it is LatexOpenGroup }
+            ?.let { it is LatexGroup } ?: true
+
+    override fun isMyContextRoot(element: PsiElement) = element is LatexNormalText && element.isNotInMathEnvironment() && element.isNotInSquareBrackets()
+
+    override fun isTypoAccepted(root: PsiElement, typoRange: IntRange, ruleRange: IntRange) = !typoRange.isAtStart(root) && !typoRange.isAtEnd(root)
+
+    override fun getReplaceCharRules(root: PsiElement) = emptyList<ReplaceCharRule>()
+
+    override fun getStealthyRanges(root: PsiElement, text: CharSequence) = StrategyUtils.indentIndexes(text, setOf(' '))
+}


### PR DESCRIPTION
#### Additions
Support of JetBrains Grazie plugin (https://plugins.jetbrains.com/plugin/12175-grazie/).
Adds support of grammar checking in Latex documents. 
![Latex support](https://user-images.githubusercontent.com/10253437/69994466-fd5c1180-155e-11ea-964a-4038c631e2d0.png)

#### Changes
Remove bundled Kotlin, use provided by IntelliJ Platform. (Needed since Grazie uses provided, decreases size by 1mb)
