### PR TITLE
Only trigger LatexSpaceAfterAbbreviationInspection on abbreviations ending with a .

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexSpaceAfterAbbreviationInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexSpaceAfterAbbreviationInspection.kt
@@ -59,8 +59,8 @@ open class LatexSpaceAfterAbbreviationInspection : TexifyInspectionBase() {
 
                 descriptors.add(manager.createProblemDescriptor(
                         text,
-                        TextRange(matchRange.last - 1, matchRange.last + 1),
-                        "Abbreviation is not followed by a normal space",
+                        TextRange(matchRange.last - 2, matchRange.last),
+                        "Abbreviation should be followed by a normal space",
                         ProblemHighlightType.WEAK_WARNING,
                         isOntheFly,
                         NormalSpaceFix(matchRange)
@@ -102,8 +102,8 @@ open class LatexSpaceAfterAbbreviationInspection : TexifyInspectionBase() {
         }
 
         private fun replaceNormalText(document: Document, normalText: LatexNormalText) {
-            val start = normalText.textOffset + whitespaceRange.last
-            val end = normalText.textOffset + whitespaceRange.last + 1
+            val start = normalText.textOffset + whitespaceRange.last - 1
+            val end = normalText.textOffset + whitespaceRange.last
             document.replaceString(start, end, "\\ ")
         }
     }

--- a/src/nl/hannahsten/texifyidea/util/Magic.kt
+++ b/src/nl/hannahsten/texifyidea/util/Magic.kt
@@ -344,7 +344,7 @@ object Magic {
          * `i.e.`. Single period abbreviations are not being detected as they can easily be confused with two letter words
          * at the end of the sentence (also localisation...) For this there is a quickfix in [LatexLineBreakInspection].
          */
-        @JvmField val abbreviation = RegexPattern.compile("[0-9A-Za-z.]+\\.[A-Za-z](\\.|\\s)")!!
+        @JvmField val abbreviation = RegexPattern.compile("[0-9A-Za-z.]+\\.[A-Za-z](\\.\\s)")!!
 
         /**
          * Matches all comments, starting with % and ending with a newline.


### PR DESCRIPTION
Fixes #1033

To test:

Check that with 
```latex
\documentclass{article}
\begin{document}
    E.g me $N$.
\end{document}
```
the inspection is not triggered, but it is triggered when using `e.g.` and the quickfix works.
