### PR TITLE
Add support for compression prevention from cleveref

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexNonBreakingSpaceInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexNonBreakingSpaceInspection.kt
@@ -33,7 +33,7 @@ open class LatexNonBreakingSpaceInspection : TexifyInspectionBase() {
          * All commands that should not have a forced breaking space.
          */
         val IGNORED_COMMANDS = setOf(
-                "\\citet", "\\citet*", "\\Citet", "\\Citet*", "\\cref", "\\cpageref", "\\autoref", "\\citeauthor"
+                "\\citet", "\\citet*", "\\Citet", "\\Citet*", "\\cref", "\\Cref", "\\cpageref", "\\autoref", "\\citeauthor"
         )
     }
 

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexUnresolvedReferenceInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexUnresolvedReferenceInspection.kt
@@ -46,6 +46,9 @@ open class LatexUnresolvedReferenceInspection : TexifyInspectionBase() {
                 val part = parts[i]
                 if (part == "*") continue
 
+                // The cleveref package allows empty items to customize enumerations
+                if (part.isEmpty() && (command.commandToken.text == "\\cref" || command.commandToken.text == "\\Cref")) continue
+
                 // If there is no label with this required label parameter value
                 if (!labels.contains(part.trim())) {
                     // We have to subtract from the total length, because we do not know whether optional

--- a/src/nl/hannahsten/texifyidea/lang/LatexRegularCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/LatexRegularCommand.kt
@@ -3,6 +3,7 @@ package nl.hannahsten.texifyidea.lang
 import nl.hannahsten.texifyidea.lang.Argument.Type
 import nl.hannahsten.texifyidea.lang.Package.Companion.AMSMATH
 import nl.hannahsten.texifyidea.lang.Package.Companion.BIBLATEX
+import nl.hannahsten.texifyidea.lang.Package.Companion.CLEVEREF
 import nl.hannahsten.texifyidea.lang.Package.Companion.CSQUOTES
 import nl.hannahsten.texifyidea.lang.Package.Companion.DEFAULT
 import nl.hannahsten.texifyidea.lang.Package.Companion.FONTENC
@@ -50,6 +51,8 @@ enum class LatexRegularCommand(
     COLUMNWIDTH("columnwidth"),
     CONTENTSLINE("contentsline", "type".asRequired(), "text".asRequired(Type.TEXT), "page".asRequired()),
     CONTENTSNAME("contentsname", "name".asRequired()),
+    CREF("cref", "label".asRequired(), dependency = CLEVEREF),
+    CREF_CAPITAL("Cref", "label".asRequired(), dependency = CLEVEREF),
     DATE("date", "text".asRequired(Type.TEXT)),
     DECLARE_MATH_OPERATOR("DeclareMathOperator", "command".asRequired(), "operator".asRequired(Type.TEXT)),
     DEF("def"),

--- a/src/nl/hannahsten/texifyidea/lang/Package.kt
+++ b/src/nl/hannahsten/texifyidea/lang/Package.kt
@@ -18,6 +18,7 @@ open class Package @JvmOverloads constructor(
         @JvmField val BIBLATEX = Package("biblatex")
         @JvmField val BOOKTABS = Package("booktabs")
         @JvmField val COMMENT = Package("comment")
+        @JvmField val CLEVEREF = Package("cleveref")
         @JvmField val CSQUOTES = Package("csquotes")
         @JvmField val FONTENC = Package("fontenc")
         @JvmField val GRAPHICX = Package("graphicx")

--- a/src/nl/hannahsten/texifyidea/util/Magic.kt
+++ b/src/nl/hannahsten/texifyidea/util/Magic.kt
@@ -109,7 +109,7 @@ object Magic {
          */
         @JvmField val labelReference = hashSetOf(
                 "\\ref", "\\eqref", "\\nameref", "\\autoref",
-                "\\fullref", "\\pageref", "\\vref", "\\Autoref", "\\cref",
+                "\\fullref", "\\pageref", "\\vref", "\\Autoref", "\\cref", "\\Cref",
                 "\\labelcref", "\\cpageref"
         )
 


### PR DESCRIPTION
Fixes #1124

The `\cref` and `\Cref` commands allow empty references to locally prevent reference compression, like this:

```latex
\documentclass{article}
\usepackage{cleveref}
\begin{document}
    \section{section1}\label{refSection1}
    \section{section2}\label{refSection2}
    \section{section3}\label{refSection3}

    \cref{refSection1,refSection2,refSection3}
    % is typeset as Sec. 1 to 3

    % note the double comma here
    \cref{refSection1,refSection2,,refSection3}
    % is typeset as Sec. 1, Sec. 2 and Sec. 3
    
    ~\ref{refSection1,,refSection2}
    % should give warning
\end{document}
```
