### PR TITLE
Speed up LatexInclusionLoopInspection

### DIFF
--- a/src/nl/hannahsten/texifyidea/util/files/RootFile.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/RootFile.kt
@@ -137,7 +137,7 @@ fun PsiFile.isRoot(): Boolean {
  * Get all required arguments, also if comma separated in a group.
  * e.g. \mycommand{arg1,arg2}{arg3} will return [arg1, arg2, arg3].
  */
-private fun LatexCommands.getAllRequiredArguments(): List<String>? {
+fun LatexCommands.getAllRequiredArguments(): List<String>? {
     val required = requiredParameters
     if (required.isEmpty()) return null
     return required.flatMap { it.split(',')}


### PR DESCRIPTION
#### Summary of additions and changes

* Instead of using DFS on all file inclusions in the project, loop over commands index once and try to find file inclusion loops. Unfortunately this means we can only detect loops involving two files, but the old way was really hurting performance too much relative to the importance of the inspection (delayed all inspections for 20s in a large project for me).

#### How to test this pull request

* Two files that include each other, inspection only shown on one of them

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki