### PR TITLE
Create issue templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Global owners, automatically request review when pull request is submitted
-*       @HannahSchellekens @stenwessel @PHPirates
+*       @HannahSchellekens @stenwessel @PHPirates @slideclimb
 
 # Patterns below override the rules above

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a bug report to help us fix incorrect behaviour of TeXiFy
+title: ''
+labels: bug, untriaged
+assignees: ''
+
+---
+
+#### Type of JetBrains IDE (IntelliJ, PyCharm, etc.) and version
+
+
+#### Operating System 
+<!-- Windows, Ubuntu, Arch Linux, MacOS, etc. -->
+
+
+#### TeXiFy IDEA version
+
+
+#### What I did (steps to reproduce)
+
+
+#### Expected behavior
+
+
+#### Actual behavior
+
+
+#### (if applicable) The full stacktrace of the exception thrown
+```
+
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,10 @@
+---
+name: Feature request
+about: Suggest an enhancement for this project
+title: ''
+labels: enhancement, untriaged
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/other-issues.md
+++ b/.github/ISSUE_TEMPLATE/other-issues.md
@@ -1,0 +1,10 @@
+---
+name: Other issues
+about: Create an issue that is not a feature request or bug report
+title: ''
+labels: untriaged
+assignees: ''
+
+---
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,15 @@
-#### Additions
+<!-- The issue that is fixed by this PR, if applicable: -->
+Fixes #
 
+#### Summary of additions and changes
 
-#### Changes
+* 
 
+#### How to test this pull request
 
-#### Backwards incompatible changes
+* 
+
+#### Wiki
+
+<!-- Add link to updated wiki page -->
+- [ ] Updated the wiki:


### PR DESCRIPTION
Apparently there are new issue templates with default labels, which allow people to choose issue type (bug/feature) themselves.
Not entirely convinced it is better, but why not.