### PR TITLE
Add support for sync using Skim on OSX

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -54,7 +54,7 @@
             <li>Formatter for LaTeX and BibTeX</li>
             <li>Structure view for LaTeX and BibTeX with filters</li>
             <li>Code folding for imports, sections, and environments</li>
-            <li>SumatraPDF (Windows), Evince (Linux) and Okular (Linux) support with forward and backward search</li>
+            <li>SumatraPDF (Windows), Evince (Linux), Okular (Linux) and Skim (MacOS) support with forward and backward search</li>
             <li>Smart quotes</li>
             <li>Unicode math preview</li>
             <li>Equation and TikZ picture preview</li>
@@ -306,6 +306,21 @@
             <action class="nl.hannahsten.texifyidea.action.okular.ConfigureInverseSearchAction" id="texify.okular.ConfigureInverseSearch"
                     text="Configure Inverse Search" description="Instructions for configuring inverse search."/>
         </group>
+
+        <!-- Skim -->
+        <group id="texify.LatexMenu.Skim" class="nl.hannahsten.texifyidea.action.group.SkimActionGroup" text="Skim"
+               description="Interact with Skim." popup="true">
+            <add-to-group group-id="texify.LatexMenuTools" anchor="first"/>
+
+            <action class="nl.hannahsten.texifyidea.action.skim.ForwardSearchAction" id="texify.skim.ForwardSearch"
+                    text="Go to _Line in PDF" description="Find the content on cursor in the PDF.">
+                <keyboard-shortcut first-keystroke="control alt shift PERIOD" keymap="$default"/>
+            </action>
+
+            <action class="nl.hannahsten.texifyidea.action.skim.ConfigureInverseSearchAction" id="texify.skim.ConfigureInverseSearch"
+                    text="Configure Inverse Search" description="Instructions for configuring inverse search."/>
+        </group>
+
     </actions>
 
     <!-- Hooks for plugin functionality -->

--- a/src/nl/hannahsten/texifyidea/action/group/SkimActionGroup.kt
+++ b/src/nl/hannahsten/texifyidea/action/group/SkimActionGroup.kt
@@ -1,0 +1,12 @@
+package nl.hannahsten.texifyidea.action.group
+
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import nl.hannahsten.texifyidea.run.linuxpdfviewer.PdfViewer
+
+class SkimActionGroup : DefaultActionGroup() {
+
+    override fun canBePerformed(context: DataContext) = PdfViewer.SKIM.isAvailable()
+
+    override fun hideIfNoVisibleChildren(): Boolean = true
+}

--- a/src/nl/hannahsten/texifyidea/action/skim/ConfigureInverseSearchAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/skim/ConfigureInverseSearchAction.kt
@@ -1,0 +1,23 @@
+package nl.hannahsten.texifyidea.action.skim
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import nl.hannahsten.texifyidea.run.linuxpdfviewer.PdfViewer
+import nl.hannahsten.texifyidea.settings.TexifySettings
+import nl.hannahsten.texifyidea.ui.SkimConfigureInverseSearchDialog
+
+/**
+ * @author Stephan Sundermann
+ */
+class ConfigureInverseSearchAction : AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        SkimConfigureInverseSearchDialog()
+    }
+
+    /**
+     * Hide this option when Okular is not available.
+     */
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabledAndVisible = TexifySettings.getInstance().pdfViewer == PdfViewer.SKIM
+    }
+}

--- a/src/nl/hannahsten/texifyidea/action/skim/ConfigureInverseSearchAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/skim/ConfigureInverseSearchAction.kt
@@ -15,7 +15,7 @@ class ConfigureInverseSearchAction : AnAction() {
     }
 
     /**
-     * Hide this option when Okular is not available.
+     * Hide this option when Skim is not available.
      */
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabledAndVisible = TexifySettings.getInstance().pdfViewer == PdfViewer.SKIM

--- a/src/nl/hannahsten/texifyidea/action/skim/ForwardSearchAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/skim/ForwardSearchAction.kt
@@ -20,7 +20,7 @@ open class ForwardSearchAction : EditorAction(
         "_ForwardSearch",
         TexifyIcons.RIGHT
 ) {
-    val skim = PdfViewer.SKIM
+    private val skim = PdfViewer.SKIM
 
     override fun actionPerformed(file: VirtualFile, project: Project, textEditor: TextEditor) {
         if (!skim.isAvailable()) {

--- a/src/nl/hannahsten/texifyidea/action/skim/ForwardSearchAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/skim/ForwardSearchAction.kt
@@ -1,0 +1,39 @@
+package nl.hannahsten.texifyidea.action.skim
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.fileEditor.TextEditor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import nl.hannahsten.texifyidea.TexifyIcons
+import nl.hannahsten.texifyidea.action.EditorAction
+import nl.hannahsten.texifyidea.run.linuxpdfviewer.PdfViewer
+import nl.hannahsten.texifyidea.settings.TexifySettings
+
+/**
+ * Starts a forward search action in Skim.
+ *
+ * Note: this is only available on MacOS.
+ *
+ * @author Stephan Sundermann
+ */
+open class ForwardSearchAction : EditorAction(
+        "_ForwardSearch",
+        TexifyIcons.RIGHT
+) {
+    val skim = PdfViewer.SKIM
+
+    override fun actionPerformed(file: VirtualFile, project: Project, textEditor: TextEditor) {
+        if (!skim.isAvailable()) {
+            return
+        }
+
+        val document = textEditor.editor.document
+        val line = document.getLineNumber(textEditor.editor.caretModel.offset) + 1
+
+        skim.conversation!!.forwardSearch(null, file.path, line, project, focusAllowed = true)
+    }
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabledAndVisible = TexifySettings.getInstance().pdfViewer == skim
+    }
+}

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexCommandLineState.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexCommandLineState.kt
@@ -161,7 +161,7 @@ open class LatexCommandLineState(environment: ExecutionEnvironment, private val 
             // Open Sumatra after compilation & execute inverse search.
             handler.addProcessListener(SumatraForwardSearchListener(runConfig, environment))
         }
-        else if (TexifySettings.getInstance().pdfViewer in listOf(PdfViewer.EVINCE, PdfViewer.OKULAR)) {
+        else if (TexifySettings.getInstance().pdfViewer in listOf(PdfViewer.EVINCE, PdfViewer.OKULAR, PdfViewer.SKIM)) {
             ViewerForwardSearch(TexifySettings.getInstance().pdfViewer).execute(handler, runConfig, environment, focusAllowed)
         }
         else if (SystemInfo.isMac) {

--- a/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/PdfViewer.kt
+++ b/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/PdfViewer.kt
@@ -3,6 +3,7 @@ package nl.hannahsten.texifyidea.run.linuxpdfviewer
 import com.intellij.openapi.util.SystemInfo
 import nl.hannahsten.texifyidea.run.linuxpdfviewer.evince.EvinceConversation
 import nl.hannahsten.texifyidea.run.linuxpdfviewer.okular.OkularConversation
+import nl.hannahsten.texifyidea.run.linuxpdfviewer.skim.SkimConversation
 import nl.hannahsten.texifyidea.run.sumatra.isSumatraAvailable
 
 /**
@@ -16,6 +17,7 @@ enum class PdfViewer(private val viewerCommand: String,
                      val conversation: ViewerConversation?) {
     EVINCE("evince", "Evince", EvinceConversation),
     OKULAR("okular", "Okular", OkularConversation),
+    SKIM("skim", "Skim", SkimConversation),
     SUMATRA("sumatra", "Sumatra", null), // Dummy options to support Windows and Mac.
     OTHER("other", "Custom PDF viewer", null);
 
@@ -35,6 +37,12 @@ enum class PdfViewer(private val viewerCommand: String,
             // Find out whether the pdf viewer is installed and in PATH, otherwise we can't use it.
             val output = "which ${this.viewerCommand}".runCommand()
             output?.contains("/${this.viewerCommand}") ?: false
+        }
+        else if (SystemInfo.isMac) {
+            // Check if Skim is installed in applications, otherwise we can't use it.
+            // Open -Ra returns an error message if application was not found, else empty string
+            val output = "open -Ra ${this.viewerCommand}".runCommand()
+            output?.isEmpty() ?: false
         }
         else {
             false

--- a/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/PdfViewer.kt
+++ b/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/PdfViewer.kt
@@ -18,7 +18,7 @@ enum class PdfViewer(private val viewerCommand: String,
     EVINCE("evince", "Evince", EvinceConversation),
     OKULAR("okular", "Okular", OkularConversation),
     SKIM("skim", "Skim", SkimConversation),
-    SUMATRA("sumatra", "Sumatra", null), // Dummy options to support Windows and Mac.
+    SUMATRA("sumatra", "Sumatra", null), // Dummy options to support Windows
     OTHER("other", "Custom PDF viewer", null);
 
     /**

--- a/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/ViewerConversation.kt
+++ b/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/ViewerConversation.kt
@@ -23,7 +23,7 @@ fun String.runCommand(): String? {
 
         // Timeout value
         proc.waitFor(10, TimeUnit.SECONDS)
-        proc.inputStream.bufferedReader().readText()
+        proc.inputStream.bufferedReader().readText() + proc.errorStream.bufferedReader().readText()
     } catch (e: IOException) {
         e.printStackTrace()
         null

--- a/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/skim/SkimConversation.kt
+++ b/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/skim/SkimConversation.kt
@@ -1,0 +1,40 @@
+package nl.hannahsten.texifyidea.run.linuxpdfviewer.skim
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.project.Project
+import nl.hannahsten.texifyidea.run.linuxpdfviewer.ViewerConversation
+
+/**
+ * Execute Skim commands.
+ *
+ * @author Stephan Sundermann
+ */
+object SkimConversation : ViewerConversation() {
+    private var pdfFilePath: String? = null
+
+    /**
+     * Execute a forward search, opens the pdf file in Skim with the line that corresponds to the cursor roughly in the center.
+     *
+     * @param pdfPath Full path of the pdf.
+     * @param sourceFilePath Full path of the tex file.
+     * @param line Line number in the source file to navigate to in the pdf.
+     */
+    override fun forwardSearch(pdfPath: String?, sourceFilePath: String, line: Int, project: Project, focusAllowed: Boolean) {
+
+        val backgroundParameter = if (focusAllowed) "" else "-g"
+
+        if (pdfPath != null) {
+            pdfFilePath = pdfPath
+        }
+
+        if (pdfFilePath != null) {
+            // This okular command opens the pdf file using the destination coming from the line in the tex file.
+            val command = "/Applications/Skim.app/Contents/SharedSupport/displayline $backgroundParameter -r $line '$pdfFilePath' '$sourceFilePath'"
+            Runtime.getRuntime().exec(arrayOf("bash", "-c", command))
+        }
+        else {
+            Notification("SkimConversation", "Could not execute forward search", "Please make sure you have compiled the document first.", NotificationType.ERROR).notify(project)
+        }
+    }
+}

--- a/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/skim/SkimConversation.kt
+++ b/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/skim/SkimConversation.kt
@@ -29,7 +29,7 @@ object SkimConversation : ViewerConversation() {
         }
 
         if (pdfFilePath != null) {
-            // This okular command opens the pdf file using the destination coming from the line in the tex file.
+            // This command opens the pdf file using the destination coming from the line in the tex file.
             val command = "/Applications/Skim.app/Contents/SharedSupport/displayline $backgroundParameter -r $line '$pdfFilePath' '$sourceFilePath'"
             Runtime.getRuntime().exec(arrayOf("bash", "-c", command))
         }

--- a/src/nl/hannahsten/texifyidea/ui/SkimConfigureInverseSearchDialog.kt
+++ b/src/nl/hannahsten/texifyidea/ui/SkimConfigureInverseSearchDialog.kt
@@ -1,0 +1,31 @@
+package nl.hannahsten.texifyidea.ui
+
+import com.intellij.openapi.ui.DialogBuilder
+import java.awt.BorderLayout
+import javax.swing.JLabel
+import javax.swing.JPanel
+
+
+/**
+ * A dialog that contains a brief explanation about configuring inverse search with Skim.
+ *
+ * @author Stephan Sundermann
+ */
+class SkimConfigureInverseSearchDialog {
+    init {
+        DialogBuilder().apply {
+            setTitle("Configure inverse search")
+
+            val body = JLabel("<html>In the Skim settings, go to the Sync tab. Select Custom as Preset, and as a command provide 'idea' and set arguments to '--line %line %file' <br><br>See the wiki for more information.</html>")
+            // Create panel.
+            val panel = JPanel()
+            panel.layout = BorderLayout()
+            panel.add(body, BorderLayout.CENTER)
+            setCenterPanel(panel)
+
+            removeAllActions()
+            addOkAction()
+            show()
+        }
+    }
+}


### PR DESCRIPTION
#### Additions
Support for sync using Skim

#### Changes
Pretty much inspired by the recent addition of the Okular viewer.

#### Backwards incompatible changes
The change in `String.runCommand` might break on Linux or Windows. On MacOS I am testing the availability of Skim using open -Ra which returns an error if Skim was not found. Thus I need to check the errorStream as well. Skim is found if there is nothing in the output so I just appended the error message to the run command as well. I'm not sure if this breaks viewer detection on Linux, so help is appreciated here.