### PR TITLE
Fix linemarker errors

### DIFF
--- a/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
+++ b/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
@@ -79,9 +79,8 @@ class LatexNavigationGutter : RelatedItemLineMarkerProvider() {
             arguments[0]
         }
 
-
         // Look up target file.
-        val containingFile = element.getContainingFile() ?: return
+        val containingFile = element.containingFile ?: return
 
         val roots = ArrayList<VirtualFile>()
         val rootFile = containingFile.findRootFile()
@@ -89,7 +88,7 @@ class LatexNavigationGutter : RelatedItemLineMarkerProvider() {
             return
         }
         roots.add(rootFile.containingDirectory.virtualFile)
-        val rootManager = ProjectRootManager.getInstance(element.getProject())
+        val rootManager = ProjectRootManager.getInstance(element.project)
         Collections.addAll(roots, *rootManager.contentSourceRoots)
 
         val psiManager = PsiManager.getInstance(element.project)

--- a/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
+++ b/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
@@ -119,7 +119,8 @@ class LatexNavigationGutter : RelatedItemLineMarkerProvider() {
         val defaultIcon = TexifyIcons.getIconFromExtension(argument.defaultExtension)
         val icon = if (ignoreFileArgument || TexifyIcons.getIconFromExtension(extension) == TexifyIcons.FILE) {
             defaultIcon
-        } else {
+        }
+        else {
             TexifyIcons.getIconFromExtension(extension)
         }
 

--- a/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
+++ b/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
@@ -108,10 +108,6 @@ class LatexNavigationGutter : RelatedItemLineMarkerProvider() {
                 .toList()
 
         // Build gutter icon.
-        // TODO: do we really need to dynamically find the maxSize? WindowManagerEx doesn't work in unit tests
-        // val maxSize = WindowManagerEx.getInstanceEx().getFrame(element.getProject())?.size?.width
-        //         ?: return
-        val maxSize = 0
 
         // Get the icon from the file extension when applicable and there exists an icon for this extension,
         // otherwise get the default icon for this argument.
@@ -129,7 +125,7 @@ class LatexNavigationGutter : RelatedItemLineMarkerProvider() {
                 .setTargets(files)
                 .setPopupTitle("Navigate to Referenced File")
                 .setTooltipText("Go to referenced file")
-                .setCellRenderer(GotoFileCellRenderer(maxSize))
+                .setCellRenderer(GotoFileCellRenderer(0))
 
         result.add(builder.createLineMarkerInfo(element))
     }

--- a/test/nl/hannahsten/texifyidea/gutter/LatexGutterTest.kt
+++ b/test/nl/hannahsten/texifyidea/gutter/LatexGutterTest.kt
@@ -1,5 +1,9 @@
 package nl.hannahsten.texifyidea.gutter
 
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzerSettings
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl
+import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import org.junit.Test
 
@@ -14,5 +18,34 @@ class LatexGutterTest : BasePlatformTestCase() {
         val gutters = myFixture.findAllGutters("$testName.tex")
         assertEquals(1, gutters.size)
         assertEquals("Compile document", gutters.first().tooltipText)
+    }
+
+    @Test
+    fun testShowMethodSeparators() {
+        val testName = getTestName(false)
+        withLineMarkersEnabled {
+            myFixture.configureByFile("$testName.tex")
+            myFixture.doHighlighting()
+            val lineMarkers = DaemonCodeAnalyzerImpl
+                    .getLineMarkers(myFixture.editor.document, myFixture.project)
+                    .filter { l -> l.separatorPlacement != null }
+            assertTrue(lineMarkers.any { l -> getLineMarkerLine(l) == 1 })
+            assertTrue(lineMarkers.any { l -> getLineMarkerLine(l) == 4 })
+        }
+
+    }
+
+    private fun getLineMarkerLine(marker: LineMarkerInfo<*>): Int {
+        return myFixture.editor.document.getLineNumber((marker.element as LeafPsiElement).textRange.startOffset)
+    }
+
+    private fun withLineMarkersEnabled(action: () -> Unit) {
+        val before = DaemonCodeAnalyzerSettings.getInstance().SHOW_METHOD_SEPARATORS
+        DaemonCodeAnalyzerSettings.getInstance().SHOW_METHOD_SEPARATORS = true
+        try {
+            action()
+        } finally {
+            DaemonCodeAnalyzerSettings.getInstance().SHOW_METHOD_SEPARATORS = before
+        }
     }
 }

--- a/test/nl/hannahsten/texifyidea/gutter/LatexGutterTest.kt
+++ b/test/nl/hannahsten/texifyidea/gutter/LatexGutterTest.kt
@@ -35,6 +35,18 @@ class LatexGutterTest : BasePlatformTestCase() {
 
     }
 
+    @Test
+    fun testShowNavigationGutter() {
+        val testName = getTestName(false)
+        myFixture.configureByFile("$testName.tex")
+        myFixture.doHighlighting()
+        val lineMarkers = DaemonCodeAnalyzerImpl
+                .getLineMarkers(myFixture.editor.document, myFixture.project)
+        val gutters = myFixture.findAllGutters()
+        assertEquals(5, gutters.size)
+        assertTrue(gutters.all { g -> g.tooltipText == "Go to referenced file" })
+    }
+
     private fun getLineMarkerLine(marker: LineMarkerInfo<*>): Int {
         return myFixture.editor.document.getLineNumber((marker.element as LeafPsiElement).textRange.startOffset)
     }

--- a/test/nl/hannahsten/texifyidea/gutter/LatexGutterTest.kt
+++ b/test/nl/hannahsten/texifyidea/gutter/LatexGutterTest.kt
@@ -40,8 +40,6 @@ class LatexGutterTest : BasePlatformTestCase() {
         val testName = getTestName(false)
         myFixture.configureByFile("$testName.tex")
         myFixture.doHighlighting()
-        @Suppress("UNUSED_VARIABLE") val lineMarkers = DaemonCodeAnalyzerImpl
-                .getLineMarkers(myFixture.editor.document, myFixture.project)
         val gutters = myFixture.findAllGutters()
         assertEquals(5, gutters.size)
         assertTrue(gutters.all { g -> g.tooltipText == "Go to referenced file" })

--- a/test/nl/hannahsten/texifyidea/gutter/LatexGutterTest.kt
+++ b/test/nl/hannahsten/texifyidea/gutter/LatexGutterTest.kt
@@ -40,7 +40,7 @@ class LatexGutterTest : BasePlatformTestCase() {
         val testName = getTestName(false)
         myFixture.configureByFile("$testName.tex")
         myFixture.doHighlighting()
-        val lineMarkers = DaemonCodeAnalyzerImpl
+        @Suppress("UNUSED_VARIABLE") val lineMarkers = DaemonCodeAnalyzerImpl
                 .getLineMarkers(myFixture.editor.document, myFixture.project)
         val gutters = myFixture.findAllGutters()
         assertEquals(5, gutters.size)

--- a/test/nl/hannahsten/texifyidea/lang/magic/MagicCommentTest.kt
+++ b/test/nl/hannahsten/texifyidea/lang/magic/MagicCommentTest.kt
@@ -73,7 +73,7 @@ fun MagicComment<String, String>.assertValue(key: String, expectedValue: String?
     val values = values(magicKey)
     if (expectedValue != null) {
         assertNotNull(values, "<$magicKey> is not present as key in comment <$this>.")
-        assertTrue(index < values!!.size,
+        assertTrue(index < values.size,
                 "Index <$index> is not present in value list <$values> of comment <$this>."
         )
     }

--- a/testData/gutter/ShowMethodSeparators.tex
+++ b/testData/gutter/ShowMethodSeparators.tex
@@ -1,0 +1,8 @@
+\begin{document}
+    \section{Section2}
+    Some section1 text
+
+    \section{Section2}
+    Some section2 text
+
+\end{document}

--- a/testData/gutter/ShowNavigationGutter.tex
+++ b/testData/gutter/ShowNavigationGutter.tex
@@ -1,0 +1,5 @@
+\usepackage{inputenc}
+\documentclass{article}
+\RequirePackage{amsmath}
+\LoadClass{article}
+\LoadClassWithOptions{article}


### PR DESCRIPTION
#### Additions
None

#### Changes
Fix LatexNavigationGutter LineMarker to use leaf elements (note added TODO) #1197 

#### Backwards incompatible changes
None

It would be nice to find a more robust way of testing the gutters than using the tooltip text (e.g. also assert the referenced file), but I couldn't find one.