### PR TITLE
Environment missing label inspection

### DIFF
--- a/gen/nl/hannahsten/texifyidea/psi/LatexBeginCommand.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexBeginCommand.java
@@ -1,13 +1,18 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface LatexBeginCommand extends PsiElement {
 
   @NotNull
   List<LatexParameter> getParameterList();
+
+  List<String> getOptionalParameters();
+
+  List<String> getRequiredParameters();
 
 }

--- a/gen/nl/hannahsten/texifyidea/psi/LatexBeginCommand.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexBeginCommand.java
@@ -4,6 +4,7 @@ package nl.hannahsten.texifyidea.psi;
 import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 
 public interface LatexBeginCommand extends PsiElement {
@@ -11,7 +12,7 @@ public interface LatexBeginCommand extends PsiElement {
   @NotNull
   List<LatexParameter> getParameterList();
 
-  List<String> getOptionalParameters();
+  LinkedHashMap<String, String> getOptionalParameters();
 
   List<String> getRequiredParameters();
 

--- a/gen/nl/hannahsten/texifyidea/psi/LatexCommands.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexCommands.java
@@ -27,4 +27,6 @@ public interface LatexCommands extends PsiNameIdentifierOwner, StubBasedPsiEleme
 
   boolean hasLabel();
 
+  String getName();
+
 }

--- a/gen/nl/hannahsten/texifyidea/psi/LatexCommands.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexCommands.java
@@ -8,6 +8,7 @@ import com.intellij.psi.StubBasedPsiElement;
 import nl.hannahsten.texifyidea.index.stub.LatexCommandsStub;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 
 public interface LatexCommands extends PsiNameIdentifierOwner, StubBasedPsiElement<LatexCommandsStub> {
@@ -21,7 +22,7 @@ public interface LatexCommands extends PsiNameIdentifierOwner, StubBasedPsiEleme
   @NotNull
   PsiReference[] getReferences();
 
-  List<String> getOptionalParameters();
+  LinkedHashMap<String, String> getOptionalParameters();
 
   List<String> getRequiredParameters();
 

--- a/gen/nl/hannahsten/texifyidea/psi/LatexEnvironment.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexEnvironment.java
@@ -1,11 +1,13 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.StubBasedPsiElement;
+import nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStub;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-public interface LatexEnvironment extends PsiElement {
+public interface LatexEnvironment extends PsiElement, StubBasedPsiElement<LatexEnvironmentStub> {
 
   @NotNull
   LatexBeginCommand getBeginCommand();
@@ -15,5 +17,9 @@ public interface LatexEnvironment extends PsiElement {
 
   @Nullable
   LatexEnvironmentContent getEnvironmentContent();
+
+  String getEnvironmentName();
+
+  boolean hasLabel();
 
 }

--- a/gen/nl/hannahsten/texifyidea/psi/LatexTypes.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexTypes.java
@@ -1,10 +1,11 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi;
 
-import com.intellij.psi.tree.IElementType;
-import com.intellij.psi.PsiElement;
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.tree.IElementType;
 import nl.hannahsten.texifyidea.index.stub.LatexCommandsStubElementType;
+import nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStubElementType;
 import nl.hannahsten.texifyidea.psi.impl.*;
 
 public interface LatexTypes {
@@ -15,7 +16,7 @@ public interface LatexTypes {
   IElementType CONTENT = new LatexElementType("CONTENT");
   IElementType DISPLAY_MATH = new LatexElementType("DISPLAY_MATH");
   IElementType END_COMMAND = new LatexElementType("END_COMMAND");
-  IElementType ENVIRONMENT = new LatexElementType("ENVIRONMENT");
+  IElementType ENVIRONMENT = new LatexEnvironmentStubElementType("ENVIRONMENT");
   IElementType ENVIRONMENT_CONTENT = new LatexElementType("ENVIRONMENT_CONTENT");
   IElementType GROUP = new LatexElementType("GROUP");
   IElementType INLINE_MATH = new LatexElementType("INLINE_MATH");

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexBeginCommandImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexBeginCommandImpl.java
@@ -11,6 +11,7 @@ import nl.hannahsten.texifyidea.psi.LatexPsiImplUtil;
 import nl.hannahsten.texifyidea.psi.LatexVisitor;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 
 public class LatexBeginCommandImpl extends ASTWrapperPsiElement implements LatexBeginCommand {
@@ -35,7 +36,7 @@ public class LatexBeginCommandImpl extends ASTWrapperPsiElement implements Latex
   }
 
   @Override
-  public List<String> getOptionalParameters() {
+  public LinkedHashMap<String, String> getOptionalParameters() {
     return LatexPsiImplUtil.getOptionalParameters(this);
   }
 

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexBeginCommandImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexBeginCommandImpl.java
@@ -1,15 +1,17 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
-import com.intellij.extapi.psi.ASTWrapperPsiElement;
-import nl.hannahsten.texifyidea.psi.*;
+import nl.hannahsten.texifyidea.psi.LatexBeginCommand;
+import nl.hannahsten.texifyidea.psi.LatexParameter;
+import nl.hannahsten.texifyidea.psi.LatexPsiImplUtil;
+import nl.hannahsten.texifyidea.psi.LatexVisitor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public class LatexBeginCommandImpl extends ASTWrapperPsiElement implements LatexBeginCommand {
 
@@ -22,7 +24,7 @@ public class LatexBeginCommandImpl extends ASTWrapperPsiElement implements Latex
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof LatexVisitor) accept((LatexVisitor)visitor);
+    if (visitor instanceof LatexVisitor) accept((LatexVisitor) visitor);
     else super.accept(visitor);
   }
 
@@ -30,6 +32,16 @@ public class LatexBeginCommandImpl extends ASTWrapperPsiElement implements Latex
   @NotNull
   public List<LatexParameter> getParameterList() {
     return PsiTreeUtil.getChildrenOfTypeAsList(this, LatexParameter.class);
+  }
+
+  @Override
+  public List<String> getOptionalParameters() {
+    return LatexPsiImplUtil.getOptionalParameters(this);
+  }
+
+  @Override
+  public List<String> getRequiredParameters() {
+    return LatexPsiImplUtil.getRequiredParameters(this);
   }
 
 }

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexCommandsImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexCommandsImpl.java
@@ -12,6 +12,7 @@ import nl.hannahsten.texifyidea.index.stub.LatexCommandsStub;
 import nl.hannahsten.texifyidea.psi.*;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import static nl.hannahsten.texifyidea.psi.LatexTypes.COMMAND_TOKEN;
@@ -58,7 +59,7 @@ public class LatexCommandsImpl extends LatexCommandsImplMixin implements LatexCo
   }
 
   @Override
-  public List<String> getOptionalParameters() {
+  public LinkedHashMap<String, String> getOptionalParameters() {
     return LatexPsiImplUtil.getOptionalParameters(this);
   }
 

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexCommandsImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexCommandsImpl.java
@@ -1,19 +1,20 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.util.PsiTreeUtil;
-import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
-import nl.hannahsten.texifyidea.psi.LatexCommandsImplMixin;
-import nl.hannahsten.texifyidea.psi.*;
 import com.intellij.psi.PsiReference;
-import nl.hannahsten.texifyidea.index.stub.LatexCommandsStub;
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.util.PsiTreeUtil;
+import nl.hannahsten.texifyidea.index.stub.LatexCommandsStub;
+import nl.hannahsten.texifyidea.psi.*;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+import static nl.hannahsten.texifyidea.psi.LatexTypes.COMMAND_TOKEN;
 
 public class LatexCommandsImpl extends LatexCommandsImplMixin implements LatexCommands {
 
@@ -69,6 +70,11 @@ public class LatexCommandsImpl extends LatexCommandsImplMixin implements LatexCo
   @Override
   public boolean hasLabel() {
     return LatexPsiImplUtil.hasLabel(this);
+  }
+
+  @Override
+  public String getName() {
+    return LatexPsiImplUtil.getName(this);
   }
 
 }

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexEnvironmentImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexEnvironmentImpl.java
@@ -1,20 +1,29 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
+import com.intellij.extapi.psi.StubBasedPsiElementBase;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.stubs.IStubElementType;
+import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
-import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
-import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStub;
 import nl.hannahsten.texifyidea.psi.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-public class LatexEnvironmentImpl extends ASTWrapperPsiElement implements LatexEnvironment {
+public class LatexEnvironmentImpl extends StubBasedPsiElementBase<LatexEnvironmentStub> implements LatexEnvironment {
+
+  public LatexEnvironmentImpl(@NotNull LatexEnvironmentStub stub, @NotNull IStubElementType type) {
+    super(stub, type);
+  }
 
   public LatexEnvironmentImpl(@NotNull ASTNode node) {
     super(node);
+  }
+
+  public LatexEnvironmentImpl(LatexEnvironmentStub stub, IElementType type, ASTNode node) {
+    super(stub, type, node);
   }
 
   public void accept(@NotNull LatexVisitor visitor) {
@@ -22,7 +31,7 @@ public class LatexEnvironmentImpl extends ASTWrapperPsiElement implements LatexE
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof LatexVisitor) accept((LatexVisitor)visitor);
+    if (visitor instanceof LatexVisitor) accept((LatexVisitor) visitor);
     else super.accept(visitor);
   }
 
@@ -42,6 +51,16 @@ public class LatexEnvironmentImpl extends ASTWrapperPsiElement implements LatexE
   @Nullable
   public LatexEnvironmentContent getEnvironmentContent() {
     return PsiTreeUtil.getChildOfType(this, LatexEnvironmentContent.class);
+  }
+
+  @Override
+  public String getEnvironmentName() {
+    return LatexPsiImplUtil.getEnvironmentName(this);
+  }
+
+  @Override
+  public boolean hasLabel() {
+    return LatexPsiImplUtil.hasLabel(this);
   }
 
 }

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -448,6 +448,7 @@
         <stubElementTypeHolder class="nl.hannahsten.texifyidea.psi.BibtexTypes"/>
 
         <stubIndex implementation="nl.hannahsten.texifyidea.index.LatexCommandsIndex"/>
+        <stubIndex implementation="nl.hannahsten.texifyidea.index.LatexEnvironmentsIndex"/>
         <stubIndex implementation="nl.hannahsten.texifyidea.index.BibtexEntryIndex"/>
         <stubIndex implementation="nl.hannahsten.texifyidea.index.LatexIncludesIndex"/>
         <stubIndex implementation="nl.hannahsten.texifyidea.index.LatexDefinitionIndex"/>

--- a/src/nl/hannahsten/texifyidea/completion/LatexCommandProvider.java
+++ b/src/nl/hannahsten/texifyidea/completion/LatexCommandProvider.java
@@ -22,7 +22,9 @@ import nl.hannahsten.texifyidea.index.LatexCommandsIndex;
 import nl.hannahsten.texifyidea.index.LatexDefinitionIndex;
 import nl.hannahsten.texifyidea.lang.*;
 import nl.hannahsten.texifyidea.psi.LatexCommands;
-import nl.hannahsten.texifyidea.util.*;
+import nl.hannahsten.texifyidea.util.Kindness;
+import nl.hannahsten.texifyidea.util.Magic;
+import nl.hannahsten.texifyidea.util.PsiCommandsKt;
 import nl.hannahsten.texifyidea.util.files.FileSetKt;
 import nl.hannahsten.texifyidea.util.files.FilesKt;
 import org.jetbrains.annotations.NotNull;
@@ -227,7 +229,7 @@ public class LatexCommandProvider extends CompletionProvider<CompletionParameter
             return "";
         }
 
-        List<String> optional = commands.getOptionalParameters();
+        List<String> optional = new LinkedList<>(commands.getOptionalParameters().keySet());
 
         int cmdParameterCount = 0;
 

--- a/src/nl/hannahsten/texifyidea/completion/handlers/LatexCommandArgumentInsertHandler.java
+++ b/src/nl/hannahsten/texifyidea/completion/handlers/LatexCommandArgumentInsertHandler.java
@@ -11,6 +11,7 @@ import nl.hannahsten.texifyidea.lang.LatexMathCommand;
 import nl.hannahsten.texifyidea.lang.LatexRegularCommand;
 import nl.hannahsten.texifyidea.psi.LatexCommands;
 
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -34,18 +35,15 @@ public class LatexCommandArgumentInsertHandler implements InsertHandler<LookupEl
     }
 
     private void insertCommands(LatexCommands commands, InsertionContext context) {
-        List<String> optional = commands.getOptionalParameters();
+        List<String> optional = new LinkedList<>(commands.getOptionalParameters().keySet());
         if (optional.isEmpty()) {
             return;
         }
 
         int cmdParameterCount = 0;
-        if (!optional.isEmpty()) {
-            try {
-                cmdParameterCount = Integer.parseInt(optional.get(0));
-            }
-            catch (NumberFormatException ignore) {
-            }
+        try {
+            cmdParameterCount = Integer.parseInt(optional.get(0));
+        } catch (NumberFormatException ignore) {
         }
 
         if (cmdParameterCount > 0) {

--- a/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
+++ b/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
@@ -60,7 +60,10 @@ commands ::= COMMAND_TOKEN STAR? parameter* {
     methods=[getReferences getOptionalParameters getRequiredParameters hasLabel getName]
 }
 
-begin_command ::= BEGIN_TOKEN STAR? parameter* { pin=1 }
+begin_command ::= BEGIN_TOKEN STAR? parameter* {
+    pin=1
+    methods=[getOptionalParameters getRequiredParameters]
+}
 
 end_command ::= END_TOKEN STAR? parameter* { pin=1 }
 

--- a/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
+++ b/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
@@ -16,6 +16,8 @@
     extends("commands")="com.intellij.extapi.psi.StubBasedPsiElementBase<nl.hannahsten.texifyidea.index.stub.LatexCommandsStub>"
     implements("commands")="com.intellij.psi.PsiNameIdentifierOwner"
 
+    extends("environment")="com.intellij.extapi.psi.StubBasedPsiElementBase<nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStub>"
+
     tokens=[
         WHITE_SPACE='regexp:\s+'
         DISPLAY_MATH_START='\['
@@ -41,7 +43,12 @@ no_math_content ::= comment | environment | math_environment | commands | group 
 
 normal_text ::= (NORMAL_TEXT_WORD | STAR)+
 
-environment ::= begin_command environment_content? end_command { pin=1 }
+environment ::= begin_command environment_content? end_command {
+    pin=1
+    elementTypeClass="nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStubElementType"
+    stubClass="nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStub"
+    methods=[getEnvironmentName hasLabel]
+ }
 
 environment_content ::= content+
 

--- a/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
+++ b/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
@@ -57,7 +57,7 @@ commands ::= COMMAND_TOKEN STAR? parameter* {
     elementTypeClass="nl.hannahsten.texifyidea.index.stub.LatexCommandsStubElementType"
     stubClass="nl.hannahsten.texifyidea.index.stub.LatexCommandsStub"
     mixin="nl.hannahsten.texifyidea.psi.LatexCommandsImplMixin"
-    methods=[getReferences getOptionalParameters getRequiredParameters hasLabel]
+    methods=[getReferences getOptionalParameters getRequiredParameters hasLabel getName]
 }
 
 begin_command ::= BEGIN_TOKEN STAR? parameter* { pin=1 }

--- a/src/nl/hannahsten/texifyidea/index/IndexKeys.java
+++ b/src/nl/hannahsten/texifyidea/index/IndexKeys.java
@@ -2,6 +2,7 @@ package nl.hannahsten.texifyidea.index;
 
 import com.intellij.psi.stubs.StubIndexKey;
 import nl.hannahsten.texifyidea.psi.LatexCommands;
+import nl.hannahsten.texifyidea.psi.LatexEnvironment;
 
 /**
  * @author Hannah Schellekens
@@ -16,4 +17,7 @@ public class IndexKeys {
 
     public static final StubIndexKey<String, LatexCommands> DEFINITIONS_KEY =
             StubIndexKey.createIndexKey("nl.hannahsten.texifyidea.definitions");
+
+    public static final StubIndexKey<String, LatexEnvironment> ENVIRONMENTS_KEY =
+            StubIndexKey.createIndexKey("nl.hannahsten.texifyidea.environments");
 }

--- a/src/nl/hannahsten/texifyidea/index/LatexEnvironmentsIndex.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexEnvironmentsIndex.kt
@@ -1,0 +1,11 @@
+package nl.hannahsten.texifyidea.index
+
+import com.intellij.psi.stubs.StringStubIndexExtension
+import nl.hannahsten.texifyidea.psi.LatexEnvironment
+
+class LatexEnvironmentsIndex : StringStubIndexExtension<LatexEnvironment>() {
+    companion object : IndexUtilBase<LatexEnvironment>(LatexEnvironment::class.java, IndexKeys.ENVIRONMENTS_KEY)
+
+    @Suppress("RedundantCompanionReference")
+    override fun getKey() = Companion.key()
+}

--- a/src/nl/hannahsten/texifyidea/index/stub/LatexCommandsStubElementType.java
+++ b/src/nl/hannahsten/texifyidea/index/stub/LatexCommandsStubElementType.java
@@ -11,6 +11,7 @@ import nl.hannahsten.texifyidea.util.Magic;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -40,7 +41,7 @@ public class LatexCommandsStubElementType extends IStubElementType<LatexCommands
         latexCommands.setName(commandToken);
 
         List<String> requiredParameters = latexCommands.getRequiredParameters();
-        List<String> optionalParameters = latexCommands.getOptionalParameters();
+        List<String> optionalParameters = new LinkedList<>(latexCommands.getOptionalParameters().keySet());
 
         return new LatexCommandsStubImpl(
                 parent, this,

--- a/src/nl/hannahsten/texifyidea/index/stub/LatexEnvironmentStub.kt
+++ b/src/nl/hannahsten/texifyidea/index/stub/LatexEnvironmentStub.kt
@@ -1,0 +1,8 @@
+package nl.hannahsten.texifyidea.index.stub
+
+import com.intellij.psi.stubs.StubElement
+import nl.hannahsten.texifyidea.psi.LatexEnvironment
+
+interface LatexEnvironmentStub : StubElement<LatexEnvironment?> {
+    val environmentName: String?
+}

--- a/src/nl/hannahsten/texifyidea/index/stub/LatexEnvironmentStubElementType.kt
+++ b/src/nl/hannahsten/texifyidea/index/stub/LatexEnvironmentStubElementType.kt
@@ -1,0 +1,35 @@
+package nl.hannahsten.texifyidea.index.stub
+
+import com.intellij.psi.stubs.*
+import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.index.LatexEnvironmentsIndex
+import nl.hannahsten.texifyidea.psi.LatexEnvironment
+import nl.hannahsten.texifyidea.psi.impl.LatexEnvironmentImpl
+import java.io.IOException
+
+open class LatexEnvironmentStubElementType(private val debugName: String) : IStubElementType<LatexEnvironmentStub, LatexEnvironment>(debugName, LatexLanguage.INSTANCE) {
+    override fun createPsi(stub: LatexEnvironmentStub): LatexEnvironment {
+        return LatexEnvironmentImpl(stub, this)
+    }
+
+    override fun createStub(psi: LatexEnvironment, parentStub: StubElement<*>): LatexEnvironmentStub {
+        return LatexEnvironmentStubImpl(parentStub, this, psi.environmentName)
+    }
+
+    override fun getExternalId() = debugName
+
+    @Throws(IOException::class)
+    override fun serialize(stub: LatexEnvironmentStub, dataStream: StubOutputStream) {
+        dataStream.writeName(stub.environmentName)
+    }
+
+    @Throws(IOException::class)
+    override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>): LatexEnvironmentStub {
+        val envName = dataStream.readName()?.string ?: ""
+        return LatexEnvironmentStubImpl(parentStub, this, envName)
+    }
+
+    override fun indexStub(stub: LatexEnvironmentStub, sink: IndexSink) {
+        sink.occurrence(LatexEnvironmentsIndex.key(), stub.environmentName!!)
+    }
+}

--- a/src/nl/hannahsten/texifyidea/index/stub/LatexEnvironmentStubImpl.kt
+++ b/src/nl/hannahsten/texifyidea/index/stub/LatexEnvironmentStubImpl.kt
@@ -1,0 +1,11 @@
+package nl.hannahsten.texifyidea.index.stub
+
+import com.intellij.psi.stubs.IStubElementType
+import com.intellij.psi.stubs.StubBase
+import com.intellij.psi.stubs.StubElement
+import nl.hannahsten.texifyidea.psi.LatexEnvironment
+
+data class LatexEnvironmentStubImpl(val parent: StubElement<*>,
+                                    val elementType: IStubElementType<LatexEnvironmentStub, LatexEnvironment>,
+                                    override val environmentName: String) :
+        StubBase<LatexEnvironment>(parent, elementType), LatexEnvironmentStub

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingLabelInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingLabelInspection.kt
@@ -48,7 +48,7 @@ open class LatexMissingLabelInspection : TexifyInspectionBase() {
 
         val environments = file.environmentsInFile()
         for (environment in environments) {
-            if (!Magic.Environment.labeled.containsKey(environment.environmentName)) {
+            if (!Magic.Environment.labeled.containsKey(environment.environmentName) || environment.environmentName == "lstlisting") {
                 continue
             }
 
@@ -128,7 +128,6 @@ open class LatexMissingLabelInspection : TexifyInspectionBase() {
 
         override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
             val command = descriptor.psiElement as LatexEnvironment
-
             val factory = LatexPsiFactory(project)
             val labelCommand = factory.createUniqueLabelCommandFor(command) ?: return
             if (command.environmentContent == null) {

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingLabelInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingLabelInspection.kt
@@ -40,9 +40,7 @@ open class LatexMissingLabelInspection : TexifyInspectionBase() {
 
         val commands = file.commandsInFile()
         for (command in commands) {
-            // It is important to use commandToken.text instead of command.name,
-            // because command.name may still be an old indexed and possibly incorrect value
-            if (!Magic.Command.labeled.containsKey(command.commandToken.text) || command.commandToken.text == "\\item" || command.hasStar()) {
+            if (!Magic.Command.labeled.containsKey(command.name) || command.name == "\\item" || command.hasStar()) {
                 continue
             }
 

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingLabelInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingLabelInspection.kt
@@ -10,9 +10,11 @@ import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.psi.LatexEnvironment
 import nl.hannahsten.texifyidea.util.*
 import nl.hannahsten.texifyidea.util.files.commandsInFile
 import nl.hannahsten.texifyidea.util.files.document
+import nl.hannahsten.texifyidea.util.files.environmentsInFile
 import nl.hannahsten.texifyidea.util.files.openedEditor
 import java.util.*
 
@@ -47,6 +49,15 @@ open class LatexMissingLabelInspection : TexifyInspectionBase() {
             addCommandDescriptor(command, descriptors, manager, isOntheFly)
         }
 
+        val environments = file.environmentsInFile()
+        for (environment in environments) {
+            if (!Magic.Environment.labeled.containsKey(environment.environmentName)) {
+                continue
+            }
+
+            addEnvironmentDescriptor(environment, descriptors, manager, isOntheFly)
+        }
+
         return descriptors
     }
 
@@ -67,6 +78,24 @@ open class LatexMissingLabelInspection : TexifyInspectionBase() {
                 InsertLabelFix(),
                 ProblemHighlightType.WEAK_WARNING,
                 isOntheFly
+        ))
+
+        return true
+    }
+
+    private fun addEnvironmentDescriptor(environment: LatexEnvironment, descriptors: MutableList<ProblemDescriptor>,
+                                         manager: InspectionManager, isOntheFly: Boolean): Boolean {
+        if (environment.hasLabel()) {
+            return false
+        }
+
+        descriptors.add(manager.createProblemDescriptor(
+                environment,
+                "Missing label",
+                LocalQuickFix.EMPTY_ARRAY,
+                ProblemHighlightType.WEAK_WARNING,
+                isOntheFly,
+                false
         ))
 
         return true

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingLabelInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingLabelInspection.kt
@@ -20,8 +20,6 @@ import java.util.*
 /**
  * Currently only works for Chapters, Sections and Subsections.
  *
- * Planned is to also implement this for other environments.
- *
  * @author Hannah Schellekens
  */
 open class LatexMissingLabelInspection : TexifyInspectionBase() {

--- a/src/nl/hannahsten/texifyidea/psi/LatexCommandsImplMixin.java
+++ b/src/nl/hannahsten/texifyidea/psi/LatexCommandsImplMixin.java
@@ -42,11 +42,6 @@ public class LatexCommandsImplMixin extends StubBasedPsiElementBase<LatexCommand
     }
 
     @Override
-    public String getName() {
-        return name;
-    }
-
-    @Override
     public String toString() {
         return "LatexCommandsImpl(COMMANDS)[STUB]{" + getName() + "}";
     }

--- a/src/nl/hannahsten/texifyidea/psi/LatexPsiImplUtil.java
+++ b/src/nl/hannahsten/texifyidea/psi/LatexPsiImplUtil.java
@@ -10,6 +10,7 @@ import nl.hannahsten.texifyidea.index.stub.LatexCommandsStub;
 import nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStub;
 import nl.hannahsten.texifyidea.reference.InputFileReference;
 import nl.hannahsten.texifyidea.reference.LatexLabelReference;
+import nl.hannahsten.texifyidea.settings.LabelingCommandInformation;
 import nl.hannahsten.texifyidea.settings.TexifySettings;
 import nl.hannahsten.texifyidea.util.Magic;
 import nl.hannahsten.texifyidea.util.PsiCommandsKt;
@@ -232,7 +233,8 @@ public class LatexPsiImplUtil {
         Collection<LatexCommands> children = PsiTreeUtil.findChildrenOfType(content, LatexCommands.class);
         if (!children.isEmpty()) {
             LatexCommands labelMaybe = children.iterator().next();
-            labelFound = TexifySettings.getInstance().getLabelPreviousCommands().containsKey(labelMaybe.getCommandToken().getText());
+            Map<String, LabelingCommandInformation> labelCommands = TexifySettings.getInstance().getLabelPreviousCommands();
+            labelFound = children.stream().anyMatch(c -> labelCommands.containsKey(c.getName()));
         }
 
         // see if we can find a label option

--- a/src/nl/hannahsten/texifyidea/psi/LatexPsiImplUtil.java
+++ b/src/nl/hannahsten/texifyidea/psi/LatexPsiImplUtil.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.util.PsiTreeUtil;
+import nl.hannahsten.texifyidea.index.stub.LatexCommandsStub;
 import nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStub;
 import nl.hannahsten.texifyidea.reference.InputFileReference;
 import nl.hannahsten.texifyidea.reference.LatexLabelReference;
@@ -178,6 +179,12 @@ public class LatexPsiImplUtil {
                             .collect(Collectors.toList()));
                 })
                 .collect(Collectors.toList());
+    }
+
+    public static String getName(@NotNull LatexCommands element) {
+        LatexCommandsStub stub = element.getStub();
+        if (stub != null) return stub.getName();
+        return element.getCommandToken().getText();
     }
 
     /**

--- a/src/nl/hannahsten/texifyidea/psi/LatexPsiImplUtil.java
+++ b/src/nl/hannahsten/texifyidea/psi/LatexPsiImplUtil.java
@@ -119,6 +119,10 @@ public class LatexPsiImplUtil {
         return getOptionalParameters(element.getParameterList());
     }
 
+    public static List<String> getOptionalParameters(@NotNull LatexBeginCommand element) {
+        return getOptionalParameters(element.getParameterList());
+    }
+
     private static List<String> getOptionalParameters(@NotNull List<LatexParameter> parameters) {
         return parameters.stream()
                 .map(LatexParameter::getOptionalParam)
@@ -145,12 +149,8 @@ public class LatexPsiImplUtil {
                 .collect(Collectors.toList());
     }
 
-    /**
-     * Generates a list of all names of all required parameters in the command.
-     */
-    public static List<String> getRequiredParameters(@NotNull LatexCommands element) {
-        return element.getParameterList().stream()
-                .map(LatexParameter::getRequiredParam)
+    private static List<String> getRequiredParameters(@NotNull List<LatexParameter> parameters) {
+        return parameters.stream().map(LatexParameter::getRequiredParam)
                 .flatMap(rp -> {
                     if (rp == null || rp.getGroup() == null) {
                         return Stream.empty();
@@ -179,6 +179,17 @@ public class LatexPsiImplUtil {
                             .collect(Collectors.toList()));
                 })
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Generates a list of all names of all required parameters in the command.
+     */
+    public static List<String> getRequiredParameters(@NotNull LatexCommands element) {
+        return getRequiredParameters(element.getParameterList());
+    }
+
+    public static List<String> getRequiredParameters(@NotNull LatexBeginCommand element) {
+        return getRequiredParameters(element.getParameterList());
     }
 
     public static String getName(@NotNull LatexCommands element) {

--- a/src/nl/hannahsten/texifyidea/run/makeindex/MakeindexRunConfiguration.kt
+++ b/src/nl/hannahsten/texifyidea/run/makeindex/MakeindexRunConfiguration.kt
@@ -145,7 +145,7 @@ class MakeindexRunConfiguration(
             LatexCommandsIndex.getItemsInFileSet(mainPsiFile)
                     .filter { it.commandToken.text in PackageUtils.PACKAGE_COMMANDS }
                     .filter { command -> command.requiredParameters.any { it == "imakeidx" } }
-                    .flatMap { it.optionalParameters }
+                    .flatMap { it.optionalParameters.keys }
         }
     }
 
@@ -158,15 +158,8 @@ class MakeindexRunConfiguration(
             val makeindexOptions = HashMap<String, String>()
             LatexCommandsIndex.getItemsInFileSet(mainPsiFile)
                     .filter { it.commandToken.text == "\\makeindex" }
-                    .flatMap { it.optionalParameters }
-                    .map { it.split("=") }
                     .forEach {
-                        if (it.size == 1) {
-                            makeindexOptions[it.first()] = ""
-                        }
-                        else if (it.size == 2) {
-                            makeindexOptions[it.first()] = it.last()
-                        }
+                        makeindexOptions.putAll(it.optionalParameters)
                     }
             makeindexOptions
         }

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexNewCommandPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexNewCommandPresentation.kt
@@ -15,7 +15,7 @@ class LatexNewCommandPresentation(newCommand: LatexCommands) : ItemPresentation 
 
     init {
         // Fetch parameter amount.
-        val optional = newCommand.optionalParameters
+        val optional = newCommand.optionalParameters.keys.toList()
         var params = -1
         if (optional.isNotEmpty()) {
             try {

--- a/src/nl/hannahsten/texifyidea/util/LatexPsiFactory.kt
+++ b/src/nl/hannahsten/texifyidea/util/LatexPsiFactory.kt
@@ -34,14 +34,9 @@ class LatexPsiFactory(private val project: Project) {
     }
 
     fun createUniqueLabelCommandFor(command: LatexEnvironment): PsiElement? {
-        val required = command.beginCommand.requiredParameters
-        if (required.isEmpty()) {
-            return null
-        }
-
         // Determine label name.
         val prefix = Magic.Environment.labeled[command.environmentName]
-        val labelName = required[0].formatAsLabel()
+        val labelName = command.environmentName.formatAsLabel()
         val labelBase = "$prefix:$labelName"
 
         return createUniqueLabelCommand(labelBase, command.containingFile)

--- a/src/nl/hannahsten/texifyidea/util/LatexPsiFactory.kt
+++ b/src/nl/hannahsten/texifyidea/util/LatexPsiFactory.kt
@@ -1,0 +1,66 @@
+package nl.hannahsten.texifyidea.util
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.psi.LatexEnvironment
+
+class LatexPsiFactory(private val project: Project) {
+
+    fun createUniqueLabelFor(command: LatexCommands): PsiElement? {
+        val required = command.requiredParameters
+        if (required.isEmpty()) {
+            return null
+        }
+
+        // Determine label name.
+        val prefix = Magic.Command.labeled[command.name]
+        val labelName = required[0].formatAsLabel()
+        val labelBase = "$prefix:$labelName"
+
+        return createUniqueLabelCommand(labelBase, command.containingFile)
+    }
+
+    fun createUniqueLabelFor(command: LatexEnvironment): PsiElement? {
+        val required = command.beginCommand.requiredParameters
+        if (required.isEmpty()) {
+            return null
+        }
+
+        // Determine label name.
+        val prefix = Magic.Environment.labeled[command.beginCommand.text]
+        val labelName = required[0].formatAsLabel()
+        val labelBase = "$prefix:$labelName"
+
+        return createUniqueLabelCommand(labelBase, command.containingFile)
+    }
+
+    private fun createUniqueLabelCommand(labelBase: String, file: PsiFile): PsiElement {
+        val allLabels = file.findLabelsInFileSet()
+        val createdLabel = appendCounter(labelBase, allLabels)
+        return createLabelCommand(createdLabel)
+    }
+
+    fun createLabelCommand(labelName: String): PsiElement {
+        val labelText = "\\label{$labelName}"
+        val fileFromText = com.intellij.psi.PsiFileFactory.getInstance(project)
+                .createFileFromText("DUMMY.tex", LatexLanguage.INSTANCE, labelText, false, true)
+        return fileFromText.firstChild
+    }
+
+    /**
+     * Keeps adding a counter behind the label until there is no other label with that name.
+     */
+    private fun appendCounter(label: String, allLabels: Set<String>): String {
+        var counter = 2
+        var candidate = label
+
+        while (allLabels.contains(candidate)) {
+            candidate = label + (counter++)
+        }
+
+        return candidate
+    }
+}

--- a/src/nl/hannahsten/texifyidea/util/Magic.kt
+++ b/src/nl/hannahsten/texifyidea/util/Magic.kt
@@ -184,7 +184,8 @@ object Magic {
                 "table", "tab",
                 "tabular", "tab",
                 "equation", "eq",
-                "algorithm", "alg"
+                "algorithm", "alg",
+                "lstlisting", "lst"
         )
 
         /**

--- a/src/nl/hannahsten/texifyidea/util/Magic.kt
+++ b/src/nl/hannahsten/texifyidea/util/Magic.kt
@@ -182,7 +182,6 @@ object Magic {
         val labeled = mapOfVarargs(
                 "figure", "fig",
                 "table", "tab",
-                "tabular", "tab",
                 "equation", "eq",
                 "algorithm", "alg",
                 "lstlisting", "lst"

--- a/src/nl/hannahsten/texifyidea/util/Packages.kt
+++ b/src/nl/hannahsten/texifyidea/util/Packages.kt
@@ -244,10 +244,10 @@ object PackageUtils {
             // Assume packages can be included in both optional and required parameters
             // Except a class, because a class is not a package
             val packages = if (cmd.commandToken.text == "\\documentclass" || cmd.commandToken.text == "\\LoadClass") {
-                setOf(cmd.optionalParameters)
+                setOf(cmd.optionalParameters.keys.toList())
             }
             else {
-                setOf(cmd.requiredParameters, cmd.optionalParameters)
+                setOf(cmd.requiredParameters, cmd.optionalParameters.keys.toList())
             }
 
             for (list in packages) {

--- a/src/nl/hannahsten/texifyidea/util/files/Files.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/Files.kt
@@ -23,9 +23,11 @@ import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.file.StyleFileType
 import nl.hannahsten.texifyidea.index.LatexCommandsIndex
 import nl.hannahsten.texifyidea.index.LatexDefinitionIndex
+import nl.hannahsten.texifyidea.index.LatexEnvironmentsIndex
 import nl.hannahsten.texifyidea.index.LatexIncludesIndex
 import nl.hannahsten.texifyidea.lang.Package
 import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.psi.LatexEnvironment
 import nl.hannahsten.texifyidea.run.latex.LatexRunConfiguration
 import nl.hannahsten.texifyidea.util.*
 import java.io.File
@@ -408,6 +410,11 @@ fun PsiFile.document(): Document? = PsiDocumentManager.getInstance(project).getD
  * @see [LatexCommandsIndex.getItems]
  */
 fun PsiFile.commandsInFile(): Collection<LatexCommands> = LatexCommandsIndex.getItems(this)
+
+/**
+ * @see [LatexEnvironmentsIndex.getItems]
+ */
+fun PsiFile.environmentsInFile(): Collection<LatexEnvironment> = LatexEnvironmentsIndex.getItems(this)
 
 /**
  * Get the editor of the file if it is currently opened.

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LabelMissingInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LabelMissingInspectionTest.kt
@@ -1,0 +1,24 @@
+package nl.hannahsten.texifyidea.inspections.latex
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl
+import org.junit.Test
+
+class GrazieInspectionTest : BasePlatformTestCase() {
+    override fun getTestDataPath(): String {
+        return "testData/inspections/latex"
+    }
+
+    override fun setUp() {
+        super.setUp()
+        myFixture.enableInspections(LatexMissingLabelInspection())
+        (myFixture as? CodeInsightTestFixtureImpl)?.canChangeDocumentDuringHighlighting(true)
+    }
+
+    @Test
+    fun testMissingLabelWarnings() {
+        val testName = getTestName(false)
+        myFixture.configureByFile("$testName.tex")
+        myFixture.checkHighlighting(false, false, true, false)
+    }
+}

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LabelMissingInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LabelMissingInspectionTest.kt
@@ -2,6 +2,7 @@ package nl.hannahsten.texifyidea.inspections.latex
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl
+import nl.hannahsten.texifyidea.testutils.writeCommand
 import org.junit.Test
 
 class GrazieInspectionTest : BasePlatformTestCase() {
@@ -20,5 +21,20 @@ class GrazieInspectionTest : BasePlatformTestCase() {
         val testName = getTestName(false)
         myFixture.configureByFile("$testName.tex")
         myFixture.checkHighlighting(false, false, true, false)
+    }
+
+    @Test
+    fun testInsertCommandLabelQuickFix() {
+        val testName = getTestName(false)
+        myFixture.configureByFile("${testName}_before.tex")
+        do {
+            // we need to collect the fixes again after applying a fix because otherwise
+            // the problem descriptors use a cached element from before the applying the fix
+            val fix = myFixture.getAllQuickFixes().firstOrNull()
+            writeCommand(myFixture.project) {
+                fix?.invoke(myFixture.project, myFixture.editor, myFixture.file)
+            }
+        } while (fix != null)
+        myFixture.checkResultByFile("${testName}_after.tex")
     }
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LabelMissingInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LabelMissingInspectionTest.kt
@@ -5,7 +5,7 @@ import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl
 import nl.hannahsten.texifyidea.testutils.writeCommand
 import org.junit.Test
 
-class GrazieInspectionTest : BasePlatformTestCase() {
+class LabelMissingInspectionTest : BasePlatformTestCase() {
     override fun getTestDataPath(): String {
         return "testData/inspections/latex"
     }
@@ -30,7 +30,8 @@ class GrazieInspectionTest : BasePlatformTestCase() {
         do {
             // we need to collect the fixes again after applying a fix because otherwise
             // the problem descriptors use a cached element from before the applying the fix
-            val fix = myFixture.getAllQuickFixes().firstOrNull()
+            val allQuickFixes = myFixture.getAllQuickFixes()
+            val fix = allQuickFixes.firstOrNull()
             writeCommand(myFixture.project) {
                 fix?.invoke(myFixture.project, myFixture.editor, myFixture.file)
             }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LabelMissingInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LabelMissingInspectionTest.kt
@@ -1,7 +1,6 @@
 package nl.hannahsten.texifyidea.inspections.latex
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl
 import nl.hannahsten.texifyidea.testutils.writeCommand
 import org.junit.Test
 
@@ -13,7 +12,6 @@ class LabelMissingInspectionTest : BasePlatformTestCase() {
     override fun setUp() {
         super.setUp()
         myFixture.enableInspections(LatexMissingLabelInspection())
-        (myFixture as? CodeInsightTestFixtureImpl)?.canChangeDocumentDuringHighlighting(true)
     }
 
     @Test

--- a/test/nl/hannahsten/texifyidea/psi/LatexPsiImplUtilTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/LatexPsiImplUtilTest.kt
@@ -1,0 +1,29 @@
+package nl.hannahsten.texifyidea.psi
+
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import nl.hannahsten.texifyidea.util.firstChildOfType
+import org.junit.Test
+
+class LatexPsiImplUtilTest : BasePlatformTestCase() {
+    override fun getTestDataPath(): String {
+        return "testData/psi"
+    }
+
+    @Test
+    fun testOptionalParameterSplitting() {
+        // given
+        val testName = getTestName(false)
+        myFixture.configureByFiles("$testName.tex")
+
+        // when
+        val psiFile = PsiDocumentManager.getInstance(myFixture.project).getPsiFile(myFixture.editor.document)!!
+        val element = psiFile.children.first().firstChildOfType(LatexCommands::class)!!
+        val optionalParameters = element.optionalParameters
+
+        // then
+        assertEquals(optionalParameters[0], "backend")
+        assertEquals(optionalParameters[1], "style")
+        assertEquals(optionalParameters[2], "optionwithoutvalue")
+    }
+}

--- a/test/nl/hannahsten/texifyidea/psi/LatexPsiImplUtilTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/LatexPsiImplUtilTest.kt
@@ -13,8 +13,7 @@ class LatexPsiImplUtilTest : BasePlatformTestCase() {
     @Test
     fun testOptionalParameterSplitting() {
         // given
-        val testName = getTestName(false)
-        myFixture.configureByFiles("$testName.tex")
+        myFixture.configureByFiles("OptionalParameters.tex")
 
         // when
         val psiFile = PsiDocumentManager.getInstance(myFixture.project).getPsiFile(myFixture.editor.document)!!
@@ -22,8 +21,24 @@ class LatexPsiImplUtilTest : BasePlatformTestCase() {
         val optionalParameters = element.optionalParameters
 
         // then
-        assertEquals(optionalParameters[0], "backend")
-        assertEquals(optionalParameters[1], "style")
-        assertEquals(optionalParameters[2], "optionwithoutvalue")
+        assertEquals("biber", optionalParameters["backend"])
+        assertEquals("alphabetic order", optionalParameters["style"])
+        assertEquals("", optionalParameters["optionwithoutvalue"])
+    }
+
+    @Test
+    fun testOptionalParameterNameOrder() {
+        // given
+        myFixture.configureByFiles("OptionalParameters.tex")
+
+        // when
+        val psiFile = PsiDocumentManager.getInstance(myFixture.project).getPsiFile(myFixture.editor.document)!!
+        val element = psiFile.children.first().firstChildOfType(LatexCommands::class)!!
+        val optionalParameters = element.optionalParameters.keys.toList()
+
+        // then
+        assertEquals("backend", optionalParameters[0])
+        assertEquals("style", optionalParameters[1])
+        assertEquals("optionwithoutvalue", optionalParameters[2])
     }
 }

--- a/test/nl/hannahsten/texifyidea/testutils/Common.kt
+++ b/test/nl/hannahsten/texifyidea/testutils/Common.kt
@@ -1,0 +1,17 @@
+package nl.hannahsten.texifyidea.testutils
+
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.project.Project
+
+/**
+ * Execute the given action as write command.
+ * Can be used e.g. for running inspection QuickFixes
+ *
+ * @see WriteCommandAction
+ * @see WriteCommandAction.Simple
+ */
+fun <T> writeCommand(project: Project, action: () -> T) {
+    WriteCommandAction.writeCommandAction(project).compute<T, Exception> {
+        action.invoke()
+    }
+}

--- a/testData/inspections/latex/InsertCommandLabelQuickFix_after.tex
+++ b/testData/inspections/latex/InsertCommandLabelQuickFix_after.tex
@@ -1,7 +1,10 @@
 \documentclass{article}
 \begin{document}
     \chapter{Chapter without label}\label{ch:chapter-without-label}
+
+
     \section{Section without label}\label{sec:section-without-label}
+
     \subsection{Subsection without label}\label{subsec:subsection-without-label}
 
 \end{document}

--- a/testData/inspections/latex/InsertCommandLabelQuickFix_after.tex
+++ b/testData/inspections/latex/InsertCommandLabelQuickFix_after.tex
@@ -1,0 +1,7 @@
+\documentclass{article}
+\begin{document}
+    \chapter{Chapter without label}\label{ch:chapter-without-label}
+    \section{Section without label}\label{sec:section-without-label}
+    \subsection{Subsection without label}\label{subsec:subsection-without-label}
+
+\end{document}

--- a/testData/inspections/latex/InsertCommandLabelQuickFix_after.tex
+++ b/testData/inspections/latex/InsertCommandLabelQuickFix_after.tex
@@ -6,5 +6,11 @@
     \section{Section without label}\label{sec:section-without-label}
 
     \subsection{Subsection without label}\label{subsec:subsection-without-label}
+    \begin{figure}
+        \caption{Some Caption}\label{fig:figure}
+    \end{figure}
+    \begin{figure}
+        \label{fig:figure2}
 
+    \end{figure}
 \end{document}

--- a/testData/inspections/latex/InsertCommandLabelQuickFix_before.tex
+++ b/testData/inspections/latex/InsertCommandLabelQuickFix_before.tex
@@ -1,0 +1,7 @@
+\documentclass{article}
+\begin{document}
+    \chapter{Chapter without label}
+    \section{Section without label}
+    \subsection{Subsection without label}
+
+\end{document}

--- a/testData/inspections/latex/InsertCommandLabelQuickFix_before.tex
+++ b/testData/inspections/latex/InsertCommandLabelQuickFix_before.tex
@@ -3,5 +3,10 @@
     \chapter{Chapter without label}
     \section{Section without label}
     \subsection{Subsection without label}
+    \begin{figure}
+        \caption{Some Caption}
+    \end{figure}
+    \begin{figure}
 
+    \end{figure}
 \end{document}

--- a/testData/inspections/latex/MissingLabelWarnings.tex
+++ b/testData/inspections/latex/MissingLabelWarnings.tex
@@ -32,16 +32,4 @@
         \caption{Some text \label{fig:figure-caption-label}}
     \end{figure}
 
-    <weak_warning descr="Missing label">\begin{lstlisting}
-                                            Listing without label
-    \end{lstlisting}</weak_warning>
-
-    \begin{lstlisting}[label={lst:listing-label}, caption={Some caption}]
-        Listing with label
-    \end{lstlisting}
-
-    \begin{lstlisting}[label=labelwithoutgroup]
-        Listing with label
-    \end{lstlisting}
-
 \end{document}

--- a/testData/inspections/latex/MissingLabelWarnings.tex
+++ b/testData/inspections/latex/MissingLabelWarnings.tex
@@ -1,0 +1,42 @@
+\documentclass{article}
+\usepackage{listings}
+
+\begin{document}
+    <weak_warning descr="Missing label">\chapter{Chapter without label}</weak_warning>
+    \chapter*{Star chapter has no label}
+    <weak_warning descr="Missing label">\section{Section without label}</weak_warning>
+    \section*{Star section has no label}
+    <weak_warning descr="Missing label">\subsection{Subsection without label}</weak_warning>
+    \subsection*{Star subsection has no label}
+    \begin{enumerate}
+        \item Item without label
+    \end{enumerate}
+    \chapter{Chapter with label}
+    \label{ch:chapter-label}
+    \section{Section with label}
+    \label{sec:section-label}
+    \subsection{Subsection with label}
+    \label{subsec:subsection-label}
+
+    % figure without label
+    <weak_warning descr="Missing label">\begin{figure}
+    \end{figure}</weak_warning>
+
+    % figure with label
+    \begin{figure}
+        \label{fig:figure-label}
+    \end{figure}
+
+    <weak_warning descr="Missing label">\begin{lstlisting}
+                                            Listing without label
+    \end{lstlisting}</weak_warning>
+
+    \begin{lstlisting}[label={lst:listing-label}, caption={Some caption}]
+        Listing with label
+    \end{lstlisting}
+
+    \begin{lstlisting}[label=labelwithoutgroup]
+        Listing with label
+    \end{lstlisting}
+
+\end{document}

--- a/testData/inspections/latex/MissingLabelWarnings.tex
+++ b/testData/inspections/latex/MissingLabelWarnings.tex
@@ -27,6 +27,11 @@
         \label{fig:figure-label}
     \end{figure}
 
+    % figure with label in caption
+    \begin{figure}
+        \caption{Some text \label{fig:figure-caption-label}}
+    \end{figure}
+
     <weak_warning descr="Missing label">\begin{lstlisting}
                                             Listing without label
     \end{lstlisting}</weak_warning>

--- a/testData/psi/OptionalParameterSplitting.tex
+++ b/testData/psi/OptionalParameterSplitting.tex
@@ -1,1 +1,0 @@
-\usepackage[backend=biber,style={alphabetic},optionwithoutvalue]{biblatex}

--- a/testData/psi/OptionalParameterSplitting.tex
+++ b/testData/psi/OptionalParameterSplitting.tex
@@ -1,0 +1,1 @@
+\usepackage[backend=biber,style={alphabetic},optionwithoutvalue]{biblatex}

--- a/testData/psi/OptionalParameters.tex
+++ b/testData/psi/OptionalParameters.tex
@@ -1,0 +1,1 @@
+\usepackage[backend=biber,style={alphabetic order},optionwithoutvalue]{biblatex}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fixes #874 

#### Summary of additions and changes

* Implements the missing label inspection + fix for environments (including figures), except for lstlistings
* Change the existing quickfix to modify the PSI tree instead of text insertion. Unfortunately this automatically applies code formatting. If this is unwanted, I can look into ways of preventing it.
* Fix the getName implementation of LatexCommands to use the stub if available and the commandName otherwise
* Fix the getOptionalParameters implementation of LatexCommands to adhere to the javadoc

Lstlistings are a special case because they have the label specified as an option. I will fix lstlistings in a separate pull request because this one is already quite big.

#### How to test this pull request

* Add a figure without a label and apply the suggested quickfix
* With the included testcases

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Conventions#Missing-labels