### PR TITLE
Add backspace handler to delete empty inline math

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -418,6 +418,7 @@
         <backspaceHandlerDelegate implementation="nl.hannahsten.texifyidea.editor.autocompile.ContinuousPreviewBackspacehandler"/>
         <typedHandler implementation="nl.hannahsten.texifyidea.editor.autocompile.AutocompileHandler"/>
         <backspaceHandlerDelegate implementation="nl.hannahsten.texifyidea.editor.autocompile.AutoCompileBackspacehandler"/>
+        <backspaceHandlerDelegate implementation="nl.hannahsten.texifyidea.editor.InlineMathBackspaceHandler" />
 
         <!-- Navigation -->
         <gotoSymbolContributor implementation="nl.hannahsten.texifyidea.navigation.GotoLabelSymbolContributor"/>

--- a/src/nl/hannahsten/texifyidea/editor/InlineMathBackspaceHandler.kt
+++ b/src/nl/hannahsten/texifyidea/editor/InlineMathBackspaceHandler.kt
@@ -1,0 +1,23 @@
+package nl.hannahsten.texifyidea.editor
+
+import com.intellij.codeInsight.editorActions.BackspaceHandlerDelegate
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiFile
+import nl.hannahsten.texifyidea.util.caretOffset
+import nl.hannahsten.texifyidea.util.files.document
+import nl.hannahsten.texifyidea.util.get
+
+class InlineMathBackspaceHandler : BackspaceHandlerDelegate() {
+    override fun beforeCharDeleted(c: Char, file: PsiFile, editor: Editor) {
+        if (c == '$') {
+            val offset = editor.caretOffset()
+            if (file.document()?.get(offset) == "$") {
+                file.document()?.deleteString(offset, offset + 1)
+            }
+        }
+    }
+
+    override fun charDeleted(c: Char, file: PsiFile, editor: Editor): Boolean {
+        return true
+    }
+}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fixes #1206

#### Summary of additions and changes

* Hardcode removal of second $ when the first one of $$ is removed. Given how much I type $$ and then realise I don't want math after all, a definite typing experience improvement.

#### How to test this pull request

* Type `$`, possibly some more, then use backspace to remove all of that.

#### Wiki
nah
<!-- Add link to updated wiki page -->
: