### PR TITLE
Texlive install packages

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,7 @@
 comment: false
+coverage:
+  status:
+    project:
+      default:
+        target: 25%
+        threshold: 5%

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,4 @@ coverage:
       default:
         target: 25%
         threshold: 5%
+    patch: off

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -648,7 +648,7 @@
                          groupName="LaTeX" displayName="Package could not be found"
                          enabledByDefault="true"/>
         <localInspection language="Latex" implementationClass="nl.hannahsten.texifyidea.inspections.latex.LatexPackageNotInstalledInspection"
-                         groupName="LaTeX" displayName="Package is not installed"/>
+                         groupName="LaTeX" displayName="Package is not installed" enabledByDefault="true"/>
 
         <!-- Bibtex inspections -->
         <localInspection language="Bibtex" implementationClass="nl.hannahsten.texifyidea.inspections.bibtex.BibtexDuplicateIdInspection"

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -34,7 +34,8 @@
     a since build of 173.* is equal to 181
     -->
     <idea-version since-build="193.4099.13"/>
-    <vendor url="https://hannah-sten.github.io/home/index.html">Hannah-Sten</vendor>
+    <vendor url="https://hannah-sten.github.io/home/index.html">Hannah-Sten
+    </vendor>
 
     <!-- Dependencies (must be defined to ensure compatibility with other IDEs) -->
     <depends>com.intellij.modules.lang</depends>
@@ -159,7 +160,7 @@
     <actions>
         <!-- New LaTeX file -->
         <action id="texify.NewFile" class="nl.hannahsten.texifyidea.action.NewLatexFileAction">
-            <add-to-group group-id="NewGroup" anchor="after" relative-to-action="NewFile" />
+            <add-to-group group-id="NewGroup" anchor="after" relative-to-action="NewFile"/>
         </action>
 
         <!-- LaTeX Edit commands -->
@@ -174,7 +175,7 @@
             <!-- Toggle Star -->
             <action class="nl.hannahsten.texifyidea.action.LatexToggleStarAction" id="texify.ToggleStar" text="Toggle _Star"
                     description="Adds/removes a star from a LaTeX command.">
-                <keyboard-shortcut first-keystroke="alt shift 8" keymap="$default" />
+                <keyboard-shortcut first-keystroke="alt shift 8" keymap="$default"/>
             </action>
         </group>
 
@@ -186,7 +187,7 @@
 
             <action class="nl.hannahsten.texifyidea.action.analysis.WordCountAction" id="texify.analysis.WordCount"
                     text="_Word Count" description="Estimate the word count of the currently active .tex file and inclusions.">
-                <keyboard-shortcut first-keystroke="control alt W" keymap="$default" />
+                <keyboard-shortcut first-keystroke="control alt W" keymap="$default"/>
             </action>
         </group>
 
@@ -218,63 +219,63 @@
             <add-to-group group-id="texify.LatexMenuEdit" anchor="first"/>
 
             <action class="nl.hannahsten.texifyidea.action.insert.InsertPartAction" id="texify.insert.sectioning.Part"
-                    text="_Part" description="Insert the part command." />
+                    text="_Part" description="Insert the part command."/>
             <action class="nl.hannahsten.texifyidea.action.insert.InsertChapterAction" id="texify.insert.sectioning.Chapter"
-                    text="_Chapter" description="Insert the chapter command." />
+                    text="_Chapter" description="Insert the chapter command."/>
             <action class="nl.hannahsten.texifyidea.action.insert.InsertSectionAction" id="texify.insert.sectioning.Section"
-                    text="_Section" description="Insert the section command." />
+                    text="_Section" description="Insert the section command."/>
             <action class="nl.hannahsten.texifyidea.action.insert.InsertSubSectionAction" id="texify.insert.sectioning.Subsection"
-                    text="S_ubsection" description="Insert the subsection command." />
+                    text="S_ubsection" description="Insert the subsection command."/>
             <action class="nl.hannahsten.texifyidea.action.insert.InsertSubSubSectionAction" id="texify.insert.sectioning.Subsubsection"
-                    text="Su_bsubsection" description="Insert the subsubsection command." />
+                    text="Su_bsubsection" description="Insert the subsubsection command."/>
             <action class="nl.hannahsten.texifyidea.action.insert.InsertParagraphAction" id="texify.insert.sectioning.Paragraph"
-                    text="_Paragraph" description="Insert the paragraph command." />
+                    text="_Paragraph" description="Insert the paragraph command."/>
             <action class="nl.hannahsten.texifyidea.action.insert.InsertSubParagraphAction" id="texify.insert.sectioning.Subparagraph"
-                    text="Subp_aragraph" description="Insert the subparagraph command." />
+                    text="Subp_aragraph" description="Insert the subparagraph command."/>
         </group>
 
         <!-- Insert: Font Style -->
         <group id="texify.LatexMenu.Insert.FontStyle" class="nl.hannahsten.texifyidea.action.group.InsertFontStyleActionGroup" text="_Font Style" description="Insert font style commands." popup="true">
-            <add-to-group group-id="texify.LatexMenuEdit" anchor="after" relative-to-action="texify.LatexMenu.Insert.Sectioning" />
+            <add-to-group group-id="texify.LatexMenuEdit" anchor="after" relative-to-action="texify.LatexMenu.Insert.Sectioning"/>
 
             <action class="nl.hannahsten.texifyidea.action.insert.InsertBoldfaceAction" id="texify.insert.fontstyle.BoldFace"
                     text="_Bold" description="Insert the command to make text appear bold.">
-                <keyboard-shortcut first-keystroke="control alt shift B" keymap="$default" />
+                <keyboard-shortcut first-keystroke="control alt shift B" keymap="$default"/>
             </action>
 
             <action class="nl.hannahsten.texifyidea.action.insert.InsertItalicsAction" id="texify.insert.fontstyle.Italics"
                     text="_Italics" description="Insert the command to make text appear in italics.">
-                <keyboard-shortcut first-keystroke="control alt shift I" keymap="$default" />
+                <keyboard-shortcut first-keystroke="control alt shift I" keymap="$default"/>
             </action>
 
             <action class="nl.hannahsten.texifyidea.action.insert.InsertUnderlineAction" id="texify.insert.fontstyle.Underline"
                     text="_Underline" description="Insert the command to underline text.">
-                <keyboard-shortcut first-keystroke="control alt shift U" keymap="$default" />
+                <keyboard-shortcut first-keystroke="control alt shift U" keymap="$default"/>
             </action>
 
             <action class="nl.hannahsten.texifyidea.action.insert.InsertOverlineAction" id="texify.insert.fontstyle.Overline"
                     text="_Overline" description="Insert the command to overline text.">
-                <keyboard-shortcut first-keystroke="control alt shift O" keymap="$default" />
+                <keyboard-shortcut first-keystroke="control alt shift O" keymap="$default"/>
             </action>
 
             <action class="nl.hannahsten.texifyidea.action.insert.InsertSmallCapsAction" id="texify.insert.fontstyle.SmallCaps"
                     text="Small _Capitals" description="Insert the command to underline text.">
-                <keyboard-shortcut first-keystroke="control alt shift C" keymap="$default" />
+                <keyboard-shortcut first-keystroke="control alt shift C" keymap="$default"/>
             </action>
 
             <action class="nl.hannahsten.texifyidea.action.insert.InsertTypewriterAction" id="texify.insert.fontstyle.Typewriter"
                     text="_Typewriter (Monospace)" description="Insert the command to make text monospace.">
-                <keyboard-shortcut first-keystroke="control alt shift T" keymap="$default" />
+                <keyboard-shortcut first-keystroke="control alt shift T" keymap="$default"/>
             </action>
 
             <action class="nl.hannahsten.texifyidea.action.insert.InsertStrikethroughAction" id="texify.insert.fontstyle.Strikethrough"
                     text="_Strikethrough (Ulem Package)" description="Insert the command to strikethrough text (inclusion of ulem package required).">
-                <keyboard-shortcut first-keystroke="control alt shift S" keymap="$default" />
+                <keyboard-shortcut first-keystroke="control alt shift S" keymap="$default"/>
             </action>
 
             <action class="nl.hannahsten.texifyidea.action.insert.InsertSlantedAction" id="texify.insert.fontstyle.Slanted"
                     text="S_lanted" description="Insert the command to make text appear slanted.">
-                <keyboard-shortcut first-keystroke="control alt shift L" keymap="$default" />
+                <keyboard-shortcut first-keystroke="control alt shift L" keymap="$default"/>
             </action>
 
             <action class="nl.hannahsten.texifyidea.action.insert.InsertEmphasisAction" id="texify.insert.fontstyle.Emphasis"
@@ -289,7 +290,7 @@
 
             <action class="nl.hannahsten.texifyidea.action.sumatra.ForwardSearchAction" id="texify.sumatra.ForwardSearch"
                     text="Go to _Line in PDF" description="Find the content on cursor in the PDF.">
-                <keyboard-shortcut first-keystroke="control alt shift PERIOD" keymap="$default" />
+                <keyboard-shortcut first-keystroke="control alt shift PERIOD" keymap="$default"/>
             </action>
             <action class="nl.hannahsten.texifyidea.action.sumatra.ConfigureInverseSearchAction" id="texify.sumatra.ConfigureInverseSearch"
                     text="_Configure Inverse Search" description="Setup inverse search integration with SumatraPDF and TeXiFy IDEA."/>
@@ -302,7 +303,7 @@
 
             <action class="nl.hannahsten.texifyidea.action.evince.ForwardSearchAction" id="texify.evince.ForwardSearch"
                     text="Go to _Line in PDF" description="Find the content on cursor in the PDF.">
-                <keyboard-shortcut first-keystroke="control alt shift PERIOD" keymap="$default" />
+                <keyboard-shortcut first-keystroke="control alt shift PERIOD" keymap="$default"/>
             </action>
         </group>
 
@@ -340,16 +341,17 @@
     <extensions defaultExtensionNs="com.intellij">
         <!-- Startup -->
         <postStartupActivity implementation="nl.hannahsten.texifyidea.startup.StartEvinceInverseSearchListener"/>
-        <postStartupActivity implementation="nl.hannahsten.texifyidea.startup.AnalyzeMenuRegistration" />
+        <postStartupActivity implementation="nl.hannahsten.texifyidea.startup.AnalyzeMenuRegistration"/>
+        <postStartupActivity implementation="nl.hannahsten.texifyidea.startup.TexLivePackageListInitializer"/>
 
         <!-- Files and project -->
         <moduleType id="LATEX_MODULE_TYPE" implementationClass="nl.hannahsten.texifyidea.modules.LatexModuleType"/>
-        <fileType implementationClass="nl.hannahsten.texifyidea.file.LatexFileType" name="LaTeX source file" language="Latex" extensions="tex" />
-        <fileType implementationClass="nl.hannahsten.texifyidea.file.StyleFileType" name="LaTeX style file" language="Latex" extensions="sty;dbx;bbx" /> <!-- dbx is a Biblatex Data Model, bbx a Biblatex Style -->
-        <fileType name="LaTeX style file" fileNames="biblatex.cfg" /> <!-- Biblatex configuration -->
-        <fileType implementationClass="nl.hannahsten.texifyidea.file.ClassFileType" name="LaTeX class file" language="Latex" extensions="cls" />
-        <fileType implementationClass="nl.hannahsten.texifyidea.file.BibtexFileType" name="BibTeX bibliography file" language="Bibtex" extensions="bib" />
-        <fileType implementationClass="nl.hannahsten.texifyidea.file.TikzFileType" name="TikZ picture file" language="Latex" extensions="tikz" />
+        <fileType implementationClass="nl.hannahsten.texifyidea.file.LatexFileType" name="LaTeX source file" language="Latex" extensions="tex"/>
+        <fileType implementationClass="nl.hannahsten.texifyidea.file.StyleFileType" name="LaTeX style file" language="Latex" extensions="sty;dbx;bbx"/> <!-- dbx is a Biblatex Data Model, bbx a Biblatex Style -->
+        <fileType name="LaTeX style file" fileNames="biblatex.cfg"/> <!-- Biblatex configuration -->
+        <fileType implementationClass="nl.hannahsten.texifyidea.file.ClassFileType" name="LaTeX class file" language="Latex" extensions="cls"/>
+        <fileType implementationClass="nl.hannahsten.texifyidea.file.BibtexFileType" name="BibTeX bibliography file" language="Bibtex" extensions="bib"/>
+        <fileType implementationClass="nl.hannahsten.texifyidea.file.TikzFileType" name="TikZ picture file" language="Latex" extensions="tikz"/>
 
         <!-- Register module type for new project creation in non-IntelliJ IDEs -->
         <directoryProjectGenerator implementation="nl.hannahsten.texifyidea.modules.LatexProjectGenerator"/>
@@ -383,7 +385,7 @@
 
         <!-- Project settings -->
         <projectService serviceImplementation="nl.hannahsten.texifyidea.settings.TexifyProjectSettings"/>
-        <projectConfigurable instance="nl.hannahsten.texifyidea.settings.TexifyProjectConfigurable" groupId="TexifyConfigurable" id="TexifyProjectConfigurable" />
+        <projectConfigurable instance="nl.hannahsten.texifyidea.settings.TexifyProjectConfigurable" groupId="TexifyConfigurable" id="TexifyProjectConfigurable"/>
 
         <!-- Languages -->
         <lang.parserDefinition language="Latex" implementationClass="nl.hannahsten.texifyidea.LatexParserDefinition"/>
@@ -432,12 +434,12 @@
         <backspaceHandlerDelegate implementation="nl.hannahsten.texifyidea.editor.autocompile.ContinuousPreviewBackspacehandler"/>
         <typedHandler implementation="nl.hannahsten.texifyidea.editor.autocompile.AutocompileHandler"/>
         <backspaceHandlerDelegate implementation="nl.hannahsten.texifyidea.editor.autocompile.AutoCompileBackspacehandler"/>
-        <backspaceHandlerDelegate implementation="nl.hannahsten.texifyidea.editor.InlineMathBackspaceHandler" />
+        <backspaceHandlerDelegate implementation="nl.hannahsten.texifyidea.editor.InlineMathBackspaceHandler"/>
 
         <!-- References and refactoring -->
         <lang.findUsagesProvider language="Latex" implementationClass="nl.hannahsten.texifyidea.reference.LatexUsagesProvider"/>
-        <lang.refactoringSupport language="Latex" implementationClass="nl.hannahsten.texifyidea.refactoring.LatexRefactoringSupportProvider" />
-        <lang.namesValidator language="Latex" implementationClass="nl.hannahsten.texifyidea.refactoring.LatexNamesValidator" />
+        <lang.refactoringSupport language="Latex" implementationClass="nl.hannahsten.texifyidea.refactoring.LatexRefactoringSupportProvider"/>
+        <lang.namesValidator language="Latex" implementationClass="nl.hannahsten.texifyidea.refactoring.LatexNamesValidator"/>
 
         <!-- Navigation -->
         <gotoSymbolContributor implementation="nl.hannahsten.texifyidea.navigation.GotoLabelSymbolContributor"/>
@@ -646,6 +648,9 @@
         <localInspection language="Latex" implementationClass="nl.hannahsten.texifyidea.inspections.latex.LatexPackageCouldNotBeFound"
                          groupName="LaTeX" displayName="Package could not be found"
                          enabledByDefault="true"/>
+        <localInspection language="Latex" implementationClass="nl.hannahsten.texifyidea.inspections.latex.LatexPackageNotInstalledInspection"
+                         groupName="LaTeX" displayName="Package is not installed"
+                         enabledByDefault="true"/>
 
         <!-- Bibtex inspections -->
         <localInspection language="Bibtex" implementationClass="nl.hannahsten.texifyidea.inspections.bibtex.BibtexDuplicateIdInspection"
@@ -663,57 +668,82 @@
 
         <!-- Intentions -->
         <intentionAction>
-            <className>nl.hannahsten.texifyidea.intentions.LatexDisplayMathIntention</className>
+            <className>
+                nl.hannahsten.texifyidea.intentions.LatexDisplayMathIntention
+            </className>
             <category>LaTeX</category>
-            <descriptionDirectoryName>LatexDisplayMath</descriptionDirectoryName>
+            <descriptionDirectoryName>LatexDisplayMath
+            </descriptionDirectoryName>
         </intentionAction>
 
         <intentionAction>
-            <className>nl.hannahsten.texifyidea.intentions.LatexMoveSectionToFileIntention</className>
+            <className>
+                nl.hannahsten.texifyidea.intentions.LatexMoveSectionToFileIntention
+            </className>
             <category>LaTeX</category>
-            <descriptionDirectoryName>LatexMoveSectionToFile</descriptionDirectoryName>
+            <descriptionDirectoryName>LatexMoveSectionToFile
+            </descriptionDirectoryName>
         </intentionAction>
 
         <intentionAction>
-            <className>nl.hannahsten.texifyidea.intentions.LatexMoveSelectionToFileIntention</className>
+            <className>
+                nl.hannahsten.texifyidea.intentions.LatexMoveSelectionToFileIntention
+            </className>
             <category>LaTeX</category>
-            <descriptionDirectoryName>LatexMoveSelectionToFile</descriptionDirectoryName>
+            <descriptionDirectoryName>LatexMoveSelectionToFile
+            </descriptionDirectoryName>
         </intentionAction>
 
         <intentionAction>
-            <className>nl.hannahsten.texifyidea.intentions.LatexUnpackUsepackageIntention</className>
+            <className>
+                nl.hannahsten.texifyidea.intentions.LatexUnpackUsepackageIntention
+            </className>
             <category>LaTeX</category>
-            <descriptionDirectoryName>LatexUnpackUsepackage</descriptionDirectoryName>
+            <descriptionDirectoryName>LatexUnpackUsepackage
+            </descriptionDirectoryName>
         </intentionAction>
 
         <intentionAction>
-            <className>nl.hannahsten.texifyidea.intentions.LatexLeftRightParenthesesIntention</className>
+            <className>
+                nl.hannahsten.texifyidea.intentions.LatexLeftRightParenthesesIntention
+            </className>
             <category>LaTeX</category>
-            <descriptionDirectoryName>LatexLeftRightParentheses</descriptionDirectoryName>
+            <descriptionDirectoryName>LatexLeftRightParentheses
+            </descriptionDirectoryName>
         </intentionAction>
 
         <intentionAction>
-            <className>nl.hannahsten.texifyidea.intentions.LatexInlineDisplayToggle</className>
+            <className>
+                nl.hannahsten.texifyidea.intentions.LatexInlineDisplayToggle
+            </className>
             <category>LaTeX</category>
-            <descriptionDirectoryName>LatexInlineDisplayToggle</descriptionDirectoryName>
+            <descriptionDirectoryName>LatexInlineDisplayToggle
+            </descriptionDirectoryName>
         </intentionAction>
 
         <intentionAction>
-            <className>nl.hannahsten.texifyidea.intentions.LatexMathToggle</className>
+            <className>nl.hannahsten.texifyidea.intentions.LatexMathToggle
+            </className>
             <category>LaTeX</category>
             <descriptionDirectoryName>LatexMathToggle</descriptionDirectoryName>
         </intentionAction>
 
         <intentionAction>
-            <className>nl.hannahsten.texifyidea.intentions.LatexToggleSmartQuotesIntention</className>
+            <className>
+                nl.hannahsten.texifyidea.intentions.LatexToggleSmartQuotesIntention
+            </className>
             <category>LaTeX</category>
-            <descriptionDirectoryName>LatexToggleSmartQuotes</descriptionDirectoryName>
+            <descriptionDirectoryName>LatexToggleSmartQuotes
+            </descriptionDirectoryName>
         </intentionAction>
 
         <intentionAction>
-            <className>nl.hannahsten.texifyidea.intentions.LatexLabelDefiningNewCommand</className>
+            <className>
+                nl.hannahsten.texifyidea.intentions.LatexLabelDefiningNewCommand
+            </className>
             <category>LaTeX</category>
-            <descriptionDirectoryName>LatexLabelDefiningNewCommand</descriptionDirectoryName>
+            <descriptionDirectoryName>LatexLabelDefiningNewCommand
+            </descriptionDirectoryName>
         </intentionAction>
     </extensions>
 </idea-plugin>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -34,8 +34,7 @@
     a since build of 173.* is equal to 181
     -->
     <idea-version since-build="193.4099.13"/>
-    <vendor url="https://hannah-sten.github.io/home/index.html">Hannah-Sten
-    </vendor>
+    <vendor url="https://hannah-sten.github.io/home/index.html">Hannah-Sten</vendor>
 
     <!-- Dependencies (must be defined to ensure compatibility with other IDEs) -->
     <depends>com.intellij.modules.lang</depends>
@@ -160,7 +159,7 @@
     <actions>
         <!-- New LaTeX file -->
         <action id="texify.NewFile" class="nl.hannahsten.texifyidea.action.NewLatexFileAction">
-            <add-to-group group-id="NewGroup" anchor="after" relative-to-action="NewFile"/>
+            <add-to-group group-id="NewGroup" anchor="after" relative-to-action="NewFile" />
         </action>
 
         <!-- LaTeX Edit commands -->
@@ -175,7 +174,7 @@
             <!-- Toggle Star -->
             <action class="nl.hannahsten.texifyidea.action.LatexToggleStarAction" id="texify.ToggleStar" text="Toggle _Star"
                     description="Adds/removes a star from a LaTeX command.">
-                <keyboard-shortcut first-keystroke="alt shift 8" keymap="$default"/>
+                <keyboard-shortcut first-keystroke="alt shift 8" keymap="$default" />
             </action>
         </group>
 
@@ -187,7 +186,7 @@
 
             <action class="nl.hannahsten.texifyidea.action.analysis.WordCountAction" id="texify.analysis.WordCount"
                     text="_Word Count" description="Estimate the word count of the currently active .tex file and inclusions.">
-                <keyboard-shortcut first-keystroke="control alt W" keymap="$default"/>
+                <keyboard-shortcut first-keystroke="control alt W" keymap="$default" />
             </action>
         </group>
 
@@ -219,63 +218,63 @@
             <add-to-group group-id="texify.LatexMenuEdit" anchor="first"/>
 
             <action class="nl.hannahsten.texifyidea.action.insert.InsertPartAction" id="texify.insert.sectioning.Part"
-                    text="_Part" description="Insert the part command."/>
+                    text="_Part" description="Insert the part command." />
             <action class="nl.hannahsten.texifyidea.action.insert.InsertChapterAction" id="texify.insert.sectioning.Chapter"
-                    text="_Chapter" description="Insert the chapter command."/>
+                    text="_Chapter" description="Insert the chapter command." />
             <action class="nl.hannahsten.texifyidea.action.insert.InsertSectionAction" id="texify.insert.sectioning.Section"
-                    text="_Section" description="Insert the section command."/>
+                    text="_Section" description="Insert the section command." />
             <action class="nl.hannahsten.texifyidea.action.insert.InsertSubSectionAction" id="texify.insert.sectioning.Subsection"
-                    text="S_ubsection" description="Insert the subsection command."/>
+                    text="S_ubsection" description="Insert the subsection command." />
             <action class="nl.hannahsten.texifyidea.action.insert.InsertSubSubSectionAction" id="texify.insert.sectioning.Subsubsection"
-                    text="Su_bsubsection" description="Insert the subsubsection command."/>
+                    text="Su_bsubsection" description="Insert the subsubsection command." />
             <action class="nl.hannahsten.texifyidea.action.insert.InsertParagraphAction" id="texify.insert.sectioning.Paragraph"
-                    text="_Paragraph" description="Insert the paragraph command."/>
+                    text="_Paragraph" description="Insert the paragraph command." />
             <action class="nl.hannahsten.texifyidea.action.insert.InsertSubParagraphAction" id="texify.insert.sectioning.Subparagraph"
-                    text="Subp_aragraph" description="Insert the subparagraph command."/>
+                    text="Subp_aragraph" description="Insert the subparagraph command." />
         </group>
 
         <!-- Insert: Font Style -->
         <group id="texify.LatexMenu.Insert.FontStyle" class="nl.hannahsten.texifyidea.action.group.InsertFontStyleActionGroup" text="_Font Style" description="Insert font style commands." popup="true">
-            <add-to-group group-id="texify.LatexMenuEdit" anchor="after" relative-to-action="texify.LatexMenu.Insert.Sectioning"/>
+            <add-to-group group-id="texify.LatexMenuEdit" anchor="after" relative-to-action="texify.LatexMenu.Insert.Sectioning" />
 
             <action class="nl.hannahsten.texifyidea.action.insert.InsertBoldfaceAction" id="texify.insert.fontstyle.BoldFace"
                     text="_Bold" description="Insert the command to make text appear bold.">
-                <keyboard-shortcut first-keystroke="control alt shift B" keymap="$default"/>
+                <keyboard-shortcut first-keystroke="control alt shift B" keymap="$default" />
             </action>
 
             <action class="nl.hannahsten.texifyidea.action.insert.InsertItalicsAction" id="texify.insert.fontstyle.Italics"
                     text="_Italics" description="Insert the command to make text appear in italics.">
-                <keyboard-shortcut first-keystroke="control alt shift I" keymap="$default"/>
+                <keyboard-shortcut first-keystroke="control alt shift I" keymap="$default" />
             </action>
 
             <action class="nl.hannahsten.texifyidea.action.insert.InsertUnderlineAction" id="texify.insert.fontstyle.Underline"
                     text="_Underline" description="Insert the command to underline text.">
-                <keyboard-shortcut first-keystroke="control alt shift U" keymap="$default"/>
+                <keyboard-shortcut first-keystroke="control alt shift U" keymap="$default" />
             </action>
 
             <action class="nl.hannahsten.texifyidea.action.insert.InsertOverlineAction" id="texify.insert.fontstyle.Overline"
                     text="_Overline" description="Insert the command to overline text.">
-                <keyboard-shortcut first-keystroke="control alt shift O" keymap="$default"/>
+                <keyboard-shortcut first-keystroke="control alt shift O" keymap="$default" />
             </action>
 
             <action class="nl.hannahsten.texifyidea.action.insert.InsertSmallCapsAction" id="texify.insert.fontstyle.SmallCaps"
                     text="Small _Capitals" description="Insert the command to underline text.">
-                <keyboard-shortcut first-keystroke="control alt shift C" keymap="$default"/>
+                <keyboard-shortcut first-keystroke="control alt shift C" keymap="$default" />
             </action>
 
             <action class="nl.hannahsten.texifyidea.action.insert.InsertTypewriterAction" id="texify.insert.fontstyle.Typewriter"
                     text="_Typewriter (Monospace)" description="Insert the command to make text monospace.">
-                <keyboard-shortcut first-keystroke="control alt shift T" keymap="$default"/>
+                <keyboard-shortcut first-keystroke="control alt shift T" keymap="$default" />
             </action>
 
             <action class="nl.hannahsten.texifyidea.action.insert.InsertStrikethroughAction" id="texify.insert.fontstyle.Strikethrough"
                     text="_Strikethrough (Ulem Package)" description="Insert the command to strikethrough text (inclusion of ulem package required).">
-                <keyboard-shortcut first-keystroke="control alt shift S" keymap="$default"/>
+                <keyboard-shortcut first-keystroke="control alt shift S" keymap="$default" />
             </action>
 
             <action class="nl.hannahsten.texifyidea.action.insert.InsertSlantedAction" id="texify.insert.fontstyle.Slanted"
                     text="S_lanted" description="Insert the command to make text appear slanted.">
-                <keyboard-shortcut first-keystroke="control alt shift L" keymap="$default"/>
+                <keyboard-shortcut first-keystroke="control alt shift L" keymap="$default" />
             </action>
 
             <action class="nl.hannahsten.texifyidea.action.insert.InsertEmphasisAction" id="texify.insert.fontstyle.Emphasis"
@@ -290,7 +289,7 @@
 
             <action class="nl.hannahsten.texifyidea.action.sumatra.ForwardSearchAction" id="texify.sumatra.ForwardSearch"
                     text="Go to _Line in PDF" description="Find the content on cursor in the PDF.">
-                <keyboard-shortcut first-keystroke="control alt shift PERIOD" keymap="$default"/>
+                <keyboard-shortcut first-keystroke="control alt shift PERIOD" keymap="$default" />
             </action>
             <action class="nl.hannahsten.texifyidea.action.sumatra.ConfigureInverseSearchAction" id="texify.sumatra.ConfigureInverseSearch"
                     text="_Configure Inverse Search" description="Setup inverse search integration with SumatraPDF and TeXiFy IDEA."/>
@@ -303,7 +302,7 @@
 
             <action class="nl.hannahsten.texifyidea.action.evince.ForwardSearchAction" id="texify.evince.ForwardSearch"
                     text="Go to _Line in PDF" description="Find the content on cursor in the PDF.">
-                <keyboard-shortcut first-keystroke="control alt shift PERIOD" keymap="$default"/>
+                <keyboard-shortcut first-keystroke="control alt shift PERIOD" keymap="$default" />
             </action>
         </group>
 
@@ -346,12 +345,12 @@
 
         <!-- Files and project -->
         <moduleType id="LATEX_MODULE_TYPE" implementationClass="nl.hannahsten.texifyidea.modules.LatexModuleType"/>
-        <fileType implementationClass="nl.hannahsten.texifyidea.file.LatexFileType" name="LaTeX source file" language="Latex" extensions="tex"/>
-        <fileType implementationClass="nl.hannahsten.texifyidea.file.StyleFileType" name="LaTeX style file" language="Latex" extensions="sty;dbx;bbx"/> <!-- dbx is a Biblatex Data Model, bbx a Biblatex Style -->
-        <fileType name="LaTeX style file" fileNames="biblatex.cfg"/> <!-- Biblatex configuration -->
-        <fileType implementationClass="nl.hannahsten.texifyidea.file.ClassFileType" name="LaTeX class file" language="Latex" extensions="cls"/>
-        <fileType implementationClass="nl.hannahsten.texifyidea.file.BibtexFileType" name="BibTeX bibliography file" language="Bibtex" extensions="bib"/>
-        <fileType implementationClass="nl.hannahsten.texifyidea.file.TikzFileType" name="TikZ picture file" language="Latex" extensions="tikz"/>
+        <fileType implementationClass="nl.hannahsten.texifyidea.file.LatexFileType" name="LaTeX source file" language="Latex" extensions="tex" />
+        <fileType implementationClass="nl.hannahsten.texifyidea.file.StyleFileType" name="LaTeX style file" language="Latex" extensions="sty;dbx;bbx" /> <!-- dbx is a Biblatex Data Model, bbx a Biblatex Style -->
+        <fileType name="LaTeX style file" fileNames="biblatex.cfg" /> <!-- Biblatex configuration -->
+        <fileType implementationClass="nl.hannahsten.texifyidea.file.ClassFileType" name="LaTeX class file" language="Latex" extensions="cls" />
+        <fileType implementationClass="nl.hannahsten.texifyidea.file.BibtexFileType" name="BibTeX bibliography file" language="Bibtex" extensions="bib" />
+        <fileType implementationClass="nl.hannahsten.texifyidea.file.TikzFileType" name="TikZ picture file" language="Latex" extensions="tikz" />
 
         <!-- Register module type for new project creation in non-IntelliJ IDEs -->
         <directoryProjectGenerator implementation="nl.hannahsten.texifyidea.modules.LatexProjectGenerator"/>
@@ -385,7 +384,7 @@
 
         <!-- Project settings -->
         <projectService serviceImplementation="nl.hannahsten.texifyidea.settings.TexifyProjectSettings"/>
-        <projectConfigurable instance="nl.hannahsten.texifyidea.settings.TexifyProjectConfigurable" groupId="TexifyConfigurable" id="TexifyProjectConfigurable"/>
+        <projectConfigurable instance="nl.hannahsten.texifyidea.settings.TexifyProjectConfigurable" groupId="TexifyConfigurable" id="TexifyProjectConfigurable" />
 
         <!-- Languages -->
         <lang.parserDefinition language="Latex" implementationClass="nl.hannahsten.texifyidea.LatexParserDefinition"/>
@@ -434,12 +433,12 @@
         <backspaceHandlerDelegate implementation="nl.hannahsten.texifyidea.editor.autocompile.ContinuousPreviewBackspacehandler"/>
         <typedHandler implementation="nl.hannahsten.texifyidea.editor.autocompile.AutocompileHandler"/>
         <backspaceHandlerDelegate implementation="nl.hannahsten.texifyidea.editor.autocompile.AutoCompileBackspacehandler"/>
-        <backspaceHandlerDelegate implementation="nl.hannahsten.texifyidea.editor.InlineMathBackspaceHandler"/>
+        <backspaceHandlerDelegate implementation="nl.hannahsten.texifyidea.editor.InlineMathBackspaceHandler" />
 
         <!-- References and refactoring -->
         <lang.findUsagesProvider language="Latex" implementationClass="nl.hannahsten.texifyidea.reference.LatexUsagesProvider"/>
-        <lang.refactoringSupport language="Latex" implementationClass="nl.hannahsten.texifyidea.refactoring.LatexRefactoringSupportProvider"/>
-        <lang.namesValidator language="Latex" implementationClass="nl.hannahsten.texifyidea.refactoring.LatexNamesValidator"/>
+        <lang.refactoringSupport language="Latex" implementationClass="nl.hannahsten.texifyidea.refactoring.LatexRefactoringSupportProvider" />
+        <lang.namesValidator language="Latex" implementationClass="nl.hannahsten.texifyidea.refactoring.LatexNamesValidator" />
 
         <!-- Navigation -->
         <gotoSymbolContributor implementation="nl.hannahsten.texifyidea.navigation.GotoLabelSymbolContributor"/>
@@ -668,82 +667,57 @@
 
         <!-- Intentions -->
         <intentionAction>
-            <className>
-                nl.hannahsten.texifyidea.intentions.LatexDisplayMathIntention
-            </className>
+            <className>nl.hannahsten.texifyidea.intentions.LatexDisplayMathIntention</className>
             <category>LaTeX</category>
-            <descriptionDirectoryName>LatexDisplayMath
-            </descriptionDirectoryName>
+            <descriptionDirectoryName>LatexDisplayMath</descriptionDirectoryName>
         </intentionAction>
 
         <intentionAction>
-            <className>
-                nl.hannahsten.texifyidea.intentions.LatexMoveSectionToFileIntention
-            </className>
+            <className>nl.hannahsten.texifyidea.intentions.LatexMoveSectionToFileIntention</className>
             <category>LaTeX</category>
-            <descriptionDirectoryName>LatexMoveSectionToFile
-            </descriptionDirectoryName>
+            <descriptionDirectoryName>LatexMoveSectionToFile</descriptionDirectoryName>
         </intentionAction>
 
         <intentionAction>
-            <className>
-                nl.hannahsten.texifyidea.intentions.LatexMoveSelectionToFileIntention
-            </className>
+            <className>nl.hannahsten.texifyidea.intentions.LatexMoveSelectionToFileIntention</className>
             <category>LaTeX</category>
-            <descriptionDirectoryName>LatexMoveSelectionToFile
-            </descriptionDirectoryName>
+            <descriptionDirectoryName>LatexMoveSelectionToFile</descriptionDirectoryName>
         </intentionAction>
 
         <intentionAction>
-            <className>
-                nl.hannahsten.texifyidea.intentions.LatexUnpackUsepackageIntention
-            </className>
+            <className>nl.hannahsten.texifyidea.intentions.LatexUnpackUsepackageIntention</className>
             <category>LaTeX</category>
-            <descriptionDirectoryName>LatexUnpackUsepackage
-            </descriptionDirectoryName>
+            <descriptionDirectoryName>LatexUnpackUsepackage</descriptionDirectoryName>
         </intentionAction>
 
         <intentionAction>
-            <className>
-                nl.hannahsten.texifyidea.intentions.LatexLeftRightParenthesesIntention
-            </className>
+            <className>nl.hannahsten.texifyidea.intentions.LatexLeftRightParenthesesIntention</className>
             <category>LaTeX</category>
-            <descriptionDirectoryName>LatexLeftRightParentheses
-            </descriptionDirectoryName>
+            <descriptionDirectoryName>LatexLeftRightParentheses</descriptionDirectoryName>
         </intentionAction>
 
         <intentionAction>
-            <className>
-                nl.hannahsten.texifyidea.intentions.LatexInlineDisplayToggle
-            </className>
+            <className>nl.hannahsten.texifyidea.intentions.LatexInlineDisplayToggle</className>
             <category>LaTeX</category>
-            <descriptionDirectoryName>LatexInlineDisplayToggle
-            </descriptionDirectoryName>
+            <descriptionDirectoryName>LatexInlineDisplayToggle</descriptionDirectoryName>
         </intentionAction>
 
         <intentionAction>
-            <className>nl.hannahsten.texifyidea.intentions.LatexMathToggle
-            </className>
+            <className>nl.hannahsten.texifyidea.intentions.LatexMathToggle</className>
             <category>LaTeX</category>
             <descriptionDirectoryName>LatexMathToggle</descriptionDirectoryName>
         </intentionAction>
 
         <intentionAction>
-            <className>
-                nl.hannahsten.texifyidea.intentions.LatexToggleSmartQuotesIntention
-            </className>
+            <className>nl.hannahsten.texifyidea.intentions.LatexToggleSmartQuotesIntention</className>
             <category>LaTeX</category>
-            <descriptionDirectoryName>LatexToggleSmartQuotes
-            </descriptionDirectoryName>
+            <descriptionDirectoryName>LatexToggleSmartQuotes</descriptionDirectoryName>
         </intentionAction>
 
         <intentionAction>
-            <className>
-                nl.hannahsten.texifyidea.intentions.LatexLabelDefiningNewCommand
-            </className>
+            <className>nl.hannahsten.texifyidea.intentions.LatexLabelDefiningNewCommand</className>
             <category>LaTeX</category>
-            <descriptionDirectoryName>LatexLabelDefiningNewCommand
-            </descriptionDirectoryName>
+            <descriptionDirectoryName>LatexLabelDefiningNewCommand</descriptionDirectoryName>
         </intentionAction>
     </extensions>
 </idea-plugin>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -648,8 +648,7 @@
                          groupName="LaTeX" displayName="Package could not be found"
                          enabledByDefault="true"/>
         <localInspection language="Latex" implementationClass="nl.hannahsten.texifyidea.inspections.latex.LatexPackageNotInstalledInspection"
-                         groupName="LaTeX" displayName="Package is not installed"
-                         enabledByDefault="true"/>
+                         groupName="LaTeX" displayName="Package is not installed"/>
 
         <!-- Bibtex inspections -->
         <localInspection language="Bibtex" implementationClass="nl.hannahsten.texifyidea.inspections.bibtex.BibtexDuplicateIdInspection"

--- a/resources/inspectionDescriptions/LatexPackageNotInstalled.html
+++ b/resources/inspectionDescriptions/LatexPackageNotInstalled.html
@@ -2,5 +2,6 @@
 <body>
 The package given in a <tt>\usepackage</tt> or <tt>\RequirePackage</tt> command is not installed on your system.
 <!-- tooltip end -->
+This inspection only checks installed packages on texlive systems (with tlmgr).
 </body>
 </html>

--- a/resources/inspectionDescriptions/LatexPackageNotInstalled.html
+++ b/resources/inspectionDescriptions/LatexPackageNotInstalled.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+The package given in a <tt>\usepackage</tt> or <tt>\RequirePackage</tt> command is not installed on your system.
+<!-- tooltip end -->
+</body>
+</html>

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexPackageCouldNotBeFound.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexPackageCouldNotBeFound.kt
@@ -32,7 +32,7 @@ class LatexPackageCouldNotBeFound : TexifyInspectionBase() {
                 .filter { it.name == "\\usepackage" || it.name == "\\RequirePackage" }
 
         for (command in commands) {
-            val `package` = command.requiredParameters.first().toLowerCase()
+            val `package` = command.requiredParameters.firstOrNull()?.toLowerCase()
             if (!packages.contains(`package`)) {
                 descriptors.add(manager.createProblemDescriptor(
                         command,

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexPackageNotInstalledInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexPackageNotInstalledInspection.kt
@@ -10,6 +10,8 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
+import com.intellij.psi.SmartPsiElementPointer
+import com.intellij.psi.util.createSmartPointer
 import nl.hannahsten.texifyidea.index.LatexDefinitionIndex
 import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
@@ -52,7 +54,7 @@ class LatexPackageNotInstalledInspection : TexifyInspectionBase() {
                         descriptors.add(manager.createProblemDescriptor(
                                 command,
                                 "Package is not installed",
-                                InstallPackage(file, `package`),
+                                InstallPackage(file.createSmartPointer(file.project), `package`),
                                 ProblemHighlightType.WARNING,
                                 isOntheFly
                         ))
@@ -63,7 +65,7 @@ class LatexPackageNotInstalledInspection : TexifyInspectionBase() {
         return descriptors
     }
 
-    private class InstallPackage(val file: PsiFile, val packageName: String) : LocalQuickFix {
+    private class InstallPackage(val filePointer: SmartPsiElementPointer<PsiFile>, val packageName: String) : LocalQuickFix {
         override fun getFamilyName(): String = "Install $packageName"
 
         /**
@@ -81,7 +83,7 @@ class LatexPackageNotInstalledInspection : TexifyInspectionBase() {
                         override fun onSuccess() {
                             TexLivePackages.packageList.add(packageName)
                             DaemonCodeAnalyzer.getInstance(project)
-                                    .restart(file)
+                                    .restart(filePointer.containingFile ?: return)
                         }
 
                     })

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexPackageNotInstalledInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexPackageNotInstalledInspection.kt
@@ -1,0 +1,55 @@
+package nl.hannahsten.texifyidea.inspections.latex
+
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.psi.PsiFile
+import nl.hannahsten.texifyidea.index.LatexDefinitionIndex
+import nl.hannahsten.texifyidea.insight.InsightGroup
+import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
+import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.util.*
+
+class LatexPackageNotInstalledInspection : TexifyInspectionBase() {
+    override val inspectionGroup: InsightGroup = InsightGroup.LATEX
+
+    override val inspectionId: String =
+            "PackageNotInstalled"
+
+    override fun getDisplayName(): String {
+        return "Package is not installed"
+    }
+
+    override fun isEnabledByDefault(): Boolean {
+        return LatexDistribution.isTexlive
+    }
+
+    override fun inspectFile(file: PsiFile, manager: InspectionManager, isOntheFly: Boolean): List<ProblemDescriptor> {
+        val descriptors = descriptorList()
+        if (LatexDistribution.isTexlive) {
+            val installedPackages = TexLivePackages.packageList
+            val customPackages = LatexDefinitionIndex.getCommandsByName("\\ProvidesPackage", file.project, file.project
+                            .projectSearchScope)
+                    .map { it.requiredParameter(0) }
+                    .map { it?.toLowerCase() }
+            val packages = installedPackages + customPackages
+
+            val commands = file.childrenOfType(LatexCommands::class)
+                    .filter { it.name == "\\usepackage" || it.name == "\\RequirePackage" }
+
+            for (command in commands) {
+                val `package` = command.requiredParameters.first().toLowerCase()
+                if (`package` !in packages) {
+                    descriptors.add(manager.createProblemDescriptor(
+                            command,
+                            "Package is not installed",
+                            Magic.General.noQuickFix,
+                            ProblemHighlightType.WARNING,
+                            isOntheFly
+                    ))
+                }
+            }
+        }
+        return descriptors
+    }
+}

--- a/src/nl/hannahsten/texifyidea/startup/TexLivePackageListInitializer.kt
+++ b/src/nl/hannahsten/texifyidea/startup/TexLivePackageListInitializer.kt
@@ -1,0 +1,13 @@
+package nl.hannahsten.texifyidea.startup
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.StartupActivity
+import nl.hannahsten.texifyidea.util.TexLivePackages
+import nl.hannahsten.texifyidea.util.runCommand
+
+class TexLivePackageListInitializer : StartupActivity {
+    override fun runActivity(project: Project) {
+        val result = "tlmgr list --only-installed".runCommand() ?: return
+        TexLivePackages.packageList = Regex("i\\s(.*):").findAll(result).map { it.groupValues.last() }.toMutableList()
+    }
+}

--- a/src/nl/hannahsten/texifyidea/startup/TexLivePackageListInitializer.kt
+++ b/src/nl/hannahsten/texifyidea/startup/TexLivePackageListInitializer.kt
@@ -2,12 +2,16 @@ package nl.hannahsten.texifyidea.startup
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.StartupActivity
+import nl.hannahsten.texifyidea.util.LatexDistribution
 import nl.hannahsten.texifyidea.util.TexLivePackages
 import nl.hannahsten.texifyidea.util.runCommand
 
 class TexLivePackageListInitializer : StartupActivity {
     override fun runActivity(project: Project) {
-        val result = "tlmgr list --only-installed".runCommand() ?: return
-        TexLivePackages.packageList = Regex("i\\s(.*):").findAll(result).map { it.groupValues.last() }.toMutableList()
+        if (LatexDistribution.isTexlive) {
+            val result = "tlmgr list --only-installed".runCommand() ?: return
+            TexLivePackages.packageList = Regex("i\\s(.*):").findAll(result)
+                    .map { it.groupValues.last() }.toMutableList()
+        }
     }
 }

--- a/src/nl/hannahsten/texifyidea/util/Packages.kt
+++ b/src/nl/hannahsten/texifyidea/util/Packages.kt
@@ -299,6 +299,18 @@ object PackageUtils {
 
 object TexLivePackages {
     lateinit var packageList: MutableList<String>
+
+    /**
+     * Given a package name used in \usepackage or \RequirePackage, find the
+     * name needed to install from TeX Live. E.g. to be able to use \usepackage{rubikrotation}
+     * we need to install the rubik package.
+     */
+    fun findTexLiveName(packageName: String): String? {
+        // Find the package name for tlmgr.
+        val searchResult = "tlmgr search --file --global /$packageName.sty".runCommand() ?: return null
+        return searchResult.split('\n')[1].dropLast(1)
+    }
+
 }
 
 /**

--- a/src/nl/hannahsten/texifyidea/util/Packages.kt
+++ b/src/nl/hannahsten/texifyidea/util/Packages.kt
@@ -25,10 +25,6 @@ object PackageUtils {
             .split(";")
             .toList()
 
-    val i by lazy {
-        4
-    }
-
     /** Commands which can include packages in optional or required arguments. **/
     val PACKAGE_COMMANDS = setOf("\\usepackage", "\\RequirePackage", "\\documentclass")
     private val TIKZ_IMPORT_COMMANDS = setOf("\\usetikzlibrary")

--- a/src/nl/hannahsten/texifyidea/util/Packages.kt
+++ b/src/nl/hannahsten/texifyidea/util/Packages.kt
@@ -25,6 +25,10 @@ object PackageUtils {
             .split(";")
             .toList()
 
+    val i by lazy {
+        4
+    }
+
     /** Commands which can include packages in optional or required arguments. **/
     val PACKAGE_COMMANDS = setOf("\\usepackage", "\\RequirePackage", "\\documentclass")
     private val TIKZ_IMPORT_COMMANDS = setOf("\\usetikzlibrary")
@@ -71,7 +75,10 @@ object PackageUtils {
         // When there are no usepackage commands: insert below documentclass.
         if (last == null) {
             val classHuh = commands.asSequence()
-                    .filter { cmd -> "\\documentclass" == cmd.commandToken.text || "\\LoadClass" == cmd.commandToken.text }
+                    .filter { cmd ->
+                        "\\documentclass" == cmd.commandToken
+                                .text || "\\LoadClass" == cmd.commandToken.text
+                    }
                     .firstOrNull()
             if (classHuh != null) {
                 insertLocation = classHuh.textOffset + classHuh.textLength
@@ -125,7 +132,9 @@ object PackageUtils {
         if (Magic.Package.conflictingPackages.any { it.contains(pack) }) {
             for (conflicts in Magic.Package.conflictingPackages) {
                 // Assuming the package is not already included
-                if (conflicts.contains(pack) && file.includedPackages().toSet().intersect(conflicts.map {it.name }).isNotEmpty()) {
+                if (conflicts.contains(pack) && file.includedPackages().toSet()
+                                .intersect(conflicts.map { it.name })
+                                .isNotEmpty()) {
                     return false
                 }
             }
@@ -214,8 +223,8 @@ object PackageUtils {
      */
     @JvmStatic
     fun <T : MutableCollection<String>> getIncludedPackages(
-        commands: Collection<LatexCommands>,
-        result: T
+            commands: Collection<LatexCommands>,
+            result: T
     ) = getPackagesFromCommands(commands, PACKAGE_COMMANDS, result)
 
     /**
@@ -223,8 +232,8 @@ object PackageUtils {
      */
     @JvmStatic
     fun <T : MutableCollection<String>> getIncludedTikzLibraries(
-        commands: Collection<LatexCommands>,
-        result: T
+            commands: Collection<LatexCommands>,
+            result: T
     ) = getPackagesFromCommands(commands, TIKZ_IMPORT_COMMANDS, result)
 
     /**
@@ -232,8 +241,8 @@ object PackageUtils {
      */
     @JvmStatic
     fun <T : MutableCollection<String>> getIncludedPgfLibraries(
-        commands: Collection<LatexCommands>,
-        result: T
+            commands: Collection<LatexCommands>,
+            result: T
     ) = getPackagesFromCommands(commands, PGF_IMPORT_COMMANDS, result)
 
     /**
@@ -243,9 +252,9 @@ object PackageUtils {
      * Note that not all elements returned may be valid package names.
      */
     private fun <T : MutableCollection<String>> getPackagesFromCommands(
-        commands: Collection<LatexCommands>,
-        packageCommands: Set<String>,
-        initial: T
+            commands: Collection<LatexCommands>,
+            packageCommands: Set<String>,
+            initial: T
     ): T {
         for (cmd in commands) {
             if (cmd.commandToken.text !in packageCommands) {
@@ -254,11 +263,14 @@ object PackageUtils {
 
             // Assume packages can be included in both optional and required parameters
             // Except a class, because a class is not a package
-            val packages = if (cmd.commandToken.text == "\\documentclass" || cmd.commandToken.text == "\\LoadClass") {
+            val packages = if (cmd.commandToken
+                            .text == "\\documentclass" || cmd.commandToken
+                            .text == "\\LoadClass") {
                 setOf(cmd.optionalParameters.keys.toList())
             }
             else {
-                setOf(cmd.requiredParameters, cmd.optionalParameters.keys.toList())
+                setOf(cmd.requiredParameters, cmd.optionalParameters.keys
+                        .toList())
             }
 
             for (list in packages) {
@@ -271,7 +283,8 @@ object PackageUtils {
 
                 // Multiple includes.
                 if (packageName.contains(",")) {
-                    initial.addAll(packageName.split(",").dropLastWhile(String::isNullOrEmpty))
+                    initial.addAll(packageName.split(",")
+                            .dropLastWhile(String::isNullOrEmpty))
                 }
                 // Single include.
                 else {
@@ -282,6 +295,10 @@ object PackageUtils {
 
         return initial
     }
+}
+
+object TexLivePackages {
+    lateinit var packageList: MutableList<String>
 }
 
 /**


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
#### Summary of additions and changes

* On TeX Live:
  * Adds inspection that checks if package is installed, and provides a quick fix to install a missing package (in the background).
* On anything not TeX Live:
  * The inspection is disabled by default and does nothing when enabled. 

#### How to test this pull request

* Use a package (with `\usepackage` or `\RequirePackage`) that is not installed and use the quick fix to install it.
* Verify that it is disabled by default on MiKTeX.
* Verify that when enabled on MiKTeX, it does nothing.

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Probable-bugs#package-may-not-exist