### PR TITLE
Fix auto insert of second $

### DIFF
--- a/src/nl/hannahsten/texifyidea/highlighting/LatexTypedHandler.java
+++ b/src/nl/hannahsten/texifyidea/highlighting/LatexTypedHandler.java
@@ -57,7 +57,7 @@ public class LatexTypedHandler extends TypedHandlerDelegate {
             if (c == '$' && TexifySettings.getInstance().getAutomaticSecondInlineMathSymbol()) {
                 IElementType tokenType = getTypedTokenType(editor);
 
-                if (tokenType != LatexTypes.COMMAND_TOKEN && tokenType != LatexTypes.COMMENT_TOKEN) {
+                if (tokenType != LatexTypes.COMMAND_TOKEN && tokenType != LatexTypes.COMMENT_TOKEN && tokenType != LatexTypes.INLINE_MATH_END) {
                     editor.getDocument().insertString(
                             editor.getCaretModel().getOffset(),
                             String.valueOf(c)


### PR DESCRIPTION
## Summary of additions and changes

* Only automatically insert the second `$` when the just typed `$` opens an inline math environment.

#### How to test this pull request

* Play with typing and removing dollar signs.