### PR TITLE
Add option to include backslash in word selection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
 }
 
 group 'nl.hannahsten'
-version '0.7-alpha.61'
+version '0.7-alpha.64'
 
 repositories {
     mavenCentral()

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -375,6 +375,8 @@
         <typedHandler implementation="nl.hannahsten.texifyidea.editor.autocompile.AutocompileHandler"/>
         <backspaceHandlerDelegate implementation="nl.hannahsten.texifyidea.editor.autocompile.AutoCompileBackspacehandler"/>
         <backspaceHandlerDelegate implementation="nl.hannahsten.texifyidea.editor.InlineMathBackspaceHandler" />
+        <extendWordSelectionHandler implementation="nl.hannahsten.texifyidea.editor.LatexCommandSelectioner"/>
+        <basicWordSelectionFilter implementation="nl.hannahsten.texifyidea.editor.CommandSelectionFilter"/>
 
         <!-- References and refactoring -->
         <lang.findUsagesProvider language="Latex" implementationClass="nl.hannahsten.texifyidea.reference.LatexUsagesProvider"/>

--- a/src/nl/hannahsten/texifyidea/editor/CommandSelectionFilter.kt
+++ b/src/nl/hannahsten/texifyidea/editor/CommandSelectionFilter.kt
@@ -1,0 +1,13 @@
+package nl.hannahsten.texifyidea.editor
+
+import com.intellij.openapi.util.Condition
+import com.intellij.psi.PsiElement
+import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.util.firstParentOfType
+
+/**
+ * Disable WordSelectioner (on by default) for LatexCommands, because we handle those in [LatexCommandSelectioner].
+ */
+class CommandSelectionFilter : Condition<PsiElement> {
+    override fun value(t: PsiElement?) = t?.firstParentOfType(LatexCommands::class)?.text != t?.text
+}

--- a/src/nl/hannahsten/texifyidea/editor/CommandSelectionFilter.kt
+++ b/src/nl/hannahsten/texifyidea/editor/CommandSelectionFilter.kt
@@ -2,7 +2,9 @@ package nl.hannahsten.texifyidea.editor
 
 import com.intellij.openapi.util.Condition
 import com.intellij.psi.PsiElement
+import nl.hannahsten.texifyidea.psi.LatexBeginCommand
 import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.psi.LatexEndCommand
 import nl.hannahsten.texifyidea.settings.TexifySettings
 import nl.hannahsten.texifyidea.util.firstParentOfType
 
@@ -10,5 +12,11 @@ import nl.hannahsten.texifyidea.util.firstParentOfType
  * Disable WordSelectioner (on by default) for LatexCommands, because we handle those in [LatexCommandSelectioner].
  */
 class CommandSelectionFilter : Condition<PsiElement> {
-    override fun value(t: PsiElement?) = !TexifySettings.getInstance().includeBackslashInSelection || t?.firstParentOfType(LatexCommands::class)?.text != t?.text
+    override fun value(t: PsiElement?) = !(
+            TexifySettings.getInstance().includeBackslashInSelection && (
+                    t?.firstParentOfType(LatexCommands::class)?.text == t?.text
+                    || t?.firstParentOfType(LatexBeginCommand::class)?.textOffset == t?.textOffset
+                    || t?.firstParentOfType(LatexEndCommand::class)?.textOffset == t?.textOffset
+                    )
+            )
 }

--- a/src/nl/hannahsten/texifyidea/editor/CommandSelectionFilter.kt
+++ b/src/nl/hannahsten/texifyidea/editor/CommandSelectionFilter.kt
@@ -3,11 +3,12 @@ package nl.hannahsten.texifyidea.editor
 import com.intellij.openapi.util.Condition
 import com.intellij.psi.PsiElement
 import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.settings.TexifySettings
 import nl.hannahsten.texifyidea.util.firstParentOfType
 
 /**
  * Disable WordSelectioner (on by default) for LatexCommands, because we handle those in [LatexCommandSelectioner].
  */
 class CommandSelectionFilter : Condition<PsiElement> {
-    override fun value(t: PsiElement?) = t?.firstParentOfType(LatexCommands::class)?.text != t?.text
+    override fun value(t: PsiElement?) = !TexifySettings.getInstance().includeBackslashInSelection || t?.firstParentOfType(LatexCommands::class)?.text != t?.text
 }

--- a/src/nl/hannahsten/texifyidea/editor/LatexCommandSelectioner.kt
+++ b/src/nl/hannahsten/texifyidea/editor/LatexCommandSelectioner.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.settings.TexifySettings
 import nl.hannahsten.texifyidea.util.firstParentOfType
 
 /**
@@ -13,7 +14,7 @@ import nl.hannahsten.texifyidea.util.firstParentOfType
  */
 class LatexCommandSelectioner : ExtendWordSelectionHandlerBase() {
     override fun canSelect(e: PsiElement): Boolean {
-        return e.firstParentOfType(LatexCommands::class)?.text == e.text
+        return TexifySettings.getInstance().includeBackslashInSelection && e.firstParentOfType(LatexCommands::class)?.text == e.text
     }
 
     override fun select(e: PsiElement, editorText: CharSequence, cursorOffset: Int, editor: Editor): MutableList<TextRange>? {

--- a/src/nl/hannahsten/texifyidea/editor/LatexCommandSelectioner.kt
+++ b/src/nl/hannahsten/texifyidea/editor/LatexCommandSelectioner.kt
@@ -5,16 +5,13 @@ import com.intellij.codeInsight.editorActions.SelectWordUtil
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
-import nl.hannahsten.texifyidea.psi.LatexCommands
-import nl.hannahsten.texifyidea.settings.TexifySettings
-import nl.hannahsten.texifyidea.util.firstParentOfType
 
 /**
  * Select all of the LatexCommands, so including the backslash.
  */
 class LatexCommandSelectioner : ExtendWordSelectionHandlerBase() {
     override fun canSelect(e: PsiElement): Boolean {
-        return TexifySettings.getInstance().includeBackslashInSelection && e.firstParentOfType(LatexCommands::class)?.text == e.text
+        return !CommandSelectionFilter().value(e)
     }
 
     override fun select(e: PsiElement, editorText: CharSequence, cursorOffset: Int, editor: Editor): MutableList<TextRange>? {

--- a/src/nl/hannahsten/texifyidea/editor/LatexCommandSelectioner.kt
+++ b/src/nl/hannahsten/texifyidea/editor/LatexCommandSelectioner.kt
@@ -1,0 +1,27 @@
+package nl.hannahsten.texifyidea.editor
+
+import com.intellij.codeInsight.editorActions.ExtendWordSelectionHandlerBase
+import com.intellij.codeInsight.editorActions.SelectWordUtil
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.util.firstParentOfType
+
+/**
+ * Select all of the LatexCommands, so including the backslash.
+ */
+class LatexCommandSelectioner : ExtendWordSelectionHandlerBase() {
+    override fun canSelect(e: PsiElement): Boolean {
+        return e.firstParentOfType(LatexCommands::class)?.text == e.text
+    }
+
+    override fun select(e: PsiElement, editorText: CharSequence, cursorOffset: Int, editor: Editor): MutableList<TextRange>? {
+        val ranges = super.select(e, editorText, cursorOffset, editor) ?: return null
+        val commandRange = e.textRange
+
+        SelectWordUtil.addWordOrLexemeSelection(false, editor, cursorOffset, mutableListOf(commandRange)) { c: Char -> c.isLetterOrDigit() || c == '\\'}
+        ranges += commandRange
+        return ranges
+    }
+}

--- a/src/nl/hannahsten/texifyidea/settings/TexifyConfigurable.kt
+++ b/src/nl/hannahsten/texifyidea/settings/TexifyConfigurable.kt
@@ -23,6 +23,7 @@ class TexifyConfigurable(private val settings: TexifySettings) : SearchableConfi
     private lateinit var autoCompile: JBCheckBox
     private lateinit var continuousPreview: JBCheckBox
     private lateinit var dockerizedMiktex: JBCheckBox
+    private lateinit var includeBackslashInSelection: JBCheckBox
     private lateinit var automaticQuoteReplacement: ComboBox<String>
     private lateinit var pdfViewer: ComboBox<String>
     private lateinit var labelDefiningCommands: TexifyConfigurableLabelCommands
@@ -45,6 +46,7 @@ class TexifyConfigurable(private val settings: TexifySettings) : SearchableConfi
                 autoCompile = addCheckbox("Automatic compilation (warning: can cause high CPU usage)")
                 continuousPreview = addCheckbox("Automatically refresh preview of math and TikZ pictures")
                 dockerizedMiktex = addCheckbox("Always use Dockerized MiKTeX")
+                includeBackslashInSelection = addCheckbox("Include the backslash in the selection when selecting a LaTeX command")
                 automaticQuoteReplacement = addSmartQuotesOptions("Off", "TeX ligatures", "TeX commands", "csquotes")
                 pdfViewer = addPdfViewerOptions()
                 add(labelDefiningCommands.getTable())
@@ -90,6 +92,7 @@ class TexifyConfigurable(private val settings: TexifySettings) : SearchableConfi
                 || autoCompile.isSelected != settings.autoCompile
                 || continuousPreview.isSelected != settings.continuousPreview
                 || dockerizedMiktex.isSelected != settings.dockerizedMiktex
+                || includeBackslashInSelection.isSelected != settings.includeBackslashInSelection
                 || automaticQuoteReplacement.selectedIndex != settings.automaticQuoteReplacement.ordinal
                 || pdfViewer.selectedIndex != settings.pdfViewer.ordinal
                 || labelDefiningCommands.isModified()
@@ -103,6 +106,7 @@ class TexifyConfigurable(private val settings: TexifySettings) : SearchableConfi
         settings.autoCompile = autoCompile.isSelected
         settings.continuousPreview = continuousPreview.isSelected
         settings.dockerizedMiktex = dockerizedMiktex.isSelected
+        settings.includeBackslashInSelection = includeBackslashInSelection.isSelected
         settings.automaticQuoteReplacement = TexifySettings.QuoteReplacement.values()[automaticQuoteReplacement.selectedIndex]
         settings.pdfViewer = PdfViewer.availableSubset()[pdfViewer.selectedIndex]
         labelDefiningCommands.apply()
@@ -116,6 +120,7 @@ class TexifyConfigurable(private val settings: TexifySettings) : SearchableConfi
         autoCompile.isSelected = settings.autoCompile
         continuousPreview.isSelected = settings.continuousPreview
         dockerizedMiktex.isSelected = settings.dockerizedMiktex
+        includeBackslashInSelection.isSelected = settings.includeBackslashInSelection
         automaticQuoteReplacement.selectedIndex = settings.automaticQuoteReplacement.ordinal
         pdfViewer.selectedIndex = PdfViewer.availableSubset().indexOf(settings.pdfViewer)
         labelDefiningCommands.reset()

--- a/src/nl/hannahsten/texifyidea/settings/TexifySettings.kt
+++ b/src/nl/hannahsten/texifyidea/settings/TexifySettings.kt
@@ -32,6 +32,7 @@ class TexifySettings : PersistentStateComponent<TexifySettingsState> {
     var autoCompile = false
     var continuousPreview = false
     var dockerizedMiktex = false
+    var includeBackslashInSelection = false
     var automaticQuoteReplacement = QuoteReplacement.NONE
     var pdfViewer = PdfViewer.values().first { it.isAvailable() }
 
@@ -50,6 +51,7 @@ class TexifySettings : PersistentStateComponent<TexifySettingsState> {
                 autoCompile = autoCompile,
                 continuousPreview = continuousPreview,
                 dockerizedMiktex = dockerizedMiktex,
+                includeBackslashInSelection = includeBackslashInSelection,
                 automaticQuoteReplacement = automaticQuoteReplacement,
                 pdfViewer = pdfViewer,
                 labelCommands = labelCommands.mapValues { it.value.toSerializableString() }
@@ -64,6 +66,7 @@ class TexifySettings : PersistentStateComponent<TexifySettingsState> {
         autoCompile = state.autoCompile
         continuousPreview = state.continuousPreview
         dockerizedMiktex = state.dockerizedMiktex
+        includeBackslashInSelection = state.includeBackslashInSelection
         automaticQuoteReplacement = state.automaticQuoteReplacement
         pdfViewer = state.pdfViewer
         state.labelCommands.forEach { labelCommands[it.key] = LabelingCommandInformation.fromString(it.value) }

--- a/src/nl/hannahsten/texifyidea/settings/TexifySettingsState.kt
+++ b/src/nl/hannahsten/texifyidea/settings/TexifySettingsState.kt
@@ -10,6 +10,7 @@ data class TexifySettingsState (
         var autoCompile: Boolean = false,
         var continuousPreview: Boolean = false,
         var dockerizedMiktex: Boolean = false,
+        var includeBackslashInSelection: Boolean = false,
         var automaticQuoteReplacement: TexifySettings.QuoteReplacement = TexifySettings.QuoteReplacement.NONE,
         var pdfViewer: PdfViewer = PdfViewer.firstAvailable(),
         var labelCommands: Map<String, String> =


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fixes #1314

#### Summary of additions and changes

* When setting is enabled, double-click or ctrl+w for example on a latex command will also select the backslash

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Global-settings#backslash-selection