### PR TITLE
Add option to disable auto package insert (and some subfiles support)

### DIFF
--- a/src/nl/hannahsten/texifyidea/index/IndexUtilBase.kt
+++ b/src/nl/hannahsten/texifyidea/index/IndexUtilBase.kt
@@ -6,10 +6,9 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
-import nl.hannahsten.texifyidea.util.files.documentClassFile
-import nl.hannahsten.texifyidea.util.files.findRootFile
-import nl.hannahsten.texifyidea.util.files.referencedFileSet
-import nl.hannahsten.texifyidea.util.files.referencedFiles
+import nl.hannahsten.texifyidea.util.PackageUtils.getIncludedPackages
+import nl.hannahsten.texifyidea.util.files.*
+import nl.hannahsten.texifyidea.util.includedPackages
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingImportInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingImportInspection.kt
@@ -19,6 +19,7 @@ import nl.hannahsten.texifyidea.lang.Package.Companion.MATHTOOLS
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexEnvironment
+import nl.hannahsten.texifyidea.settings.TexifySettings
 import nl.hannahsten.texifyidea.util.*
 import nl.hannahsten.texifyidea.util.files.commandsInFile
 import nl.hannahsten.texifyidea.util.files.definitionsAndRedefinitionsInFileSet
@@ -40,6 +41,11 @@ open class LatexMissingImportInspection : TexifyInspectionBase() {
     override fun getDisplayName() = "Missing imports"
 
     override fun inspectFile(file: PsiFile, manager: InspectionManager, isOntheFly: Boolean): List<ProblemDescriptor> {
+
+        if (!TexifySettings.getInstance().automaticDependencyCheck) {
+            return emptyList()
+        }
+
         val descriptors = descriptorList()
 
         val includedPackages = PackageUtils.getIncludedPackages(file)

--- a/src/nl/hannahsten/texifyidea/lang/LatexRegularCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/LatexRegularCommand.kt
@@ -8,6 +8,7 @@ import nl.hannahsten.texifyidea.lang.Package.Companion.DEFAULT
 import nl.hannahsten.texifyidea.lang.Package.Companion.FONTENC
 import nl.hannahsten.texifyidea.lang.Package.Companion.GRAPHICX
 import nl.hannahsten.texifyidea.lang.Package.Companion.NATBIB
+import nl.hannahsten.texifyidea.lang.Package.Companion.SUBFILES
 import nl.hannahsten.texifyidea.lang.Package.Companion.ULEM
 
 /**
@@ -218,6 +219,7 @@ enum class LatexRegularCommand(
     STEPCOUNTER("stepcounter", "counter".asRequired()),
     STOP("stop"),
     STRETCH("stretch", "factor".asRequired()),
+    SUBFILE("subfile", RequiredFileArgument("sourcefile", "tex"), dependency = SUBFILES),
     SUBITEM("subitem"),
     SUBPARAGRAPH("subparagraph", "shorttitle".asOptional(Type.TEXT), "title".asRequired(Type.TEXT)),
     SUBPARAGRAPH_STAR("subparagraph*", "title".asRequired(Type.TEXT)),
@@ -362,6 +364,7 @@ enum class LatexRegularCommand(
         private val lookupDisplay = HashMap<String, LatexRegularCommand>()
 
         init {
+            @Suppress("RemoveRedundantQualifierName")
             for (command in LatexRegularCommand.values()) {
                 lookup[command.command] = command
                 if (command.display != null) {

--- a/src/nl/hannahsten/texifyidea/lang/Package.kt
+++ b/src/nl/hannahsten/texifyidea/lang/Package.kt
@@ -29,6 +29,7 @@ open class Package @JvmOverloads constructor(
         @JvmField val MATHABX = Package("mathabx")
         @JvmField val MATHTOOLS = Package("mathtools")
         @JvmField val NATBIB = Package("natbib")
+        @JvmField val SUBFILES = Package("subfiles")
         @JvmField val ULEM = Package("ulem")
         @JvmField val XPARSE = Package("xparse")
     }

--- a/src/nl/hannahsten/texifyidea/settings/TexifyConfigurable.kt
+++ b/src/nl/hannahsten/texifyidea/settings/TexifyConfigurable.kt
@@ -19,6 +19,7 @@ class TexifyConfigurable(private val settings: TexifySettings) : SearchableConfi
     private lateinit var automaticSecondInlineMathSymbol: JBCheckBox
     private lateinit var automaticUpDownBracket: JBCheckBox
     private lateinit var automaticItemInItemize: JBCheckBox
+    private lateinit var automaticDependencyCheck: JBCheckBox
     private lateinit var continuousPreview: JBCheckBox
     private lateinit var automaticQuoteReplacement: ComboBox<String>
     private lateinit var pdfViewer: ComboBox<String>
@@ -38,6 +39,7 @@ class TexifyConfigurable(private val settings: TexifySettings) : SearchableConfi
                 automaticSecondInlineMathSymbol = addCheckbox("Automatically insert second '$'")
                 automaticUpDownBracket = addCheckbox("Automatically insert braces around text in subscript and superscript")
                 automaticItemInItemize = addCheckbox("Automatically insert '\\item' in itemize-like environments on pressing enter")
+                automaticDependencyCheck = addCheckbox("Automatically check for required package dependencies and insert them")
                 continuousPreview = addCheckbox("Automatically refresh preview of math and TikZ pictures")
                 automaticQuoteReplacement = addSmartQuotesOptions("Off", "TeX ligatures", "TeX commands", "csquotes")
                 pdfViewer = addPdfViewerOptions()
@@ -80,6 +82,7 @@ class TexifyConfigurable(private val settings: TexifySettings) : SearchableConfi
         return automaticSecondInlineMathSymbol.isSelected != settings.automaticSecondInlineMathSymbol
                 || automaticUpDownBracket.isSelected != settings.automaticUpDownBracket
                 || automaticItemInItemize.isSelected != settings.automaticItemInItemize
+                || automaticDependencyCheck.isSelected != settings.automaticDependencyCheck
                 || continuousPreview.isSelected != settings.continuousPreview
                 || automaticQuoteReplacement.selectedIndex != settings.automaticQuoteReplacement.ordinal
                 || pdfViewer.selectedIndex != settings.pdfViewer.ordinal
@@ -90,6 +93,7 @@ class TexifyConfigurable(private val settings: TexifySettings) : SearchableConfi
         settings.automaticSecondInlineMathSymbol = automaticSecondInlineMathSymbol.isSelected
         settings.automaticUpDownBracket = automaticUpDownBracket.isSelected
         settings.automaticItemInItemize = automaticItemInItemize.isSelected
+        settings.automaticDependencyCheck = automaticDependencyCheck.isSelected
         settings.continuousPreview = continuousPreview.isSelected
         settings.automaticQuoteReplacement = TexifySettings.QuoteReplacement.values()[automaticQuoteReplacement.selectedIndex]
         settings.pdfViewer = PdfViewer.availableSubset()[pdfViewer.selectedIndex]
@@ -100,6 +104,7 @@ class TexifyConfigurable(private val settings: TexifySettings) : SearchableConfi
         automaticSecondInlineMathSymbol.isSelected = settings.automaticSecondInlineMathSymbol
         automaticUpDownBracket.isSelected = settings.automaticUpDownBracket
         automaticItemInItemize.isSelected = settings.automaticItemInItemize
+        automaticDependencyCheck.isSelected = settings.automaticDependencyCheck
         continuousPreview.isSelected = settings.continuousPreview
         automaticQuoteReplacement.selectedIndex = settings.automaticQuoteReplacement.ordinal
         pdfViewer.selectedIndex = PdfViewer.availableSubset().indexOf(settings.pdfViewer)

--- a/src/nl/hannahsten/texifyidea/settings/TexifySettings.kt
+++ b/src/nl/hannahsten/texifyidea/settings/TexifySettings.kt
@@ -28,6 +28,7 @@ class TexifySettings : PersistentStateComponent<TexifySettingsState> {
     var automaticSecondInlineMathSymbol = true
     var automaticUpDownBracket = true
     var automaticItemInItemize = true
+    var automaticDependencyCheck = true
     var continuousPreview = false
     var automaticQuoteReplacement = QuoteReplacement.NONE
     var pdfViewer = PdfViewer.values().first { it.isAvailable() }
@@ -43,6 +44,7 @@ class TexifySettings : PersistentStateComponent<TexifySettingsState> {
                 automaticSecondInlineMathSymbol = automaticSecondInlineMathSymbol,
                 automaticUpDownBracket = automaticUpDownBracket,
                 automaticItemInItemize = automaticItemInItemize,
+                automaticDependencyCheck = automaticDependencyCheck,
                 continuousPreview = continuousPreview,
                 automaticQuoteReplacement = automaticQuoteReplacement,
                 pdfViewer = pdfViewer,
@@ -54,6 +56,7 @@ class TexifySettings : PersistentStateComponent<TexifySettingsState> {
         automaticSecondInlineMathSymbol = state.automaticSecondInlineMathSymbol
         automaticUpDownBracket = state.automaticUpDownBracket
         automaticItemInItemize = state.automaticItemInItemize
+        automaticDependencyCheck = state.automaticDependencyCheck
         continuousPreview = state.continuousPreview
         automaticQuoteReplacement = state.automaticQuoteReplacement
         pdfViewer = state.pdfViewer

--- a/src/nl/hannahsten/texifyidea/settings/TexifySettingsState.kt
+++ b/src/nl/hannahsten/texifyidea/settings/TexifySettingsState.kt
@@ -6,6 +6,7 @@ data class TexifySettingsState (
         var automaticSecondInlineMathSymbol : Boolean = true,
         var automaticUpDownBracket : Boolean = true,
         var automaticItemInItemize: Boolean = true,
+        var automaticDependencyCheck: Boolean = true,
         var continuousPreview: Boolean = false,
         var automaticQuoteReplacement: TexifySettings.QuoteReplacement = TexifySettings.QuoteReplacement.NONE,
         var pdfViewer: PdfViewer = PdfViewer.firstAvailable(),

--- a/src/nl/hannahsten/texifyidea/util/Magic.kt
+++ b/src/nl/hannahsten/texifyidea/util/Magic.kt
@@ -201,7 +201,7 @@ object Magic {
          * All commands that include other files.
          */
         @JvmField val includes = hashSetOf(
-                "\\includeonly", "\\include", "\\input", "\\bibliography", "\\addbibresource", "\\RequirePackage", "\\usepackage"
+                "\\includeonly", "\\include", "\\input", "\\bibliography", "\\addbibresource", "\\RequirePackage", "\\usepackage", "\\subfile"
         )
 
         /**
@@ -243,6 +243,7 @@ object Magic {
         @JvmField val includeOnlyExtensions = mapOf(
                 "\\include" to hashSetOf("tex"),
                 "\\includeonly" to hashSetOf("tex"),
+                "\\subfile" to hashSetOf("tex"),
                 "\\bibliography" to hashSetOf("bib"),
                 "\\addbibresource" to hashSetOf("bib"),
                 "\\RequirePackage" to hashSetOf("sty"),

--- a/src/nl/hannahsten/texifyidea/util/Packages.kt
+++ b/src/nl/hannahsten/texifyidea/util/Packages.kt
@@ -227,6 +227,7 @@ object PackageUtils {
 
     /**
      * Analyses all the given commands and reduces it to a set of all included packages.
+     * Classes will not be included.
      *
      * Note that not all elements returned may be valid package names.
      */
@@ -240,8 +241,16 @@ object PackageUtils {
                 continue
             }
 
-            // Packages can be loaded both in optional and required parameters
-            for (list in setOf(cmd.requiredParameters, cmd.optionalParameters)) {
+            // Assume packages can be included in both optional and required parameters
+            // Except a class, because a class is not a package
+            val packages = if (cmd.commandToken.text == "\\documentclass" || cmd.commandToken.text == "\\LoadClass") {
+                setOf(cmd.optionalParameters)
+            }
+            else {
+                setOf(cmd.requiredParameters, cmd.optionalParameters)
+            }
+
+            for (list in packages) {
 
                 if (list.isEmpty()) {
                     continue


### PR DESCRIPTION
Fixes #1101 

This PR
- Adds a global setting to disable auto insertion of package requirements (and also disables LatexMissingImportInspection)
- The root file when using the subfiles package is now correct, so package imports will be added to the correct preamble and imports will be resolved correctly (try using autocomplete for something in section1.tex)
- Added the subfile command
- Do not add the class in the list of included packages, otherwise it thinks that subfiles is included twice.

https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Automatic-package-importing

```latex
\documentclass{article}
\usepackage{amsmath}
\usepackage{subfiles}
\begin{document}
    \section{One}\label{sec:one}
    \subfile{section1}
\end{document}
```

```latex
\documentclass[main.tex]{subfiles}

\begin{document}

    \begin{align*}
        \alpha
    \end{align*}

\end{document}
```
