### PR TITLE
Add typewriter (\texttt) postfix template

### DIFF
--- a/resources/postfixTemplates/LatexWrapWithTypewriterPostfixTemplate/after.tex.template
+++ b/resources/postfixTemplates/LatexWrapWithTypewriterPostfixTemplate/after.tex.template
@@ -1,0 +1,1 @@
+\texttt{word}

--- a/resources/postfixTemplates/LatexWrapWithTypewriterPostfixTemplate/before.tex.template
+++ b/resources/postfixTemplates/LatexWrapWithTypewriterPostfixTemplate/before.tex.template
@@ -1,0 +1,1 @@
+<spot>word</spot>$key

--- a/resources/postfixTemplates/LatexWrapWithTypewriterPostfixTemplate/description.html
+++ b/resources/postfixTemplates/LatexWrapWithTypewriterPostfixTemplate/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Put previous word in typerwriter face.
+</body>
+</html>

--- a/src/nl/hannahsten/texifyidea/editor/postfix/LatexPostFixTemplateProvider.kt
+++ b/src/nl/hannahsten/texifyidea/editor/postfix/LatexPostFixTemplateProvider.kt
@@ -16,7 +16,8 @@ object LatexPostFixTemplateProvider : PostfixTemplateProvider, CompletionContrib
     private val wrapWithTextCommandTemplates = mutableSetOf<PostfixTemplate>(
             LatexWrapWithBoldFacePostfixTemplate,
             LatexWrapWithItalicFacePostfixTemplate,
-            LatexWrapWithEmphPostfixTemplate
+            LatexWrapWithEmphPostfixTemplate,
+            LatexWrapWithTypewriterPostfixTemplate
     )
 
     private val wrapWithMathCommandTemplates = mutableSetOf<PostfixTemplate>(

--- a/src/nl/hannahsten/texifyidea/editor/postfix/LatexStringBasedPostfixTemplates.kt
+++ b/src/nl/hannahsten/texifyidea/editor/postfix/LatexStringBasedPostfixTemplates.kt
@@ -48,6 +48,7 @@ internal object LatexWrapWithTextPostfixTemplate : ConstantStringBasedPostfixTem
 internal object LatexWrapWithBoldFacePostfixTemplate : LatexWrapWithCommandPostfixTemplate("textbf", name = "bf", textOnly = true)
 internal object LatexWrapWithItalicFacePostfixTemplate : LatexWrapWithCommandPostfixTemplate("textit", name = "it", textOnly = true)
 internal object LatexWrapWithEmphPostfixTemplate : LatexWrapWithCommandPostfixTemplate("emph", textOnly = true)
+internal object LatexWrapWithTypewriterPostfixTemplate : LatexWrapWithCommandPostfixTemplate("texttt", name = "tt", textOnly = true)
 
 
 /* Wrap with math command postfix templates. */


### PR DESCRIPTION
Simply adds another default postfix template for \texttt