### PR TITLE
Group indents

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -350,6 +350,11 @@
         <applicationConfigurable instance="nl.hannahsten.texifyidea.settings.TexifyConfigurable" groupId="language" id="TexifyConfigurable"/>
         <colorSettingsPage implementation="nl.hannahsten.texifyidea.highlighting.LatexColorSettingsPage"/>
         <colorSettingsPage implementation="nl.hannahsten.texifyidea.highlighting.BibtexColorSettingsPage"/>
+
+        <!-- Code style settings -->
+        <codeStyleSettingsProvider implementation="nl.hannahsten.texifyidea.settings.codestyle.LatexCodeStyleSettingsProvider"/>
+        <langCodeStyleSettingsProvider implementation="nl.hannahsten.texifyidea.settings.codestyle.LatexLanguageCodeStyleSettingsProvider"/>
+
         <!-- Project settings -->
         <projectService serviceInterface="nl.hannahsten.texifyidea.settings.TexifyProjectSettings" serviceImplementation="nl.hannahsten.texifyidea.settings.TexifyProjectSettings"/>
         <projectConfigurable instance="nl.hannahsten.texifyidea.settings.TexifyProjectConfigurable" groupId="TexifyConfigurable" id="TexifyProjectConfigurable" />

--- a/src/nl/hannahsten/texifyidea/formatting/LatexBlock.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexBlock.kt
@@ -4,7 +4,10 @@ import com.intellij.formatting.*
 import com.intellij.lang.ASTNode
 import com.intellij.psi.TokenType
 import com.intellij.psi.formatter.common.AbstractBlock
+import nl.hannahsten.texifyidea.lang.DefaultEnvironment
 import nl.hannahsten.texifyidea.psi.LatexTypes
+import nl.hannahsten.texifyidea.psi.impl.LatexEnvironmentImpl
+import nl.hannahsten.texifyidea.util.requiredParameters
 import java.util.*
 
 /**
@@ -44,8 +47,16 @@ class LatexBlock(
                 // somehow they are not placed inside environments.
                 || myNode.elementType === LatexTypes.COMMENT_TOKEN
                 && myNode.treeParent.elementType === LatexTypes.ENVIRONMENT) {
-            return Indent.getNormalIndent(true)
+
+            val environment = myNode.treeParent.psi.originalElement as LatexEnvironmentImpl
+            // Check if we are in a listings environment by checking the required
+            // parameter of the begin command.
+            return if (environment.beginCommand.requiredParameters().any { it.text.contains(DefaultEnvironment.LISTINGS.environmentName) }) {
+                Indent.getAbsoluteNoneIndent()
+            }
+            else Indent.getNormalIndent(true)
         }
+
         // Indent content of groups. Not relative to their parent, because that
         // would be relative to the open brace of the group instead of the
         // (usually) command.

--- a/src/nl/hannahsten/texifyidea/formatting/LatexBlock.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexBlock.kt
@@ -37,12 +37,20 @@ class LatexBlock(
     }
 
     override fun getIndent(): Indent? {
-        // Fix for leading comments inside an environment, because somehow they are not placed inside environments
         if (myNode.elementType === LatexTypes.ENVIRONMENT_CONTENT
+                // Fix for leading comments inside an environment, because
+                // somehow they are not placed inside environments.
                 || myNode.elementType === LatexTypes.COMMENT_TOKEN
                 && myNode.treeParent.elementType === LatexTypes.ENVIRONMENT) {
             return Indent.getNormalIndent(true)
         }
+        // Indent content of groups. Not relative to their parent, because that
+        // would be relative to the open brace of the group instead of the (usually) command.
+        if (myNode.elementType === LatexTypes.CONTENT
+                && myNode.treeParent.elementType === LatexTypes.GROUP) {
+            return Indent.getNormalIndent()
+        }
+
         // Display math
         return if ((myNode.elementType === LatexTypes.MATH_CONTENT || myNode.elementType === LatexTypes.COMMENT_TOKEN)
                 && myNode.treeParent.elementType === LatexTypes.DISPLAY_MATH) {

--- a/src/nl/hannahsten/texifyidea/formatting/LatexBlock.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexBlock.kt
@@ -14,7 +14,8 @@ class LatexBlock(
         node: ASTNode,
         wrap: Wrap?,
         alignment: Alignment?,
-        private val spacingBuilder: LatexSpacingBuilder
+        private val spacingBuilder: LatexSpacingBuilder,
+        private val wrappingStrategy: LatexWrappingStrategy
 ) : AbstractBlock(node, wrap, alignment) {
 
     override fun buildChildren(): List<Block> {
@@ -25,9 +26,10 @@ class LatexBlock(
             if (child.elementType !== TokenType.WHITE_SPACE) {
                 val block: Block = LatexBlock(
                         child,
-                        Wrap.createWrap(WrapType.NONE, false),
+                        wrappingStrategy.getWrap(child),
                         null,
-                        spacingBuilder
+                        spacingBuilder,
+                        wrappingStrategy
                 )
                 blocks.add(block)
             }
@@ -48,7 +50,7 @@ class LatexBlock(
         // would be relative to the open brace of the group instead of the
         // (usually) command.
         if (myNode.elementType === LatexTypes.CONTENT
-                && myNode.treeParent.elementType === LatexTypes.GROUP) {
+                && myNode.treeParent.elementType in setOf(LatexTypes.GROUP, LatexTypes.OPEN_GROUP)) {
             return Indent.getNormalIndent()
         }
 

--- a/src/nl/hannahsten/texifyidea/formatting/LatexBlock.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexBlock.kt
@@ -45,7 +45,8 @@ class LatexBlock(
             return Indent.getNormalIndent(true)
         }
         // Indent content of groups. Not relative to their parent, because that
-        // would be relative to the open brace of the group instead of the (usually) command.
+        // would be relative to the open brace of the group instead of the
+        // (usually) command.
         if (myNode.elementType === LatexTypes.CONTENT
                 && myNode.treeParent.elementType === LatexTypes.GROUP) {
             return Indent.getNormalIndent()

--- a/src/nl/hannahsten/texifyidea/formatting/LatexBlock.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexBlock.kt
@@ -14,7 +14,7 @@ class LatexBlock(
         node: ASTNode,
         wrap: Wrap?,
         alignment: Alignment?,
-        private val spacingBuilder: SpacingBuilder
+        private val spacingBuilder: LatexSpacingBuilder
 ) : AbstractBlock(node, wrap, alignment) {
 
     override fun buildChildren(): List<Block> {

--- a/src/nl/hannahsten/texifyidea/formatting/LatexFormattingModelBuilder.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexFormattingModelBuilder.kt
@@ -18,7 +18,8 @@ class LatexFormattingModelBuilder : FormattingModelBuilder {
                         element.node,
                         Wrap.createWrap(WrapType.NONE, false),
                         Alignment.createAlignment(),
-                        createSpacingBuilder(settings)
+                        createSpacingBuilder(settings),
+                        LatexWrappingStrategy(settings)
                 ),
                 settings
         )
@@ -26,19 +27,5 @@ class LatexFormattingModelBuilder : FormattingModelBuilder {
 
     override fun getRangeAffectingIndent(file: PsiFile, offset: Int, elementAtOffset: ASTNode): TextRange? {
         return null
-    }
-
-    companion object {
-        private fun createSpaceBuilder(settings: CodeStyleSettings): LatexSpacingBuilder {
-            val spacingBuilder = LatexSpacingBuilder(settings)
-            // Insert one space between two words.
-//            spacingBuilder.between(LatexTypes.NORMAL_TEXT_WORD, LatexTypes.NORMAL_TEXT_WORD)
-//                    .spaces(1)
-            // Put the content of an environment on its own lines, i.e. put a
-            // newline after a begin command and before an end command.
-//            spacingBuilder.around(LatexTypes.ENVIRONMENT_CONTENT)
-//                    .lineBreakInCode()
-            return spacingBuilder
-        }
     }
 }

--- a/src/nl/hannahsten/texifyidea/formatting/LatexFormattingModelBuilder.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexFormattingModelBuilder.kt
@@ -6,8 +6,6 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.codeStyle.CodeStyleSettings
-import nl.hannahsten.texifyidea.LatexLanguage
-import nl.hannahsten.texifyidea.psi.LatexTypes
 
 /**
  * @author Sten Wessel
@@ -20,7 +18,7 @@ class LatexFormattingModelBuilder : FormattingModelBuilder {
                         element.node,
                         Wrap.createWrap(WrapType.NONE, false),
                         Alignment.createAlignment(),
-                        createSpaceBuilder(settings)
+                        createSpacingBuilder(settings)
                 ),
                 settings
         )
@@ -31,15 +29,15 @@ class LatexFormattingModelBuilder : FormattingModelBuilder {
     }
 
     companion object {
-        private fun createSpaceBuilder(settings: CodeStyleSettings): SpacingBuilder {
-            val spacingBuilder = SpacingBuilder(settings, LatexLanguage.INSTANCE)
+        private fun createSpaceBuilder(settings: CodeStyleSettings): LatexSpacingBuilder {
+            val spacingBuilder = LatexSpacingBuilder(settings)
             // Insert one space between two words.
-            spacingBuilder.between(LatexTypes.NORMAL_TEXT_WORD, LatexTypes.NORMAL_TEXT_WORD)
-                    .spaces(1)
+//            spacingBuilder.between(LatexTypes.NORMAL_TEXT_WORD, LatexTypes.NORMAL_TEXT_WORD)
+//                    .spaces(1)
             // Put the content of an environment on its own lines, i.e. put a
             // newline after a begin command and before an end command.
-            spacingBuilder.around(LatexTypes.ENVIRONMENT_CONTENT)
-                    .lineBreakInCode()
+//            spacingBuilder.around(LatexTypes.ENVIRONMENT_CONTENT)
+//                    .lineBreakInCode()
             return spacingBuilder
         }
     }

--- a/src/nl/hannahsten/texifyidea/formatting/LatexFormattingModelBuilder.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexFormattingModelBuilder.kt
@@ -33,8 +33,11 @@ class LatexFormattingModelBuilder : FormattingModelBuilder {
     companion object {
         private fun createSpaceBuilder(settings: CodeStyleSettings): SpacingBuilder {
             val spacingBuilder = SpacingBuilder(settings, LatexLanguage.INSTANCE)
+            // Insert one space between two words.
             spacingBuilder.between(LatexTypes.NORMAL_TEXT_WORD, LatexTypes.NORMAL_TEXT_WORD)
                     .spaces(1)
+            // Put the content of an environment on its own lines, i.e. put a
+            // newline after a begin command and before an end command.
             spacingBuilder.around(LatexTypes.ENVIRONMENT_CONTENT)
                     .lineBreakInCode()
             return spacingBuilder

--- a/src/nl/hannahsten/texifyidea/formatting/LatexSpacingBuilder.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexSpacingBuilder.kt
@@ -1,0 +1,149 @@
+package nl.hannahsten.texifyidea.formatting
+
+import com.intellij.formatting.ASTBlock
+import com.intellij.formatting.Block
+import com.intellij.formatting.Spacing
+import com.intellij.formatting.SpacingBuilder
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings
+import com.intellij.psi.tree.IElementType
+import com.intellij.psi.tree.TokenSet
+
+/**
+ * Based on KotlinSpacingBuilder in the Kotlin plugin.
+ *
+ * @author Sten Wessel
+ */
+class LatexSpacingBuilder(private val commonSettings: CommonCodeStyleSettings) {
+
+    private val builders = ArrayList<Builder>()
+
+    /**
+     * Generic spacing builder.
+     */
+    private interface Builder {
+        fun getSpacing(parent: ASTBlock, left: ASTBlock, right: ASTBlock): Spacing?
+    }
+
+    /**
+     * Basic spacing builder that is based on the implementation of [SpacingBuilder].
+     */
+    inner class BasicSpacingBuilder : SpacingBuilder(commonSettings), Builder {
+        override fun getSpacing(parent: ASTBlock, left: ASTBlock, right: ASTBlock): Spacing? {
+            return super.getSpacing(parent, left, right)
+        }
+    }
+
+    /**
+     * Represents a rule condition.
+     *
+     * The rule is only matched when the condition holds.
+     */
+    private data class Condition(
+            val parent: IElementType? = null,
+            val left: IElementType? = null,
+            val right: IElementType? = null,
+            val parentSet: TokenSet? = null,
+            val leftSet: TokenSet? = null,
+            val rightSet: TokenSet? = null
+    ) : (ASTBlock, ASTBlock, ASTBlock) -> Boolean {
+
+        override fun invoke(p: ASTBlock, l: ASTBlock, r: ASTBlock): Boolean =
+                (parent == null || p.node!!.elementType == parent) &&
+                        (left == null || l.node!!.elementType == left) &&
+                        (right == null || r.node!!.elementType == right) &&
+                        (parentSet == null || p.node!!.elementType in parentSet) &&
+                        (leftSet == null || l.node!!.elementType in leftSet) &&
+                        (rightSet == null || r.node!!.elementType in rightSet)
+    }
+
+    /**
+     * Rule that upon matching the conditions returns the spacing action.
+     */
+    private data class Rule(
+            val conditions: List<Condition>,
+            val action: (ASTBlock, ASTBlock, ASTBlock) -> Spacing?
+    ) : (ASTBlock, ASTBlock, ASTBlock) -> Spacing? {
+
+        override fun invoke(p: ASTBlock, l: ASTBlock, r: ASTBlock): Spacing? =
+                if (conditions.all { it(p, l, r) }) action(p, l, r) else null
+    }
+
+    /**
+     * Build more advanced rules with [Rule] and [Condition] above.
+     */
+    inner class CustomSpacingBuilder : Builder {
+        private val rules = ArrayList<Rule>()
+        private var conditions = ArrayList<Condition>()
+
+        override fun getSpacing(parent: ASTBlock, left: ASTBlock, right: ASTBlock): Spacing? {
+            for (rule in rules) {
+                return rule(parent, left, right) ?: continue
+            }
+
+            return null
+        }
+
+        fun inPosition(parent: IElementType? = null,
+                       left: IElementType? = null,
+                       right: IElementType? = null,
+                       parentSet: TokenSet? = null,
+                       leftSet: TokenSet? = null,
+                       rightSet: TokenSet? = null) : CustomSpacingBuilder {
+            conditions.add(Condition(parent, left, right, parentSet, leftSet, rightSet))
+            return this
+        }
+
+        fun spacing(spacing: Spacing) {
+            newRule { _, _, _ -> spacing }
+        }
+
+        fun customRule(block: (parent: ASTBlock, left: ASTBlock, right: ASTBlock) -> Spacing?) {
+            newRule(block)
+        }
+
+        private fun newRule(rule: (ASTBlock, ASTBlock, ASTBlock) -> Spacing?) {
+            val savedConditions = ArrayList(conditions)
+            rules.add(Rule(savedConditions, rule))
+            conditions.clear()
+        }
+    }
+
+    /**
+     * Get the spacing from the composite builders.
+     */
+    fun getSpacing(parent: Block, child1: Block?, child2: Block): Spacing? {
+        if (parent !is ASTBlock || child1 !is ASTBlock || child2 !is ASTBlock) {
+            return null
+        }
+
+        for (builder in builders) {
+            return builder.getSpacing(parent, child1, child2) ?: continue
+        }
+
+        return null
+    }
+
+    /**
+     * Rules for the basic spacing builder implementation.
+     */
+    fun simple(init: BasicSpacingBuilder.() -> Unit) {
+        val builder = BasicSpacingBuilder()
+        builder.init()
+        builders.add(builder)
+    }
+
+    fun custom(init: CustomSpacingBuilder.() -> Unit) {
+        val builder = CustomSpacingBuilder()
+        builder.init()
+        builders.add(builder)
+    }
+}
+
+/**
+ * Build a [LatexSpacingBuilder] with a set of rules.
+ */
+fun rules(latexSettings: CommonCodeStyleSettings, init: LatexSpacingBuilder.() -> Unit): LatexSpacingBuilder {
+    val builder = LatexSpacingBuilder(latexSettings)
+    builder.init()
+    return builder
+}

--- a/src/nl/hannahsten/texifyidea/formatting/LatexSpacingRules.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexSpacingRules.kt
@@ -1,0 +1,36 @@
+package nl.hannahsten.texifyidea.formatting
+
+import com.intellij.formatting.Spacing
+import com.intellij.psi.codeStyle.CodeStyleSettings
+import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.psi.LatexTypes.*
+import nl.hannahsten.texifyidea.settings.codestyle.LatexCodeStyleSettings
+
+/**
+ *
+ * @author Sten Wessel
+ */
+fun createSpacingBuilder(settings: CodeStyleSettings): LatexSpacingBuilder {
+    val latexSettings = settings.getCustomSettings(LatexCodeStyleSettings::class.java)!!
+    val latexCommonSettings = settings.getCommonSettings(LatexLanguage.INSTANCE)!!
+
+    return rules(latexCommonSettings) {
+
+        simple {
+            between(NORMAL_TEXT_WORD, NORMAL_TEXT_WORD).spaces(1)
+            around(ENVIRONMENT_CONTENT).lineBreakInCode()
+        }
+
+        custom {
+            fun commentSpacing(minSpaces: Int): Spacing {
+                // TODO: blank lines settings
+                if (latexCommonSettings.KEEP_FIRST_COLUMN_COMMENT) {
+                    return Spacing.createKeepingFirstColumnSpacing(minSpaces, Int.MAX_VALUE, latexCommonSettings.KEEP_LINE_BREAKS, latexCommonSettings.KEEP_BLANK_LINES_IN_CODE)
+                }
+                return Spacing.createSpacing(minSpaces, Int.MAX_VALUE, 0, latexCommonSettings.KEEP_LINE_BREAKS, latexCommonSettings.KEEP_BLANK_LINES_IN_CODE)
+            }
+
+            inPosition(right = COMMENT_TOKEN).spacing(commentSpacing(0))
+        }
+    }
+}

--- a/src/nl/hannahsten/texifyidea/formatting/LatexSpacingRules.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexSpacingRules.kt
@@ -23,7 +23,6 @@ fun createSpacingBuilder(settings: CodeStyleSettings): LatexSpacingBuilder {
 
         custom {
             fun commentSpacing(minSpaces: Int): Spacing {
-                // TODO: blank lines settings
                 if (latexCommonSettings.KEEP_FIRST_COLUMN_COMMENT) {
                     return Spacing.createKeepingFirstColumnSpacing(minSpaces, Int.MAX_VALUE, latexCommonSettings.KEEP_LINE_BREAKS, latexCommonSettings.KEEP_BLANK_LINES_IN_CODE)
                 }

--- a/src/nl/hannahsten/texifyidea/formatting/LatexSpacingRules.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexSpacingRules.kt
@@ -11,8 +11,8 @@ import nl.hannahsten.texifyidea.settings.codestyle.LatexCodeStyleSettings
  * @author Sten Wessel
  */
 fun createSpacingBuilder(settings: CodeStyleSettings): LatexSpacingBuilder {
-    val latexSettings = settings.getCustomSettings(LatexCodeStyleSettings::class.java)!!
-    val latexCommonSettings = settings.getCommonSettings(LatexLanguage.INSTANCE)!!
+    val latexSettings = settings.getCustomSettings(LatexCodeStyleSettings::class.java)
+    val latexCommonSettings = settings.getCommonSettings(LatexLanguage.INSTANCE)
 
     return rules(latexCommonSettings) {
 

--- a/src/nl/hannahsten/texifyidea/formatting/LatexWrappingStrategy.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexWrappingStrategy.kt
@@ -1,0 +1,20 @@
+package nl.hannahsten.texifyidea.formatting
+
+import com.intellij.formatting.Wrap
+import com.intellij.formatting.WrapType
+import com.intellij.lang.ASTNode
+import com.intellij.psi.codeStyle.CodeStyleSettings
+import nl.hannahsten.texifyidea.LatexLanguage
+
+/**
+ *
+ * @author Sten Wessel
+ */
+class LatexWrappingStrategy(settings: CodeStyleSettings) {
+
+    private val commonSettings = settings.getCommonSettings(LatexLanguage.INSTANCE)
+
+    fun getWrap(element: ASTNode): Wrap? {
+        return Wrap.createWrap(WrapType.NONE, false)
+    }
+}

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexCollapseCiteInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexCollapseCiteInspection.kt
@@ -30,7 +30,7 @@ open class LatexCollapseCiteInspection : TexifyInspectionBase() {
 
     override val outerSuppressionScopes = EnumSet.of(MagicCommentScope.COMMAND)!!
 
-    override fun getDisplayName() = "Collapce cite commands"
+    override fun getDisplayName() = "Collapse cite commands"
 
     override fun inspectFile(file: PsiFile, manager: InspectionManager, isOntheFly: Boolean): MutableList<ProblemDescriptor> {
         val descriptors = descriptorList()

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexLabelConventionInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexLabelConventionInspection.kt
@@ -105,8 +105,6 @@ open class LatexLabelConventionInspection : TexifyInspectionBase() {
                 continue
             }
         }
-
-        // TODO: make this work. but it's a bit dodgy..
     }
 
     /**

--- a/src/nl/hannahsten/texifyidea/lang/DefaultEnvironment.kt
+++ b/src/nl/hannahsten/texifyidea/lang/DefaultEnvironment.kt
@@ -83,7 +83,10 @@ enum class DefaultEnvironment(
     COMMENT(environmentName = "comment", context = Context.COMMENT, dependency = Package.COMMENT),
 
     // lualatex
-    LUACODE(environmentName = "luacode", dependency = Package.LUACODE);
+    LUACODE(environmentName = "luacode", dependency = Package.LUACODE),
+
+    // listings
+    LISTINGS(environmentName = "lstlisting", dependency = Package.LISTINGS);
 
     companion object {
 

--- a/src/nl/hannahsten/texifyidea/lang/Package.kt
+++ b/src/nl/hannahsten/texifyidea/lang/Package.kt
@@ -25,6 +25,7 @@ open class Package @JvmOverloads constructor(
         @JvmField val IMAKEIDX = Package("imakeidx")
         @JvmField val INPUTENC = Package("inputenc")
         @JvmField val LATEXSYMB = Package("latexsymb")
+        @JvmField val LISTINGS = Package("listings")
         @JvmField val LUACODE = Package("luacode")
         @JvmField val MATHABX = Package("mathabx")
         @JvmField val MATHTOOLS = Package("mathtools")

--- a/src/nl/hannahsten/texifyidea/settings/codestyle/LatexCodeStyleSettings.kt
+++ b/src/nl/hannahsten/texifyidea/settings/codestyle/LatexCodeStyleSettings.kt
@@ -1,0 +1,14 @@
+package nl.hannahsten.texifyidea.settings.codestyle
+
+import com.intellij.psi.codeStyle.CodeStyleSettings
+import com.intellij.psi.codeStyle.CustomCodeStyleSettings
+import nl.hannahsten.texifyidea.LatexLanguage
+
+/**
+ *
+ * @author Sten Wessel
+ */
+class LatexCodeStyleSettings(container: CodeStyleSettings) : CustomCodeStyleSettings(LatexLanguage.INSTANCE.id, container) {
+
+
+}

--- a/src/nl/hannahsten/texifyidea/settings/codestyle/LatexCodeStyleSettingsProvider.kt
+++ b/src/nl/hannahsten/texifyidea/settings/codestyle/LatexCodeStyleSettingsProvider.kt
@@ -1,0 +1,45 @@
+package nl.hannahsten.texifyidea.settings.codestyle
+
+import com.intellij.application.options.CodeStyleAbstractConfigurable
+import com.intellij.application.options.CodeStyleAbstractPanel
+import com.intellij.application.options.TabbedLanguageCodeStylePanel
+import com.intellij.openapi.options.Configurable
+import com.intellij.psi.codeStyle.CodeStyleSettings
+import com.intellij.psi.codeStyle.CodeStyleSettingsProvider
+import nl.hannahsten.texifyidea.LatexLanguage
+
+/**
+ *
+ * @author Sten Wessel
+ */
+class LatexCodeStyleSettingsProvider : CodeStyleSettingsProvider() {
+
+    override fun createCustomSettings(settings: CodeStyleSettings?) = settings?.let { LatexCodeStyleSettings(it) }
+
+    override fun getConfigurableDisplayName() = LatexLanguage.INSTANCE.displayName
+
+    override fun createSettingsPage(settings: CodeStyleSettings, originalSettings: CodeStyleSettings?): Configurable {
+        return object : CodeStyleAbstractConfigurable(settings, originalSettings, configurableDisplayName) {
+
+            override fun createPanel(settings: CodeStyleSettings?): CodeStyleAbstractPanel {
+                val language = LatexLanguage.INSTANCE
+
+                return object : TabbedLanguageCodeStylePanel(language, currentSettings, settings) {
+
+                    override fun initTabs(settings: CodeStyleSettings?) {
+                        addIndentOptionsTab(settings)
+                        addWrappingAndBracesTab(settings)
+                    }
+
+                    override fun addWrappingAndBracesTab(settings: CodeStyleSettings?) {
+                        addTab(object : MyWrappingAndBracesPanel(settings) {
+                            // Remove "Braces" from tab title
+                            override fun getTabTitle() = "Wrapping"
+                        })
+                    }
+                }
+            }
+
+        }
+    }
+}

--- a/src/nl/hannahsten/texifyidea/settings/codestyle/LatexLanguageCodeStyleSettingsProvider.kt
+++ b/src/nl/hannahsten/texifyidea/settings/codestyle/LatexLanguageCodeStyleSettingsProvider.kt
@@ -1,0 +1,60 @@
+package nl.hannahsten.texifyidea.settings.codestyle
+
+import com.intellij.application.options.SmartIndentOptionsEditor
+import com.intellij.psi.codeStyle.CodeStyleSettingsCustomizable
+import com.intellij.psi.codeStyle.CodeStyleSettingsCustomizable.WrappingOrBraceOption.*
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings
+import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider
+import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider.SettingsType.*
+import com.intellij.psi.codeStyle.extractor.values.Value.VAR_KIND.RIGHT_MARGIN
+import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.util.Magic
+import nl.hannahsten.texifyidea.util.removeHtmlTags
+
+/**
+ *
+ * @author Sten Wessel
+ */
+class LatexLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider() {
+
+    companion object {
+
+        private val demoText = Magic.General.demoText.removeHtmlTags()
+    }
+
+    override fun getLanguage() = LatexLanguage.INSTANCE!!
+
+    override fun getCodeSample(settingsType: SettingsType) = demoText
+
+    override fun getIndentOptionsEditor() = SmartIndentOptionsEditor()
+
+    override fun getDefaultCommonSettings() = CommonCodeStyleSettings(language).also { it.initIndentOptions() }
+
+    override fun customizeSettings(consumer: CodeStyleSettingsCustomizable, settingsType: SettingsType) {
+        when (settingsType) {
+
+            SPACING_SETTINGS -> customizeSpacingSettings(consumer)
+            WRAPPING_AND_BRACES_SETTINGS -> customizeWrappingAndBracesSettings(consumer)
+            BLANK_LINES_SETTINGS -> customizeBlankLinesSettings(consumer)
+
+            else -> return
+        }
+    }
+
+    private fun customizeSpacingSettings(consumer: CodeStyleSettingsCustomizable) {
+        // TODO: add remove multiple spaces option
+    }
+
+    private fun customizeWrappingAndBracesSettings(consumer: CodeStyleSettingsCustomizable) {
+        consumer.showStandardOptions(*arrayOf(
+                RIGHT_MARGIN,
+                WRAP_ON_TYPING,
+                WRAP_LONG_LINES,
+                KEEP_FIRST_COLUMN_COMMENT
+        ).map { it.toString() }.toTypedArray())
+    }
+
+    private fun customizeBlankLinesSettings(consumer: CodeStyleSettingsCustomizable) {
+        // TODO: add custom settings
+    }
+}

--- a/src/nl/hannahsten/texifyidea/settings/codestyle/LatexLanguageCodeStyleSettingsProvider.kt
+++ b/src/nl/hannahsten/texifyidea/settings/codestyle/LatexLanguageCodeStyleSettingsProvider.kt
@@ -5,7 +5,7 @@ import com.intellij.psi.codeStyle.CodeStyleSettingsCustomizable
 import com.intellij.psi.codeStyle.CodeStyleSettingsCustomizable.WrappingOrBraceOption.*
 import com.intellij.psi.codeStyle.CommonCodeStyleSettings
 import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider
-import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider.SettingsType.*
+import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider.SettingsType.WRAPPING_AND_BRACES_SETTINGS
 import com.intellij.psi.codeStyle.extractor.values.Value.VAR_KIND.RIGHT_MARGIN
 import nl.hannahsten.texifyidea.LatexLanguage
 import nl.hannahsten.texifyidea.util.Magic
@@ -33,16 +33,10 @@ class LatexLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider
     override fun customizeSettings(consumer: CodeStyleSettingsCustomizable, settingsType: SettingsType) {
         when (settingsType) {
 
-            SPACING_SETTINGS -> customizeSpacingSettings(consumer)
             WRAPPING_AND_BRACES_SETTINGS -> customizeWrappingAndBracesSettings(consumer)
-            BLANK_LINES_SETTINGS -> customizeBlankLinesSettings(consumer)
 
             else -> return
         }
-    }
-
-    private fun customizeSpacingSettings(consumer: CodeStyleSettingsCustomizable) {
-        // TODO: add remove multiple spaces option
     }
 
     private fun customizeWrappingAndBracesSettings(consumer: CodeStyleSettingsCustomizable) {
@@ -54,7 +48,4 @@ class LatexLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider
         ).map { it.toString() }.toTypedArray())
     }
 
-    private fun customizeBlankLinesSettings(consumer: CodeStyleSettingsCustomizable) {
-        // TODO: add custom settings
-    }
 }

--- a/src/nl/hannahsten/texifyidea/util/Magic.kt
+++ b/src/nl/hannahsten/texifyidea/util/Magic.kt
@@ -6,6 +6,7 @@ import nl.hannahsten.texifyidea.TexifyIcons
 import nl.hannahsten.texifyidea.file.*
 import nl.hannahsten.texifyidea.inspections.latex.LatexLineBreakInspection
 import nl.hannahsten.texifyidea.lang.Package
+import org.intellij.lang.annotations.Language
 import java.awt.Color
 import java.util.regex.Pattern
 
@@ -28,6 +29,71 @@ object Magic {
         @JvmField val emptyStringArray = arrayOfNulls<String>(0)
         @JvmField val emptyPsiElementArray = arrayOfNulls<PsiElement>(0)
         @JvmField val noQuickFix: LocalQuickFix? = null
+
+        @Language("Latex")
+        @JvmField val demoText = """
+                |%
+                |%  An amazing example for LaTeX.
+                |%
+                |\documentclass[<optionalParam>12pt,a4paper</optionalParam>]{article}
+                |
+                |% Package imports.
+                |\usepackage{amsmath}
+                |\usepackage{comment}
+                |
+                |% Start document.
+                |\begin{document}
+                |
+                |    % Make title.
+                |    \title{A Very Simple \LaTeXe{} Template}
+                |    \author{
+                |            Henk-Jan\\Department of YUROP\\University of Cheese\\
+                |            Windmill City, 2198 AL, \underline{Tulipa}
+                |    }
+                |    \date{\today}
+                |    \maketitle
+                |
+                |    % Start writing amazing stuff now.
+                |    \begin{abstract}
+                |        This is the paper's abstract \ldots.
+                |    \end{abstract}
+                |
+                |    <comment>\begin{comment}
+                |        Yes, even comment environments get highlighted.
+                |    \end{comment}</comment>
+                |
+                |    \section{Introduction}\label{sec:introduction}
+                |    This is time for all good men to come to the aid of their party!
+                |
+                |    \paragraph{Mathematics}
+                |    Please take a look at the value of <inlineMath>${'$'}x <inlineCommand>\times</inlineCommand>
+                |    <inlineCommand>\frac</inlineCommand>{5}{<inlineCommand>\sqrt</inlineCommand>{3}}${'$'}</inlineMath> in the following equation:
+                |    <displayMath>\[
+                |       x <displayCommand>\times</displayCommand> <displayCommand>\frac</displayCommand>{5}{<displayCommand>\sqrt</displayCommand>{3}} = y <displayCommand>\cdot</displayCommand> <displayCommand>\max\left</displayCommand>{ 4, <displayCommand>\alpha</displayCommand>, 6 <displayCommand>\right</displayCommand>} +
+                |           <displayCommand>\sqrt</displayCommand>[<optionalParam>1234</optionalParam>]{5678}.
+                |    \]</displayMath>
+                |
+                |    \section{More work}\label{sec:moreWork}
+                |    A much longer \LaTeXe{} example was written by Henk-Jan~\cite{Gil:02}. But
+                |    we can also just do some more epic plugin showoffy stuff like
+                |    <displayMath>\begin{align}
+                |       <displayCommand>\text</displayCommand>{Stuff here is also highlighted, and also }
+                |       <displayCommand>\sum</displayCommand>_{i=0}^n <displayCommand>\left</displayCommand>( i <displayCommand>\right</displayCommand>)
+                |    \end{align}</displayMath>
+                |
+                |    \section{Results}\label{sec:results}
+                |    In this section we describe the results. So basically <inlineMath>${'$'}x${'$'}</inlineMath> but maybe
+                |    also <inlineMath>${'$'}<inlineCommand>\hat</inlineCommand>{x}^{2y}${'$'}</inlineMath>.
+                |
+                |    \section{Conclusions}\label{sec:conclusions}
+                |    We worked hard, and achieved very little. Or did we?
+                |
+                |    % Another extremely descriptive comment.
+                |    \bibliographystyle{abbrv}
+                |    \bibliography{main}
+                |
+                |\end{document}
+        """.trimMargin()
     }
 
     /**
@@ -394,6 +460,11 @@ object Magic {
          * Checks if the string is `text`, two newlines, `text`.
          */
         @JvmField val containsMultipleNewlines = RegexPattern.compile("[^\\n]*\\n\\n+[^\\n]*")!!
+
+        /**
+         * Matches HTML tags of the form `<tag>`, `<tag/>` and `</tag>`.
+         */
+        @JvmField val htmlTag = RegexPattern.compile("""<.*?/?>""")!!
 
         /**
          * Matches a LaTeX command that is the start of an \if-\fi structure.

--- a/src/nl/hannahsten/texifyidea/util/Strings.kt
+++ b/src/nl/hannahsten/texifyidea/util/Strings.kt
@@ -169,3 +169,12 @@ fun String.formatAsLabel(): String {
  * Split the given string on whitespace.
  */
 fun String.splitWhitespace() = split(Regex("\\s+"))
+
+/**
+ * Removes HTML tags from the string.
+ *
+ * @return The string with HTML tags removed.
+ *
+ * @see [Magic.Pattern.htmlTag]
+ */
+fun String.removeHtmlTags() = this.replace(Magic.Pattern.htmlTag.toRegex(), "")


### PR DESCRIPTION
### Reintroduces the code style settings from [`code-style-settings`](https://github.com/Hannah-Sten/TeXiFy-IDEA/tree/code-style-settings).
Defines code style settings and provides the standard IJ settings with respect to indent size and text wrapping. In particular:
- Select the `Comment at first column` option in the `Wrapping` tab to let the formatter ignore the indents of comments.
- Set `Wrap on typing` to `yes`, and select the `Ensure right margin is not exceeded` to let the formatter hard break text that exceeds the right margin guide (#250)

### Changes to the formatter

#### Indent groups (#567)
Use <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>L</kbd> on 
```latex
\tikzset{
mystyle/.style={
draw,
circle,
label={[fill=yellow]0:#1}
}
}
```

to get

```latex
\tikzset{
    mystyle/.style={
        draw,
        circle,
        label={[fill=yellow]0:#1}
    }
}
```

Unfortunately, when typing `\tikzset{}` and hitting enter in the braces, the cursor goes to the beginning of the line (without indent). I haven't found a way to fix this, @stenwessel any suggestions?

#### Remove the indents in `lstlisting` environments
Indents `lstlisting` environments to the leftmost column, i.e.

```latex
\begin{document}
    hi
    \begin{lstlisting}[language=Python]
        def test():
            print("test")
    \end{lstlisting}
\end{document}
```

becomes

```latex
\begin{document}
    hi
    \begin{lstlisting}[language=Python]
def test():
    print("test")
    \end{lstlisting}
\end{document}
```
