### PR TITLE
Generation code style settings

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -353,6 +353,7 @@
 
         <!-- Code style settings -->
         <codeStyleSettingsProvider implementation="nl.hannahsten.texifyidea.settings.codestyle.LatexCodeStyleSettingsProvider"/>
+        <codeStyleSettingsProvider implementation="nl.hannahsten.texifyidea.settings.codestyle.LatexGenerationSettingsProvider"/>
         <langCodeStyleSettingsProvider implementation="nl.hannahsten.texifyidea.settings.codestyle.LatexLanguageCodeStyleSettingsProvider"/>
         <codeStyleSettingsProvider implementation="nl.hannahsten.texifyidea.settings.codestyle.BibtexCodeStyleSettingsProvider"/>
         <langCodeStyleSettingsProvider implementation="nl.hannahsten.texifyidea.settings.codestyle.BibtexLanguageCodeStyleSettingsProvider"/>

--- a/src/nl/hannahsten/texifyidea/settings/codestyle/LatexCodeStyleSettingsProvider.kt
+++ b/src/nl/hannahsten/texifyidea/settings/codestyle/LatexCodeStyleSettingsProvider.kt
@@ -34,6 +34,13 @@ class LatexCodeStyleSettingsProvider : CodeStyleSettingsProvider() {
                         addIndentOptionsTab(settings)
                         addWrappingAndBracesTab(settings)
                         addBlankLinesTab(settings)
+
+                        // Adds the Code Generation tab.
+                        for (provider in EXTENSION_POINT_NAME.extensions) {
+                            if (provider.language === LatexLanguage.INSTANCE && !provider.hasSettingsPage()) {
+                                createTab(provider)
+                            }
+                        }
                     }
 
                     override fun addWrappingAndBracesTab(settings: CodeStyleSettings?) {

--- a/src/nl/hannahsten/texifyidea/settings/codestyle/LatexGenerationSettingsProvider.kt
+++ b/src/nl/hannahsten/texifyidea/settings/codestyle/LatexGenerationSettingsProvider.kt
@@ -1,0 +1,64 @@
+package nl.hannahsten.texifyidea.settings.codestyle
+
+import com.intellij.application.options.codeStyle.CommenterForm
+import com.intellij.openapi.application.ApplicationBundle
+import com.intellij.psi.codeStyle.CodeStyleConfigurable
+import com.intellij.psi.codeStyle.CodeStyleSettings
+import com.intellij.psi.codeStyle.CodeStyleSettingsProvider
+import com.intellij.psi.codeStyle.DisplayPriority
+import com.intellij.ui.IdeBorderFactory
+import com.intellij.util.ui.JBInsets
+import nl.hannahsten.texifyidea.LatexLanguage
+import javax.swing.BoxLayout
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+/**
+ * Copied from the Kotlin plugin.
+ *
+ * @author Abby Berkers
+ */
+class LatexGenerationSettingsProvider : CodeStyleSettingsProvider() {
+    override fun createConfigurable(settings: CodeStyleSettings, modelSettings: CodeStyleSettings): CodeStyleConfigurable {
+        return LatexCodeStyleGenerationConfigurable(settings)
+    }
+
+    override fun getConfigurableDisplayName(): String = ApplicationBundle.message("title.code.generation")
+    override fun getPriority(): DisplayPriority = DisplayPriority.CODE_SETTINGS
+    override fun hasSettingsPage() = false
+    override fun getLanguage() = LatexLanguage.INSTANCE
+}
+
+class LatexCodeStyleGenerationConfigurable(private val mySettings: CodeStyleSettings) : CodeStyleConfigurable {
+    private val myCommenterForm: CommenterForm = CommenterForm(LatexLanguage.INSTANCE)
+
+    override fun getDisplayName(): String = ApplicationBundle.message("title.code.generation")
+
+    override fun createComponent(): JComponent {
+        return JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            border = IdeBorderFactory.createEmptyBorder(JBInsets(0, 10, 10, 10))
+            add(myCommenterForm.commenterPanel)
+        }
+    }
+
+    override fun isModified(): Boolean {
+        return myCommenterForm.isModified(mySettings)
+    }
+
+    override fun apply() {
+        apply(mySettings)
+    }
+
+    override fun reset() {
+        reset(mySettings)
+    }
+
+    override fun reset(settings: CodeStyleSettings) {
+        myCommenterForm.reset(settings)
+    }
+
+    override fun apply(settings: CodeStyleSettings) {
+        myCommenterForm.apply(settings)
+    }
+}

--- a/src/nl/hannahsten/texifyidea/settings/codestyle/LatexLanguageCodeStyleSettingsProvider.kt
+++ b/src/nl/hannahsten/texifyidea/settings/codestyle/LatexLanguageCodeStyleSettingsProvider.kt
@@ -1,12 +1,14 @@
 package nl.hannahsten.texifyidea.settings.codestyle
 
+// import com.intellij.psi.codeStyle.CodeStyleSettingsCustomizable.CommenterOption.*
 import com.intellij.application.options.SmartIndentOptionsEditor
 import com.intellij.psi.codeStyle.CodeStyleSettingsCustomizable
+import com.intellij.psi.codeStyle.CodeStyleSettingsCustomizable.CommenterOption.LINE_COMMENT_ADD_SPACE
+import com.intellij.psi.codeStyle.CodeStyleSettingsCustomizable.CommenterOption.LINE_COMMENT_AT_FIRST_COLUMN
 import com.intellij.psi.codeStyle.CodeStyleSettingsCustomizable.WrappingOrBraceOption.*
 import com.intellij.psi.codeStyle.CommonCodeStyleSettings
 import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider
-import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider.SettingsType.BLANK_LINES_SETTINGS
-import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider.SettingsType.WRAPPING_AND_BRACES_SETTINGS
+import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider.SettingsType.*
 import com.intellij.psi.codeStyle.extractor.values.Value.VAR_KIND.RIGHT_MARGIN
 import nl.hannahsten.texifyidea.LatexLanguage
 import nl.hannahsten.texifyidea.util.Magic
@@ -33,11 +35,9 @@ class LatexLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider
     override fun customizeSettings(consumer: CodeStyleSettingsCustomizable, settingsType: SettingsType) {
         when (settingsType) {
             WRAPPING_AND_BRACES_SETTINGS -> customizeWrappingAndBracesSettings(consumer)
-            BLANK_LINES_SETTINGS -> customizeBlankLinesSettings(consumer)
-            SettingsType.COMMENTER_SETTINGS -> {
-                consumer.showAllStandardOptions()
-            }
-            else -> return
+            BLANK_LINES_SETTINGS         -> customizeBlankLinesSettings(consumer)
+            COMMENTER_SETTINGS           -> customizeCodeGenerationSettings(consumer)
+            else                         -> return
         }
     }
 
@@ -59,6 +59,13 @@ class LatexLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider
                     CodeStyleSettingsCustomizable.BLANK_LINES
             )
         }
+    }
+
+    private fun customizeCodeGenerationSettings(consumer: CodeStyleSettingsCustomizable) {
+        consumer.showStandardOptions(*arrayOf(
+                LINE_COMMENT_AT_FIRST_COLUMN,
+                LINE_COMMENT_ADD_SPACE
+        ).map { it.toString() }.toTypedArray())
     }
 
 }

--- a/src/nl/hannahsten/texifyidea/settings/codestyle/LatexLanguageCodeStyleSettingsProvider.kt
+++ b/src/nl/hannahsten/texifyidea/settings/codestyle/LatexLanguageCodeStyleSettingsProvider.kt
@@ -34,6 +34,9 @@ class LatexLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider
         when (settingsType) {
             WRAPPING_AND_BRACES_SETTINGS -> customizeWrappingAndBracesSettings(consumer)
             BLANK_LINES_SETTINGS -> customizeBlankLinesSettings(consumer)
+            SettingsType.COMMENTER_SETTINGS -> {
+                consumer.showAllStandardOptions()
+            }
             else -> return
         }
     }


### PR DESCRIPTION
Adds the _Code Generation_ tab to the LaTeX code style settings. With the settings in this tab it is possible to change the behaviour of using <kbd>Ctrl</kbd> + <kbd>/</kbd> to comment out LaTeX. Using the line

```latex
    I am a sentence.
```

as an example, the option _Line comment at first column_ will produce

```latex
%    I am a sentence.
```

and the option _Add a space at comment start_ will produce

```latex
    % I am a sentence.
```

**Note** that this setting is only for comment generation, and does not affect the formatter.

Somewhat relates to #610.
