### PR TITLE
Use real instead of indexed command name for missing label inspection

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingLabelInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingLabelInspection.kt
@@ -38,7 +38,9 @@ open class LatexMissingLabelInspection : TexifyInspectionBase() {
 
         val commands = file.commandsInFile()
         for (command in commands) {
-            if (!Magic.Command.labeled.containsKey(command.name) || command.name == "\\item" || command.hasStar()) {
+            // It is important to use commandToken.text instead of command.name,
+            // because command.name may still be an old indexed and possibly incorrect value
+            if (!Magic.Command.labeled.containsKey(command.commandToken.text) || command.commandToken.text == "\\item" || command.hasStar()) {
                 continue
             }
 


### PR DESCRIPTION
Fixes #1097

The bug occurred when a command like \subsection was directly after another command like \section, because then the index entry of the second would not be removed. It would be removed when there was text inbetween. When the entry was not removed, the `\input` command would be there but the missing label inspection would think it was the `\subsection` command because that was in the index.

Anyway, the move section contents to file will not trigger the missing label inspection anymore:
```latex
\section{One}\label{sec:one}
\subsection{Two}\label{subsec:two}
```


