### PR TITLE
Use ctrl+enter to break line in itemize

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -418,6 +418,7 @@
         <backspaceHandlerDelegate implementation="nl.hannahsten.texifyidea.editor.autocompile.ContinuousPreviewBackspacehandler"/>
         <typedHandler implementation="nl.hannahsten.texifyidea.editor.autocompile.AutocompileHandler"/>
         <backspaceHandlerDelegate implementation="nl.hannahsten.texifyidea.editor.autocompile.AutoCompileBackspacehandler"/>
+        <backspaceHandlerDelegate implementation="nl.hannahsten.texifyidea.editor.InlineMathBackspaceHandler" />
 
         <!-- Navigation -->
         <gotoSymbolContributor implementation="nl.hannahsten.texifyidea.navigation.GotoLabelSymbolContributor"/>

--- a/src/nl/hannahsten/texifyidea/editor/ControlTracker.kt
+++ b/src/nl/hannahsten/texifyidea/editor/ControlTracker.kt
@@ -1,0 +1,63 @@
+package nl.hannahsten.texifyidea.editor
+
+import com.intellij.codeInsight.editorActions.TypedHandlerDelegate
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import java.awt.event.KeyEvent
+import java.awt.event.KeyListener
+import javax.swing.JComponent
+
+/**
+ * Tracks the control key.
+ *
+ * @see ShiftTracker
+ */
+object ControlTracker : KeyListener, TypedHandlerDelegate() {
+
+    /**
+     * `true` if the control key is pressed, `false` if the control key is not pressed.
+     */
+    var isControlPressed = false
+        private set
+
+    /**
+     * Set of all components that have been tracked.
+     */
+    private var registered: MutableSet<JComponent> = HashSet()
+
+    /**
+     * Setsup the control tracker.
+     */
+    @JvmStatic
+    fun setup(component: JComponent) {
+        if (registered.contains(component)) {
+            return
+        }
+
+        component.addKeyListener(this)
+        registered.add(component)
+    }
+
+    override fun beforeCharTyped(c: Char, project: Project, editor: Editor, file: PsiFile, fileType: FileType): Result {
+        setup(editor.contentComponent)
+        return super.beforeCharTyped(c, project, editor, file, fileType)
+    }
+
+    override fun keyTyped(e: KeyEvent?) {
+        // Do nothing.
+    }
+
+    override fun keyPressed(e: KeyEvent?) {
+        if (e?.keyCode == KeyEvent.VK_CONTROL) {
+            isControlPressed = true
+        }
+    }
+
+    override fun keyReleased(e: KeyEvent?) {
+        if (e?.keyCode == KeyEvent.VK_CONTROL) {
+            isControlPressed = false
+        }
+    }
+}

--- a/src/nl/hannahsten/texifyidea/editor/ControlTracker.kt
+++ b/src/nl/hannahsten/texifyidea/editor/ControlTracker.kt
@@ -28,7 +28,7 @@ object ControlTracker : KeyListener, TypedHandlerDelegate() {
     private var registered: MutableSet<JComponent> = HashSet()
 
     /**
-     * Setsup the control tracker.
+     * Set up the control tracker.
      */
     @JvmStatic
     fun setup(component: JComponent) {

--- a/src/nl/hannahsten/texifyidea/editor/InlineMathBackspaceHandler.kt
+++ b/src/nl/hannahsten/texifyidea/editor/InlineMathBackspaceHandler.kt
@@ -1,0 +1,23 @@
+package nl.hannahsten.texifyidea.editor
+
+import com.intellij.codeInsight.editorActions.BackspaceHandlerDelegate
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiFile
+import nl.hannahsten.texifyidea.util.caretOffset
+import nl.hannahsten.texifyidea.util.files.document
+import nl.hannahsten.texifyidea.util.get
+
+class InlineMathBackspaceHandler : BackspaceHandlerDelegate() {
+    override fun beforeCharDeleted(c: Char, file: PsiFile, editor: Editor) {
+        if (c == '$') {
+            val offset = editor.caretOffset()
+            if (file.document()?.get(offset) == "$") {
+                file.document()?.deleteString(offset, offset + 1)
+            }
+        }
+    }
+
+    override fun charDeleted(c: Char, file: PsiFile, editor: Editor): Boolean {
+        return true
+    }
+}

--- a/src/nl/hannahsten/texifyidea/editor/InsertEnumerationItem.kt
+++ b/src/nl/hannahsten/texifyidea/editor/InsertEnumerationItem.kt
@@ -23,15 +23,22 @@ class InsertEnumerationItem : EnterHandlerDelegate {
 
     override fun postProcessEnter(file: PsiFile, editor: Editor,
                                   context: DataContext): Result {
-        ShiftTracker.setup(editor.contentComponent)
         if (file.fileType != LatexFileType) {
             return Result.Continue
         }
+
+        ShiftTracker.setup(editor.contentComponent)
+        ControlTracker.setup(editor.contentComponent)
 
         val caret = editor.caretModel
         val element = file.findElementAt(caret.offset)
         if (hasValidContext(element)) {
             editor.insertAndMove(caret.offset, getInsertionString(element!!))
+        }
+        else {
+            if (ControlTracker.isControlPressed) {
+                editor.insertAndMove(caret.offset, "")
+            }
         }
 
         return Result.Continue
@@ -111,7 +118,7 @@ class InsertEnumerationItem : EnterHandlerDelegate {
      * @return `true` insertion desired, `false` insertion not desired or element is `null`.
      */
     private fun hasValidContext(element: PsiElement?): Boolean {
-        if (!TexifySettings.getInstance().automaticItemInItemize || element == null || ShiftTracker.isShiftPressed() || element.inMathContext()) {
+        if (!TexifySettings.getInstance().automaticItemInItemize || element == null || ShiftTracker.isShiftPressed() || ControlTracker.isControlPressed || element.inMathContext()) {
             return false
         }
 

--- a/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/PdfViewer.kt
+++ b/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/PdfViewer.kt
@@ -5,6 +5,7 @@ import nl.hannahsten.texifyidea.run.linuxpdfviewer.evince.EvinceConversation
 import nl.hannahsten.texifyidea.run.linuxpdfviewer.okular.OkularConversation
 import nl.hannahsten.texifyidea.run.linuxpdfviewer.skim.SkimConversation
 import nl.hannahsten.texifyidea.run.sumatra.isSumatraAvailable
+import nl.hannahsten.texifyidea.util.runCommand
 
 /**
  * List of supported PDF viewers on Linux.

--- a/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/ViewerConversation.kt
+++ b/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/ViewerConversation.kt
@@ -1,31 +1,7 @@
 package nl.hannahsten.texifyidea.run.linuxpdfviewer
 
 import com.intellij.openapi.project.Project
-import java.io.IOException
-import java.util.concurrent.TimeUnit
 
 abstract class ViewerConversation {
     abstract fun forwardSearch(pdfPath: String?, sourceFilePath: String, line: Int, project: Project, focusAllowed: Boolean)
-}
-
-/**
- * Run a command in the terminal.
- *
- * @return The output of the command or null if an exception was thrown.
- */
-fun String.runCommand(): String? {
-    return try {
-        val parts = this.split("\\s".toRegex())
-        val proc = ProcessBuilder(*parts.toTypedArray())
-                .redirectOutput(ProcessBuilder.Redirect.PIPE)
-                .redirectError(ProcessBuilder.Redirect.PIPE)
-                .start()
-
-        // Timeout value
-        proc.waitFor(10, TimeUnit.SECONDS)
-        proc.inputStream.bufferedReader().readText() + proc.errorStream.bufferedReader().readText()
-    } catch (e: IOException) {
-        e.printStackTrace()
-        null
-    }
 }

--- a/src/nl/hannahsten/texifyidea/startup/StartEvinceInverseSearchListener.kt
+++ b/src/nl/hannahsten/texifyidea/startup/StartEvinceInverseSearchListener.kt
@@ -15,7 +15,7 @@ class StartEvinceInverseSearchListener : StartupActivity, DumbAware {
 
     override fun runActivity(project: Project) {
         if (SystemInfo.isLinux && TexifySettings.getInstance().pdfViewer == PdfViewer.EVINCE) {
-            EvinceInverseSearchListener().start()
+            EvinceInverseSearchListener().start(project)
         }
     }
 }

--- a/src/nl/hannahsten/texifyidea/util/Strings.kt
+++ b/src/nl/hannahsten/texifyidea/util/Strings.kt
@@ -1,6 +1,8 @@
 package nl.hannahsten.texifyidea.util
 
 import org.intellij.lang.annotations.Language
+import java.io.IOException
+import java.util.concurrent.TimeUnit
 
 /**
  * Capitalises the first character of the string.
@@ -178,3 +180,25 @@ fun String.splitWhitespace() = split(Regex("\\s+"))
  * @see [Magic.Pattern.htmlTag]
  */
 fun String.removeHtmlTags() = this.replace(Magic.Pattern.htmlTag.toRegex(), "")
+
+/**
+ * Run a command in the terminal.
+ *
+ * @return The output of the command or null if an exception was thrown.
+ */
+fun String.runCommand(): String? {
+    return try {
+        val parts = this.split("\\s".toRegex())
+        val proc = ProcessBuilder(*parts.toTypedArray())
+                .redirectOutput(ProcessBuilder.Redirect.PIPE)
+                .redirectError(ProcessBuilder.Redirect.PIPE)
+                .start()
+
+        // Timeout value
+        proc.waitFor(10, TimeUnit.SECONDS)
+        proc.inputStream.bufferedReader().readText() + proc.errorStream.bufferedReader().readText()
+    } catch (e: IOException) {
+        e.printStackTrace()
+        null
+    }
+}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fixes #262

#### Summary of additions and changes

* Now you can split a line while in an itemize, by using Ctrl+Enter.
Shift+Enter is already in use by IntelliJ as 'create new line', so to keep things consistent we hijacked Ctrl+Enter instead.

#### How to test this pull request

* Try using enter/shift+enter/ctrl+enter in itemize-like environments

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Item-insertion