### PR TITLE
added \ifoot to ignoredIfs to prevent error on default-footer change

### DIFF
--- a/src/nl/hannahsten/texifyidea/util/Magic.kt
+++ b/src/nl/hannahsten/texifyidea/util/Magic.kt
@@ -409,7 +409,7 @@ object Magic {
          * All commands that at first glance look like \if-esque commands, but that actually aren't.
          */
         @JvmField
-        val ignoredIfs = hashSetOf("\\newif", "\\iff", "\\ifthenelse", "\\iftoggle")
+        val ignoredIfs = hashSetOf("\\newif", "\\iff", "\\ifthenelse", "\\iftoggle", "\\ifoot")
 
         /**
          * List of all TeX style primitives.


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fixes #1219

#### Summary of additions and changes

* \ifoot was assumed as if condition start but should be ignored. 

#### How to test this pull request

* I tested in Sandbox and it worked. 

Tested with:
IntelliJ IDEA 2019.3.2 (Ultimate Edition)
Build #IU-193.6015.39, built on January 21, 2020

Operating System:
Fedora 31 x64
Kernel: 5.4.13-201.fc31.x86_64