### PR TITLE
Environment injectable

### DIFF
--- a/gen/nl/hannahsten/texifyidea/psi/LatexCommands.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexCommands.java
@@ -1,15 +1,14 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi;
 
+import java.util.List;
+import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiNameIdentifierOwner;
-import com.intellij.psi.PsiReference;
 import com.intellij.psi.StubBasedPsiElement;
 import nl.hannahsten.texifyidea.index.stub.LatexCommandsStub;
-import org.jetbrains.annotations.NotNull;
-
+import com.intellij.psi.PsiReference;
 import java.util.LinkedHashMap;
-import java.util.List;
 
 public interface LatexCommands extends PsiNameIdentifierOwner, StubBasedPsiElement<LatexCommandsStub> {
 

--- a/gen/nl/hannahsten/texifyidea/psi/LatexEnvironment.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexEnvironment.java
@@ -1,13 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi;
 
+import java.util.List;
+import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLanguageInjectionHost;
 import com.intellij.psi.StubBasedPsiElement;
 import nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStub;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import com.intellij.psi.LiteralTextEscaper;
 
-public interface LatexEnvironment extends PsiElement, StubBasedPsiElement<LatexEnvironmentStub> {
+public interface LatexEnvironment extends PsiLanguageInjectionHost, StubBasedPsiElement<LatexEnvironmentStub> {
 
   @NotNull
   LatexBeginCommand getBeginCommand();
@@ -21,5 +23,12 @@ public interface LatexEnvironment extends PsiElement, StubBasedPsiElement<LatexE
   String getEnvironmentName();
 
   String getLabel();
+
+  boolean isValidHost();
+
+  PsiLanguageInjectionHost updateText(@NotNull String text);
+
+  @NotNull
+  LiteralTextEscaper<LatexEnvironment> createLiteralTextEscaper();
 
 }

--- a/gen/nl/hannahsten/texifyidea/psi/LatexVisitor.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexVisitor.java
@@ -4,6 +4,7 @@ package nl.hannahsten.texifyidea.psi;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLanguageInjectionHost;
 import com.intellij.psi.PsiNameIdentifierOwner;
 
 public class LatexVisitor extends PsiElementVisitor {
@@ -33,7 +34,7 @@ public class LatexVisitor extends PsiElementVisitor {
   }
 
   public void visitEnvironment(@NotNull LatexEnvironment o) {
-    visitPsiElement(o);
+    visitPsiLanguageInjectionHost(o);
   }
 
   public void visitEnvironmentContent(@NotNull LatexEnvironmentContent o) {
@@ -78,6 +79,10 @@ public class LatexVisitor extends PsiElementVisitor {
 
   public void visitRequiredParam(@NotNull LatexRequiredParam o) {
     visitPsiElement(o);
+  }
+
+  public void visitPsiLanguageInjectionHost(@NotNull PsiLanguageInjectionHost o) {
+    visitElement(o);
   }
 
   public void visitPsiNameIdentifierOwner(@NotNull PsiNameIdentifierOwner o) {

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexBeginCommandImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexBeginCommandImpl.java
@@ -1,18 +1,16 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi.impl;
 
-import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import java.util.List;
+import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import nl.hannahsten.texifyidea.psi.LatexBeginCommand;
-import nl.hannahsten.texifyidea.psi.LatexParameter;
-import nl.hannahsten.texifyidea.psi.LatexPsiImplUtil;
-import nl.hannahsten.texifyidea.psi.LatexVisitor;
-import org.jetbrains.annotations.NotNull;
-
+import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import nl.hannahsten.texifyidea.psi.*;
 import java.util.LinkedHashMap;
-import java.util.List;
 
 public class LatexBeginCommandImpl extends ASTWrapperPsiElement implements LatexBeginCommand {
 

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexCommandsImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexCommandsImpl.java
@@ -1,21 +1,20 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi.impl;
 
+import java.util.List;
+import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
+import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
+import nl.hannahsten.texifyidea.psi.LatexCommandsImplMixin;
+import nl.hannahsten.texifyidea.psi.*;
 import com.intellij.psi.PsiReference;
+import java.util.LinkedHashMap;
+import nl.hannahsten.texifyidea.index.stub.LatexCommandsStub;
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.tree.IElementType;
-import com.intellij.psi.util.PsiTreeUtil;
-import nl.hannahsten.texifyidea.index.stub.LatexCommandsStub;
-import nl.hannahsten.texifyidea.psi.*;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.LinkedHashMap;
-import java.util.List;
-
-import static nl.hannahsten.texifyidea.psi.LatexTypes.COMMAND_TOKEN;
 
 public class LatexCommandsImpl extends LatexCommandsImplMixin implements LatexCommands {
 

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexEnvironmentImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexEnvironmentImpl.java
@@ -11,6 +11,8 @@ import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
 import com.intellij.extapi.psi.StubBasedPsiElementBase;
 import nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStub;
 import nl.hannahsten.texifyidea.psi.*;
+import com.intellij.psi.LiteralTextEscaper;
+import com.intellij.psi.PsiLanguageInjectionHost;
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.tree.IElementType;
 
@@ -63,6 +65,22 @@ public class LatexEnvironmentImpl extends StubBasedPsiElementBase<LatexEnvironme
   @Override
   public String getLabel() {
     return LatexPsiImplUtil.getLabel(this);
+  }
+
+  @Override
+  public boolean isValidHost() {
+    return LatexPsiImplUtil.isValidHost(this);
+  }
+
+  @Override
+  public PsiLanguageInjectionHost updateText(@NotNull String text) {
+    return LatexPsiImplUtil.updateText(this, text);
+  }
+
+  @Override
+  @NotNull
+  public LiteralTextEscaper<LatexEnvironment> createLiteralTextEscaper() {
+    return LatexPsiImplUtil.createLiteralTextEscaper(this);
   }
 
 }

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -589,6 +589,11 @@
                          groupName="LaTeX" displayName="Package could not be found"
                          enabledByDefault="true"/>
 
+        <!-- Element manipulator -->
+        <lang.elementManipulator forClass="nl.hannahsten.texifyidea.psi.impl.LatexEnvironmentImpl"
+                                 implementationClass="nl.hannahsten.texifyidea.psi.LatexEnvironmentManipulator"/>
+
+
         <!-- Bibtex inspections -->
         <localInspection language="Bibtex" implementationClass="nl.hannahsten.texifyidea.inspections.bibtex.BibtexDuplicateIdInspection"
                          groupName="BibTeX" displayName="Duplicate ID"

--- a/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
+++ b/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
@@ -17,6 +17,7 @@
     implements("commands")="com.intellij.psi.PsiNameIdentifierOwner"
 
     extends("environment")="com.intellij.extapi.psi.StubBasedPsiElementBase<nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStub>"
+    implements("environment")="com.intellij.psi.PsiLanguageInjectionHost"
 
     tokens=[
         WHITE_SPACE='regexp:\s+'
@@ -47,7 +48,7 @@ environment ::= begin_command environment_content? end_command {
     pin=1
     elementTypeClass="nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStubElementType"
     stubClass="nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStub"
-    methods=[getEnvironmentName getLabel]
+    methods=[getEnvironmentName getLabel isValidHost updateText createLiteralTextEscaper]
  }
 
 environment_content ::= content+

--- a/src/nl/hannahsten/texifyidea/psi/LatexEnvironmentManipulator.kt
+++ b/src/nl/hannahsten/texifyidea/psi/LatexEnvironmentManipulator.kt
@@ -1,0 +1,30 @@
+package nl.hannahsten.texifyidea.psi
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.AbstractElementManipulator
+import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.util.PsiTreeUtil
+import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.psi.impl.LatexEnvironmentImpl
+
+class LatexEnvironmentManipulator : AbstractElementManipulator<LatexEnvironmentImpl>() {
+
+  override fun handleContentChange(element: LatexEnvironmentImpl,
+                                   range: TextRange,
+                                   newContent: String): LatexEnvironmentImpl? {
+    val oldText = element.text
+    val newText = oldText.substring(0, range.startOffset) +
+        newContent +
+        oldText.substring(range.endOffset)
+    val file = PsiFileFactory.getInstance(element.project)
+        .createFileFromText("temp.tex", LatexLanguage.INSTANCE, newText)
+    val res =
+        PsiTreeUtil.findChildOfType(file, LatexEnvironmentImpl::class.java) ?: return null
+    element.replace(res)
+    return element
+  }
+
+}
+
+
+

--- a/src/nl/hannahsten/texifyidea/psi/LatexPsiImplUtil.java
+++ b/src/nl/hannahsten/texifyidea/psi/LatexPsiImplUtil.java
@@ -1,7 +1,6 @@
 package nl.hannahsten.texifyidea.psi;
 
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiReference;
+import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTreeUtil;
 import nl.hannahsten.texifyidea.index.stub.LatexCommandsStub;
 import nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStub;
@@ -188,4 +187,20 @@ public class LatexPsiImplUtil {
 
         return paramText.getText();
     }
+
+
+    public static boolean isValidHost(@NotNull LatexEnvironment element) {
+        return true;
+    }
+
+    public static PsiLanguageInjectionHost updateText(@NotNull LatexEnvironment element, @NotNull String text) {
+        return ElementManipulators.handleContentChange(element, text);
+    }
+
+    @NotNull
+    public static LiteralTextEscaper<LatexEnvironment> createLiteralTextEscaper(@NotNull LatexEnvironment element) {
+        return LiteralTextEscaper.createSimple(element);
+    }
+
+
 }


### PR DESCRIPTION

#### Summary of additions and changes

* Make the LatexEnvironment element injectable by implementing 

That way, people can write plugin to support literate programming by inject their language inside, e.g:
```latex
\begin{code}[javascript]
let a = [1, 2, 3].filter(x => x > 2).sort();
console.log("hello world");
\end{code}
```
Screenshot when I inject Haskell to support https://wiki.haskell.org/Literate_programming:
![image](https://user-images.githubusercontent.com/10379980/74283952-db1a0900-4cf0-11ea-9de0-61a48d821e66.png)



#### How to test this pull request

* Make a new plugin that have Texify-IDEA as depdendency
* Inject your language to LatexEnvironment node, e.g:
```kotlin
class HaskellInjector : LanguageInjector {
  override fun getLanguagesToInject(host: PsiLanguageInjectionHost, injectionPlacesRegistrar: InjectedLanguagePlaces) {
    when (host) {
      is LatexEnvironmentImpl -> {
        if (host.environmentName != "code") return
        val begin = host.beginCommand.startOffsetInParent + host.beginCommand.textLength + 1
        val end = host.endCommand?.startOffsetInParent ?: host.textLength
        injectionPlacesRegistrar.addPlace(HaskellLanguage.Instance, TextRange.create(begin, end), "", "")
      }
      else -> return
    }
  }

}

```

P/S: Why don't we ignore `gen` directory?