### PR TITLE
Fix hanging when block comments shortcut is used (and fix some crashes)

### DIFF
--- a/src/nl/hannahsten/texifyidea/editor/LatexCommenter.kt
+++ b/src/nl/hannahsten/texifyidea/editor/LatexCommenter.kt
@@ -9,11 +9,11 @@ open class LatexCommenter : Commenter {
 
     override fun getLineCommentPrefix() = "%"
 
-    override fun getBlockCommentPrefix() = ""
+    override fun getBlockCommentPrefix(): String? = null
 
-    override fun getBlockCommentSuffix() = ""
+    override fun getBlockCommentSuffix(): String? = null
 
-    override fun getCommentedBlockCommentPrefix() = ""
+    override fun getCommentedBlockCommentPrefix(): String? = null
 
-    override fun getCommentedBlockCommentSuffix() = ""
+    override fun getCommentedBlockCommentSuffix(): String? = null
 }

--- a/src/nl/hannahsten/texifyidea/inspections/bibtex/BibtexDuplicateBibliographyInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/bibtex/BibtexDuplicateBibliographyInspection.kt
@@ -56,6 +56,8 @@ open class BibtexDuplicateBibliographyInspection : TexifyInspectionBase() {
                         if (command.containingFile != file) continue
 
                         val parameterIndex = command.requiredParameter(0)?.indexOf(fileName) ?: break
+                        if (parameterIndex < 0) break
+
                         descriptors.add(manager.createProblemDescriptor(
                                 command,
                                 TextRange(parameterIndex, parameterIndex + fileName.length).shiftRight(command.commandToken.textLength + 1),

--- a/src/nl/hannahsten/texifyidea/ui/PreviewFormUpdater.kt
+++ b/src/nl/hannahsten/texifyidea/ui/PreviewFormUpdater.kt
@@ -106,11 +106,16 @@ $previewCode
             try {
                 // Create the default temp directory.
                 setPreviewCodeInTemp(createTempDir())
-            } catch (exception: AccessDeniedException) {
+            }
+            catch (exception: AccessDeniedException) {
                 // If pdf2svg or inkscape does not have access to the temp directory, try again with temp folder in the
                 // home directory.
                 setPreviewCodeInTemp(createTempDir(directory = File(System.getProperty("user.home"))))
-            } catch (exception: IOException) {
+            }
+            catch (exception: IOException) {
+                previewForm.setLatexErrorMessage("${exception.message}")
+            }
+            catch (exception: AccessDeniedException) {
                 previewForm.setLatexErrorMessage("${exception.message}")
             }
         }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fixes #1328
Fixes #1330 
Fixes #1331 

#### Summary of additions and changes

* Disable support for block comments

#### How to test this pull request

* ctrl + shift + / vs ctrl + /

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Line-commenting