### PR TITLE
Register analyze menu action group using a service instead of a deprecated application component

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -141,16 +141,6 @@
         </p>
     ]]></change-notes>
 
-    <module-components>
-    </module-components>
-
-    <!-- Register Analyze menu items programmatically. -->
-    <application-components>
-        <component>
-            <implementation-class>nl.hannahsten.texifyidea.action.AnalyzeMenuRegistration</implementation-class>
-        </component>
-    </application-components>
-
     <!-- Custom actions -->
     <actions>
         <!-- New LaTeX file -->
@@ -321,7 +311,8 @@
     <!-- Hooks for plugin functionality -->
     <extensions defaultExtensionNs="com.intellij">
         <!-- Startup -->
-        <postStartupActivity implementation="nl.hannahsten.texifyidea.startup.TexifyStartupActivity"/>
+        <postStartupActivity implementation="nl.hannahsten.texifyidea.startup.StartEvinceInverseSearchListener"/>
+        <postStartupActivity implementation="nl.hannahsten.texifyidea.startup.AnalyzeMenuRegistration" />
 
         <!-- Files and project -->
         <moduleType id="LATEX_MODULE_TYPE" implementationClass="nl.hannahsten.texifyidea.modules.LatexModuleType"/>
@@ -346,12 +337,12 @@
         <liveTemplateContext implementation="nl.hannahsten.texifyidea.templates.BibtexContext"/>
 
         <!-- Application settings -->
-        <applicationService serviceInterface="nl.hannahsten.texifyidea.settings.TexifySettings" serviceImplementation="nl.hannahsten.texifyidea.settings.TexifySettings"/>
+        <applicationService serviceImplementation="nl.hannahsten.texifyidea.settings.TexifySettings"/>
         <applicationConfigurable instance="nl.hannahsten.texifyidea.settings.TexifyConfigurable" groupId="language" id="TexifyConfigurable"/>
         <colorSettingsPage implementation="nl.hannahsten.texifyidea.highlighting.LatexColorSettingsPage"/>
         <colorSettingsPage implementation="nl.hannahsten.texifyidea.highlighting.BibtexColorSettingsPage"/>
         <!-- Project settings -->
-        <projectService serviceInterface="nl.hannahsten.texifyidea.settings.TexifyProjectSettings" serviceImplementation="nl.hannahsten.texifyidea.settings.TexifyProjectSettings"/>
+        <projectService serviceImplementation="nl.hannahsten.texifyidea.settings.TexifyProjectSettings"/>
         <projectConfigurable instance="nl.hannahsten.texifyidea.settings.TexifyProjectConfigurable" groupId="TexifyConfigurable" id="TexifyProjectConfigurable" />
 
         <!-- Languages -->

--- a/src/nl/hannahsten/texifyidea/startup/AnalyzeMenuRegistration.kt
+++ b/src/nl/hannahsten/texifyidea/startup/AnalyzeMenuRegistration.kt
@@ -1,23 +1,21 @@
-package nl.hannahsten.texifyidea.action
+package nl.hannahsten.texifyidea.startup
 
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.actionSystem.IdeActions
 import com.intellij.openapi.application.ApplicationNamesInfo
-import com.intellij.openapi.components.BaseComponent
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.StartupActivity
 
 /**
  * Register a menu item programmatically instead of in plugin.xml, so we can customize when it is shown or not (xml is preferred, but we cannot switch on application name in xml).
  *
  * @author Thomas Schouten
  */
-class AnalyzeMenuRegistration : BaseComponent {
+class AnalyzeMenuRegistration : StartupActivity, DumbAware {
 
-    override fun initComponent() {
-        super.initComponent()
-
-        // Documentation for registering an action: http://www.jetbrains.org/intellij/sdk/docs/basics/action_system.html?search=action#registering-actions-from-code
-
+    override fun runActivity(project: Project) {
         // Get the group which should be added to either the Analyze menu or something else
         val latexAnalyzeMenuGroup = ActionManager.getInstance().getAction("texify.LatexMenuAnalyze") as DefaultActionGroup
 
@@ -34,7 +32,7 @@ class AnalyzeMenuRegistration : BaseComponent {
         }
         else {
             // Get an instance of the Code action group by ID
-            val analyzeGroup: DefaultActionGroup = com.intellij.openapi.actionSystem.ActionManager.getInstance().getAction("CodeMenu") as DefaultActionGroup
+            val analyzeGroup: DefaultActionGroup = ActionManager.getInstance().getAction("CodeMenu") as DefaultActionGroup
 
             analyzeGroup.add(latexAnalyzeMenuGroup)
         }

--- a/src/nl/hannahsten/texifyidea/startup/StartEvinceInverseSearchListener.kt
+++ b/src/nl/hannahsten/texifyidea/startup/StartEvinceInverseSearchListener.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.startup
 
+import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.StartupActivity
 import com.intellij.openapi.util.SystemInfo
@@ -10,7 +11,7 @@ import nl.hannahsten.texifyidea.settings.TexifySettings
 /**
  * @author Sten Wessel
  */
-class TexifyStartupActivity : StartupActivity {
+class StartEvinceInverseSearchListener : StartupActivity, DumbAware {
 
     override fun runActivity(project: Project) {
         if (SystemInfo.isLinux && TexifySettings.getInstance().pdfViewer == PdfViewer.EVINCE) {


### PR DESCRIPTION
Fixes #1141

The problem was that the registering of the analyze menu action group was done using the deprecated plugin component, which made it load too early in the process hence cause the stateError.
Now it is registered using a service.

Maybe this allows TeXiFy to update without restart? Need to check if more needs to be done for that.

Docs:
https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_components.html
https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_services.html#sample-plugin
https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_extensions.html

To test this PR:
- Check that in the Analyze menu the LaTeX group is still there with the word count action.