### PR TITLE
Show the real gutter icon

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group 'nl.hannahsten'
-version '0.7-alpha.47'
+version '0.7-alpha.48'
 
 repositories {
     mavenCentral()

--- a/src/nl/hannahsten/texifyidea/TexifyIcons.java
+++ b/src/nl/hannahsten/texifyidea/TexifyIcons.java
@@ -402,6 +402,8 @@ public class TexifyIcons {
                 return STYLE_FILE;
             case "txt":
                 return TEXT_FILE;
+            case "tikz":
+                return TIKZ_FILE;
             case "log":
                 return TEXT_FILE;
             case "pdf":

--- a/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
+++ b/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
@@ -108,7 +108,7 @@ class LatexNavigationGutter : RelatedItemLineMarkerProvider() {
         // Get the icon from the file extension when applicable and there exists an icon for this extension,
         // otherwise get the default icon for this argument.
         val extensionIcon = TexifyIcons.getIconFromExtension(fileNames[0].split(".").last())
-        val icon = if (ignoreFileArgument || (!ignoreFileArgument && extensionIcon == TexifyIcons.FILE)) {
+        val icon = if (ignoreFileArgument || extensionIcon == TexifyIcons.FILE) {
             TexifyIcons.getIconFromExtension(argument.defaultExtension)
         } else {
             extensionIcon

--- a/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
+++ b/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
@@ -39,7 +39,7 @@ class LatexNavigationGutter : RelatedItemLineMarkerProvider() {
 
         val fullCommand = element.commandToken.text ?: return
 
-        // True when it doesnt have a required _file_ argument, but must be handled.
+        // True when it doesn't have a required _file_ argument, but must be handled.
         val ignoreFileArgument = IGNORE_FILE_ARGUMENTS.contains(fullCommand)
 
         // Fetch the corresponding LatexRegularCommand object.
@@ -54,14 +54,6 @@ class LatexNavigationGutter : RelatedItemLineMarkerProvider() {
             return
         }
 
-        // Get the required file arguments.
-        val argument = if (ignoreFileArgument) {
-            RequiredFileArgument("", "sty", "cls")
-        }
-        else {
-            arguments[0]
-        }
-
         val requiredParams = element.requiredParameters()
         if (requiredParams.isEmpty()) {
             return
@@ -69,6 +61,18 @@ class LatexNavigationGutter : RelatedItemLineMarkerProvider() {
 
         // Find filenames.
         val fileNames = splitContent(requiredParams[0], ",")
+
+        // Get the required file arguments.
+        val argument = if (ignoreFileArgument) {
+            if (commandName == LatexRegularCommand.DOCUMENTCLASS.command) {
+                RequiredFileArgument("", "cls")
+            } else {
+                RequiredFileArgument("", "sty")
+            }
+        } else {
+            arguments[0]
+        }
+
 
         // Look up target file.
         val containingFile = element.getContainingFile() ?: return
@@ -98,10 +102,20 @@ class LatexNavigationGutter : RelatedItemLineMarkerProvider() {
                 .toList()
 
         // Build gutter icon.
-        val maxSize = WindowManagerEx.getInstanceEx().getFrame(element.getProject())?.size?.width ?: return
+        val maxSize = WindowManagerEx.getInstanceEx().getFrame(element.getProject())?.size?.width
+                ?: return
+
+        // Get the icon from the file extension when applicable and there exists an icon for this extension,
+        // otherwise get the default icon for this argument.
+        val extensionIcon = TexifyIcons.getIconFromExtension(fileNames[0].split(".").last())
+        val icon = if (ignoreFileArgument || (!ignoreFileArgument && extensionIcon == TexifyIcons.FILE)) {
+            TexifyIcons.getIconFromExtension(argument.defaultExtension)
+        } else {
+            extensionIcon
+        }
 
         val builder = NavigationGutterIconBuilder
-                .create(TexifyIcons.getIconFromExtension(argument.defaultExtension))
+                .create(icon)
                 .setTargets(files)
                 .setPopupTitle("Navigate to Referenced File")
                 .setTooltipText("Go to referenced file")

--- a/src/nl/hannahsten/texifyidea/lang/LatexRegularCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/LatexRegularCommand.kt
@@ -108,7 +108,7 @@ enum class LatexRegularCommand(
     I("i", display = "i (dotless)"),
     INCLUDE("include", RequiredFileArgument("sourcefile", "tex")),
     INPUT("input", RequiredFileArgument("sourcefile", "tex")),
-    INCLUDEGRAPHICS("includegraphics", "key-val-list".asOptional(), RequiredFileArgument("imagefile", "pdf", "png", "jpg", "eps"), dependency = GRAPHICX),
+    INCLUDEGRAPHICS("includegraphics", "key-val-list".asOptional(), RequiredFileArgument("imagefile", "pdf", "png", "jpg", "eps", "tikz"), dependency = GRAPHICX),
     INCLUDEONLY("includeonly", RequiredFileArgument("sourcefile", "tex")),
     INDEXNAME("indexname", "name".asRequired()),
     INDEXSPACE("indexspace"),


### PR DESCRIPTION
Fixes #1135

When showing a gutter icon, it now first tries to get the icon based on the file extension (if this is available) before using the default icon for the given command.

Try the following snippet and notice the TikZ (instead of pdf) and cls (instead of sty) icons in the gutter:
main.tex
```latex
\documentclass{article}

\usepackage{tikz}
\usepackage{tikzscale}
\usepackage{graphicx}

\begin{document}
    \includegraphics{figure.tikz}
\end{document}
```

figure.tikz
```latex
\begin{tikzpicture}
    \draw (0, 0) -- (1, 1);
\end{tikzpicture}
```
