### PR TITLE
Custom preamble in preview

### DIFF
--- a/src/nl/hannahsten/texifyidea/action/preview/PreviewAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/preview/PreviewAction.kt
@@ -11,6 +11,7 @@ import nl.hannahsten.texifyidea.action.EditorAction
 import nl.hannahsten.texifyidea.ui.EquationPreviewToolWindow
 import nl.hannahsten.texifyidea.ui.PreviewFormUpdater
 import nl.hannahsten.texifyidea.util.files.referencedFileSet
+import java.util.*
 import javax.swing.Icon
 
 /**
@@ -93,8 +94,8 @@ abstract class PreviewAction(name: String, val icon: Icon?) : EditorAction(name,
     fun findPreamblesFromMagicComments(psiFile: PsiFile, name: String): String {
         val fileset = psiFile.referencedFileSet()
         val preambleRegex = """
-                %! begin = $name preamble(?<content>(\n.*)*\n)%! end = $name preamble
-            """.trimIndent().toRegex()
+                %! begin preamble\s*=\s*$name(?<content>(\n.*)*\n)%! end preamble\s*=\s*$name
+            """.trimIndent().toRegex(EnumSet.of(RegexOption.IGNORE_CASE))
 
         var preamble = ""
 

--- a/src/nl/hannahsten/texifyidea/action/preview/PreviewAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/preview/PreviewAction.kt
@@ -61,6 +61,7 @@ abstract class PreviewAction(name: String, val icon: Icon?) : EditorAction(name,
             val content = toolWindow.contentManager.getContent(i) ?: continue
             if (!content.isPinned) {
                 val form = content.getUserData(key) ?: continue
+                form.config()
                 form.compilePreview(element.text)
                 content.displayName = displayName
                 replaced = true

--- a/src/nl/hannahsten/texifyidea/action/preview/PreviewAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/preview/PreviewAction.kt
@@ -5,10 +5,12 @@ import com.intellij.openapi.util.Key
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.ui.content.ContentFactory
 import nl.hannahsten.texifyidea.action.EditorAction
 import nl.hannahsten.texifyidea.ui.EquationPreviewToolWindow
 import nl.hannahsten.texifyidea.ui.PreviewFormUpdater
+import nl.hannahsten.texifyidea.util.files.referencedFileSet
 import javax.swing.Icon
 
 /**
@@ -85,6 +87,22 @@ abstract class PreviewAction(name: String, val icon: Icon?) : EditorAction(name,
         }
         // Show but not focus the window
         toolWindow.activate(null, false)
+    }
 
+    fun findPreamblesFromMagicComments(psiFile: PsiFile, name: String): String {
+        val fileset = psiFile.referencedFileSet()
+        val preambleRegex = """
+                %! begin = $name preamble(?<content>(\n.*)*\n)%! end = $name preamble
+            """.trimIndent().toRegex()
+
+        var preamble = ""
+
+        for (f in fileset) {
+            preambleRegex.findAll(f.text).forEach {
+                preamble += it.groups["content"]?.value?.trim() ?: return@forEach
+            }
+        }
+
+        return preamble
     }
 }

--- a/src/nl/hannahsten/texifyidea/action/preview/PreviewAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/preview/PreviewAction.kt
@@ -93,15 +93,22 @@ abstract class PreviewAction(name: String, val icon: Icon?) : EditorAction(name,
 
     fun findPreamblesFromMagicComments(psiFile: PsiFile, name: String): String {
         val fileset = psiFile.referencedFileSet()
-        val preambleRegex = """
+        val preambleRegex = """%! preview preamble\s*=\s*$name""".toRegex(EnumSet.of(RegexOption.IGNORE_CASE))
+        val preambleRegexBeginEnd = """
                 %! begin preamble\s*=\s*$name(?<content>(\n.*)*\n)%! end preamble\s*=\s*$name
             """.trimIndent().toRegex(EnumSet.of(RegexOption.IGNORE_CASE))
 
         var preamble = ""
 
         for (f in fileset) {
-            preambleRegex.findAll(f.text).forEach {
-                preamble += it.groups["content"]?.value?.trim() ?: return@forEach
+            if (preambleRegex.containsMatchIn(f.text)) {
+                preamble += f.text
+            }
+            else {
+                preambleRegexBeginEnd.findAll(f.text).forEach {
+                    preamble += it.groups["content"]?.value?.trim()
+                            ?: return@forEach
+                }
             }
         }
 

--- a/src/nl/hannahsten/texifyidea/action/preview/ShowEquationPreview.kt
+++ b/src/nl/hannahsten/texifyidea/action/preview/ShowEquationPreview.kt
@@ -32,6 +32,8 @@ class ShowEquationPreview : PreviewAction("Equation Preview", TexifyIcons.EQUATI
 
         displayPreview(project, outerMathEnvironment, FORM_KEY) {
             preamble += MATH_PREAMBLE
+            val psiFile = element.containingFile
+            preamble += findPreamblesFromMagicComments(psiFile, "math")
         }
     }
 }

--- a/src/nl/hannahsten/texifyidea/action/preview/ShowEquationPreview.kt
+++ b/src/nl/hannahsten/texifyidea/action/preview/ShowEquationPreview.kt
@@ -31,6 +31,7 @@ class ShowEquationPreview : PreviewAction("Equation Preview", TexifyIcons.EQUATI
         val outerMathEnvironment = element.findOuterMathEnvironment() ?: return
 
         displayPreview(project, outerMathEnvironment, FORM_KEY) {
+            resetPreamble()
             preamble += MATH_PREAMBLE
             val psiFile = element.containingFile
             preamble += findPreamblesFromMagicComments(psiFile, "math")

--- a/src/nl/hannahsten/texifyidea/action/preview/ShowTikzPreview.kt
+++ b/src/nl/hannahsten/texifyidea/action/preview/ShowTikzPreview.kt
@@ -28,22 +28,26 @@ class ShowTikzPreview : PreviewAction("Tikz Picture Preview", TexifyIcons.TIKZ_P
     }
 
     override fun actionPerformed(file: VirtualFile, project: Project, textEditor: TextEditor) {
-        val element: PsiElement = getElement(file, project, textEditor) ?: return
+        val element: PsiElement = getElement(file, project, textEditor)
+                ?: return
 
         // Make sure we're currently in a tikz environment.
         val tikzEnvironment = findTikzEnvironment(element) ?: return
 
         displayPreview(project, tikzEnvironment, FORM_KEY) {
+            val psiFile = getPsiFile(file, project) ?: return@displayPreview
+
             preamble += "\\usepackage{tikz, pgfplots, amsmath}\n"
 
             // Add all of the tikz libs included in related packages (via \usetikzlibrary{}) to the produced document.
-            val tikzLibs = PackageUtils.getIncludedTikzLibraries(getPsiFile(file, project) ?: return@displayPreview)
+            val tikzLibs = PackageUtils.getIncludedTikzLibraries(psiFile)
             preamble += "\\usetikzlibrary{${tikzLibs.joinToString()}}\n"
 
             // Add all of the pgfplots libs included in related packages (via \usepgfplotslibrary{}) to the produced document.
-            val pgfLibs = PackageUtils.getIncludedPgfLibraries(getPsiFile(file, project) ?: return@displayPreview)
+            val pgfLibs = PackageUtils.getIncludedPgfLibraries(psiFile)
             preamble += "\\usepgfplotslibrary{${pgfLibs.joinToString()}}\n"
 
+            preamble += findPreamblesFromMagicComments(psiFile, "tikz")
             waitTime = 5L
         }
     }
@@ -53,7 +57,8 @@ class ShowTikzPreview : PreviewAction("Tikz Picture Preview", TexifyIcons.TIKZ_P
         if (innerElement is LatexEnvironment && innerElement.isTikz()) return innerElement
 
         // Find the first LatexEnvironment parent. If there are none, we aren't in tikz.
-        var currElement = innerElement.parentOfType(LatexEnvironment::class) ?: return null
+        var currElement = innerElement.parentOfType(LatexEnvironment::class)
+                ?: return null
 
         // Continue this process until we find a tikz environment or run out of parent environments.
         while (!currElement.isTikz() && currElement.hasParent(LatexEnvironment::class)) {
@@ -64,5 +69,6 @@ class ShowTikzPreview : PreviewAction("Tikz Picture Preview", TexifyIcons.TIKZ_P
         return if (currElement.isTikz()) currElement else null
     }
 
-    private fun LatexEnvironment.isTikz() = beginCommand.environmentName()?.toLowerCase() == "tikzpicture"
+    private fun LatexEnvironment.isTikz() = beginCommand.environmentName()
+            ?.toLowerCase() == "tikzpicture"
 }

--- a/src/nl/hannahsten/texifyidea/action/preview/ShowTikzPreview.kt
+++ b/src/nl/hannahsten/texifyidea/action/preview/ShowTikzPreview.kt
@@ -35,6 +35,7 @@ class ShowTikzPreview : PreviewAction("Tikz Picture Preview", TexifyIcons.TIKZ_P
         val tikzEnvironment = findTikzEnvironment(element) ?: return
 
         displayPreview(project, tikzEnvironment, FORM_KEY) {
+            resetPreamble()
             val psiFile = getPsiFile(file, project) ?: return@displayPreview
 
             preamble += "\\usepackage{tikz, pgfplots, amsmath}\n"

--- a/src/nl/hannahsten/texifyidea/completion/LatexMagicCommentValueProvider.kt
+++ b/src/nl/hannahsten/texifyidea/completion/LatexMagicCommentValueProvider.kt
@@ -1,0 +1,16 @@
+package nl.hannahsten.texifyidea.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionProvider
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.util.ProcessingContext
+
+class LatexMagicCommentValueProvider(val values: HashSet<String>) : CompletionProvider<CompletionParameters>() {
+
+    override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
+        result.addAllElements(values.map {
+            LookupElementBuilder.create(it)
+        })
+    }
+}

--- a/src/nl/hannahsten/texifyidea/completion/TexifyCompletionContributor.kt
+++ b/src/nl/hannahsten/texifyidea/completion/TexifyCompletionContributor.kt
@@ -192,6 +192,20 @@ open class TexifyCompletionContributor : CompletionContributor() {
                 LatexInspectionIdProvider
         )
 
+        // List containing tikz/math to autocomplete the begin/end/preamble values in magic comments.
+        val beginEndRegex = Regex("""(begin|end|preview) preamble\s*=\s*""", EnumSet.of(RegexOption.IGNORE_CASE))
+        extend(
+                CompletionType.BASIC,
+                PlatformPatterns.psiElement().inside(PsiComment::class.java)
+                        .with(object : PatternCondition<PsiElement>("Magic comment preamble pattern") {
+                            override fun accepts(comment: PsiElement, context: ProcessingContext?): Boolean {
+                                return comment.isMagicComment() && comment.text.contains(beginEndRegex)
+                            }
+                        })
+                        .withLanguage(LatexLanguage.INSTANCE),
+                LatexMagicCommentValueProvider(Magic.Comment.preambleValues)
+        )
+
         // Package names
         extendLatexCommands(LatexPackageNameProvider, "\\usepackage", "\\RequirePackage")
 

--- a/src/nl/hannahsten/texifyidea/lang/DefaultEnvironment.kt
+++ b/src/nl/hannahsten/texifyidea/lang/DefaultEnvironment.kt
@@ -89,6 +89,9 @@ enum class DefaultEnvironment(
     // listings
     LISTINGS(environmentName = "lstlisting", dependency = Package.LISTINGS),
 
+    // tikz
+    TIKZPICTURE(environmentName = "tikzpicture", dependency = Package.TIKZ),
+
     // xcolor
     TESTCOLORS(environmentName = "testcolors", arguments = *arrayOf(OptionalArgument("num models")), dependency = XCOLOR);
 

--- a/src/nl/hannahsten/texifyidea/lang/Package.kt
+++ b/src/nl/hannahsten/texifyidea/lang/Package.kt
@@ -34,6 +34,7 @@ open class Package @JvmOverloads constructor(
         @JvmField val MATHTOOLS = Package("mathtools")
         @JvmField val NATBIB = Package("natbib")
         @JvmField val SUBFILES = Package("subfiles")
+        @JvmField val TIKZ = Package("tikz")
         @JvmField val ULEM = Package("ulem")
         @JvmField val XCOLOR = Package("xcolor")
         @JvmField val XPARSE = Package("xparse")

--- a/src/nl/hannahsten/texifyidea/lang/magic/DefaultMagicKeys.kt
+++ b/src/nl/hannahsten/texifyidea/lang/magic/DefaultMagicKeys.kt
@@ -29,6 +29,18 @@ enum class DefaultMagicKeys(
         You can suppress multiple inspections by separating the name of inspections by a comma.
     """.trimIndent().trim()),
 
+    BEGIN_PREAMBLE("Begin preamble", """
+        Indicates the start of a (part of) preamble to be included in the preview.
+    """.trimIndent().trim(), MagicCommentScope.FILE.singleScope()),
+
+    END_PREAMBLE("End preamble", """
+        Indicates the end of a (part of) preamble to be included in the preview.
+    """.trimIndent().trim(), MagicCommentScope.FILE.singleScope()),
+
+    PREVIEW_PREAMBLE("Preview preamble", """
+        Indicates that this file has to be included in the preamble of the preview.
+    """.trimIndent().trim(), MagicCommentScope.FILE.singleScope()),
+
     // TeXdoc.
     INFO("Info", """
         A documentation description for a definition.

--- a/src/nl/hannahsten/texifyidea/ui/PreviewFormUpdater.kt
+++ b/src/nl/hannahsten/texifyidea/ui/PreviewFormUpdater.kt
@@ -15,24 +15,32 @@ import javax.swing.SwingUtilities.invokeLater
  * @author Sergei Izmailov
  */
 class PreviewFormUpdater(private val previewForm: PreviewForm) {
-
     /**
-     * Modify this variable to include more packages.
+     * The default preamble.
      *
      * Unless you are going to set your own \pagestyle{}, simply append to this variable.
      */
-    var preamble = """
+    private val defaultPreamble = """
         \pagestyle{empty}
-
-        \usepackage{color}
-
     """.trimIndent()
+
+    /**
+     * Modify this variable to include more packages.
+     */
+    var preamble = defaultPreamble
 
     /**
      * Controls how long (in seconds) we will wait for the document compilation. If the time taken exceeds this,
      * we will return an error and not output a preview.
      */
     var waitTime = 3L
+
+    /**
+     * Reset the preamble to the default preamble.
+     */
+    fun resetPreamble() {
+        preamble = defaultPreamble
+    }
 
     /**
      * Sets the code that will be previewed, whether that be an equation, a tikz picture, or whatever else

--- a/src/nl/hannahsten/texifyidea/util/Magic.kt
+++ b/src/nl/hannahsten/texifyidea/util/Magic.kt
@@ -221,6 +221,10 @@ object Magic {
         val verbatim = hashSetOf("verbatim", "Verbatim", "lstlisting", "plantuml")
     }
 
+    object Comment {
+        val preambleValues = hashSetOf("tikz", "math")
+    }
+
     /**
      * @author Hannah Schellekens
      */


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fixes #1052 

#### Summary of additions and changes

* Add magic comments to surround preamble of math or tikz preamble of the preview: `%! begin preamble = tikz`
* Add magic comments to include entire file in preamble of the preview: `%! preview preamble = tikz`

#### How to test this pull request

**main.tex**
```latex
\documentclass[11pt]{article}
\usepackage{packages/mypackage}
%! Begin preamble = math
\newcommand{\ha}{\pi\xi\alpha}
%! End preamble = math

\begin{document}
    \begin{tikzpicture}[>=Latex]
        \bla
        \node[right = of 0] (1) {2};

        \draw[->] (0) -- (1);
    \end{tikzpicture}

    \[
        \ha \phi
    \]
\end{document}
```

**packages/mypackage.sty**
```latex
%! preview preamble = tikz
\NeedsTeXFormat{LaTeX2e}
\ProvidesPackage{packages/mypackage}[My Package]
\RequirePackage{tikz}
\usetikzlibrary{positioning}
\usetikzlibrary{arrows.meta}
\newcommand{\bla}{\node[draw, circle] (0) {$x$};}
```

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Preview#custom-preamble-for-equation-and-tikz-preview