### PR TITLE
Refactor environments

### DIFF
--- a/src/nl/hannahsten/texifyidea/psi/LatexNormalTextUtil.kt
+++ b/src/nl/hannahsten/texifyidea/psi/LatexNormalTextUtil.kt
@@ -2,6 +2,7 @@ package nl.hannahsten.texifyidea.psi
 
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
+import nl.hannahsten.texifyidea.reference.LatexEnvironmentReference
 import nl.hannahsten.texifyidea.reference.LatexLabelParameterReference
 import nl.hannahsten.texifyidea.util.Magic
 import nl.hannahsten.texifyidea.util.firstParentOfType
@@ -16,10 +17,15 @@ fun getReferences(element: LatexNormalText): Array<PsiReference> {
         val reference = LatexLabelParameterReference(element)
         if (reference.multiResolve(false).isNotEmpty()) {
             arrayOf<PsiReference>(reference)
-        } else {
+        }
+        else {
             emptyArray<PsiReference>()
         }
-    } else {
+    }
+    else if (element.firstParentOfType(LatexEndCommand::class) != null) {
+        arrayOf<PsiReference>(LatexEnvironmentReference(element))
+    }
+    else {
         emptyArray<PsiReference>()
     }
 }
@@ -31,7 +37,8 @@ fun getReference(element: LatexNormalText): PsiReference? {
     val references = getReferences(element)
     return if (references.size != 1) {
         null
-    } else {
+    }
+    else {
         references[0]
     }
 }

--- a/src/nl/hannahsten/texifyidea/reference/LatexEnvironmentReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/LatexEnvironmentReference.kt
@@ -1,0 +1,39 @@
+package nl.hannahsten.texifyidea.reference
+
+import com.intellij.psi.*
+import com.intellij.util.containers.toArray
+import nl.hannahsten.texifyidea.psi.LatexBeginCommand
+import nl.hannahsten.texifyidea.psi.LatexEnvironment
+import nl.hannahsten.texifyidea.psi.LatexNormalText
+import nl.hannahsten.texifyidea.util.extractLabelName
+import nl.hannahsten.texifyidea.util.findLatexLabelPsiElementsInFileSetAsSequence
+import nl.hannahsten.texifyidea.util.firstChildOfType
+import nl.hannahsten.texifyidea.util.firstParentOfType
+
+/**
+ * This reference allows refactoring of environments, by letting the text in \end resolve to the text in \begin, so the \begin is viewed as a definition and the text in \end as usage.
+ *
+ * @author Thomas
+ */
+class LatexEnvironmentReference(element: LatexNormalText) : PsiReferenceBase<LatexNormalText>(element) {
+
+    init {
+        rangeInElement = ElementManipulators.getValueTextRange(element)
+    }
+
+    override fun isReferenceTo(element: PsiElement): Boolean {
+        return resolve() == element
+    }
+
+    override fun resolve(): PsiElement? {
+        // Navigate from the current text in \end, to the text in \begin
+        return element.firstParentOfType(LatexEnvironment::class)
+                ?.firstChildOfType(LatexBeginCommand::class)
+                ?.firstChildOfType(LatexNormalText::class)
+    }
+
+    override fun handleElementRename(newElementName: String): PsiElement {
+        myElement.setName(newElementName)
+        return myElement
+    }
+}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fixes #575, fixes #1158

#### Summary of additions and changes

This is implemented by making the text in \end resolve to the text in \begin.

#### How to test this pull request

* Shift+F6 on environment name
* Also check if renaming/find usages of labels still works

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Refactoring