### PR TITLE
Fix #1259 by trimming optional parameters

### DIFF
--- a/src/nl/hannahsten/texifyidea/psi/LatexCommandsImplUtil.kt
+++ b/src/nl/hannahsten/texifyidea/psi/LatexCommandsImplUtil.kt
@@ -97,7 +97,7 @@ fun getOptionalParameters(parameters: List<LatexParameter>): LinkedHashMap<Strin
     if (parameterString.trim { it <= ' ' }.isNotEmpty()) {
         for (parameter in parameterString.split(",")) {
             val parts = parameter.split("=".toRegex()).toTypedArray()
-            parameterMap[parts[0]] = if (parts.size > 1) parts[1] else ""
+            parameterMap[parts[0].trim()] = if (parts.size > 1) parts[1].trim() else ""
         }
     }
     return parameterMap

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LabelMissingInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LabelMissingInspectionTest.kt
@@ -93,6 +93,20 @@ class LabelMissingInspectionTest : BasePlatformTestCase() {
         myFixture.checkHighlighting(false, false, true, false)
     }
 
+    fun testListingLabelIsNotMissingWarnings() {
+        myFixture.configureByText(LatexFileType, """
+            \usepackage{listings}
+            \begin{document}
+                \begin{lstlisting}[language=Python, label=somelabel]
+                \end{lstlisting}
+                
+                \begin{lstlisting}[label={label with spaces}]
+                \end{lstlisting}
+            \end{document}
+        """.trimIndent())
+        myFixture.checkHighlighting(false, false, true, false)
+    }
+
     @Test
     fun testMissingListingLabelQuickFixNoParameters() {
         testQuickFix("""

--- a/test/nl/hannahsten/texifyidea/psi/LatexPsiImplUtilTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/LatexPsiImplUtilTest.kt
@@ -104,4 +104,36 @@ class LatexPsiImplUtilTest : BasePlatformTestCase() {
                 url
         )
     }
+
+    @Test
+    fun testBeginCommandOptionalParameterSplitting() {
+        myFixture.configureByText(LatexFileType, """\begin{lstlisting}[language=Python, label={lst:listing}]\end{lstlisting}""")
+
+        val psiFile = PsiDocumentManager.getInstance(myFixture.project).getPsiFile(myFixture.editor.document)!!
+        val element = psiFile.children.first().firstChildOfType(LatexBeginCommand::class)!!
+        val optionalParameters = element.optionalParameters
+
+        assertEquals("Python", optionalParameters["language"])
+        assertEquals("lst:listing", optionalParameters["label"])
+    }
+
+    @Test
+    fun testLabelFirstArgumentEnvironment() {
+        myFixture.configureByText(LatexFileType, """\begin{lstlisting}[label={lst:listing}, language=Python]\end{lstlisting}""")
+
+        val psiFile = PsiDocumentManager.getInstance(myFixture.project).getPsiFile(myFixture.editor.document)!!
+        val element = psiFile.children.first().firstChildOfType(LatexEnvironment::class)!!
+
+        assertEquals("lst:listing", element.label)
+    }
+
+    @Test
+    fun testLabelNotFirstParameterEnvironment() {
+        myFixture.configureByText(LatexFileType, """\begin{lstlisting}[language=Python, label={lst:listing}]\end{lstlisting}""")
+
+        val psiFile = PsiDocumentManager.getInstance(myFixture.project).getPsiFile(myFixture.editor.document)!!
+        val element = psiFile.children.first().firstChildOfType(LatexEnvironment::class)!!
+
+        assertEquals("lst:listing", element.label)
+    }
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fixes #1259 

#### Summary of additions and changes

* Trim optional parameters and their keys when asking for the label

#### How to test this pull request
The following doesn't trigger the missing label inspection:
```latex
    % @formatter:off
    \begin{lstlisting}[language=Python, label={lst:lstlisting}]
Hallo
    \end{lstlisting}
    % @formatter:on
```