### PR TITLE
Compiler magic comments

### DIFF
--- a/src/nl/hannahsten/texifyidea/completion/LatexMagicCommentKeyProvider.kt
+++ b/src/nl/hannahsten/texifyidea/completion/LatexMagicCommentKeyProvider.kt
@@ -19,7 +19,7 @@ object LatexMagicCommentKeyProvider : CompletionProvider<CompletionParameters>()
     override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
         val keys = DefaultMagicKeys.values()
         result.addAllElements(ContainerUtil.map2List(keys) {
-            LookupElementBuilder.create(it, it.key)
+            LookupElementBuilder.create(it, it.displayKey)
                     .withCaseSensitivity(false)
                     .withPresentableText(it.key)
                     .bold()

--- a/src/nl/hannahsten/texifyidea/completion/TexifyCompletionContributor.kt
+++ b/src/nl/hannahsten/texifyidea/completion/TexifyCompletionContributor.kt
@@ -17,6 +17,8 @@ import nl.hannahsten.texifyidea.completion.pathcompletion.LatexGraphicsPathProvi
 import nl.hannahsten.texifyidea.lang.*
 import nl.hannahsten.texifyidea.psi.*
 import nl.hannahsten.texifyidea.psi.LatexMathEnvironment
+import nl.hannahsten.texifyidea.run.compiler.BibliographyCompiler
+import nl.hannahsten.texifyidea.run.compiler.LatexCompiler
 import nl.hannahsten.texifyidea.util.*
 import java.util.*
 
@@ -178,34 +180,21 @@ open class TexifyCompletionContributor : CompletionContributor() {
 
         extendLatexCommands(LatexBibliographyReferenceProvider, Magic.Command.bibliographyReference)
 
-        // Inspection list for magic comment suppress.
+        // Inspection list for magic comment suppress
         val suppressRegex = Regex("""suppress\s*=\s*""", EnumSet.of(RegexOption.IGNORE_CASE))
-        extend(
-                CompletionType.BASIC,
-                PlatformPatterns.psiElement().inside(PsiComment::class.java)
-                        .with(object : PatternCondition<PsiElement>("Magic comment suppress pattern") {
-                            override fun accepts(comment: PsiElement, context: ProcessingContext?): Boolean {
-                                return comment.isMagicComment() && comment.text.contains(suppressRegex)
-                            }
-                        })
-                        .withLanguage(LatexLanguage.INSTANCE),
-                LatexInspectionIdProvider
-        )
+        extendMagicCommentValues("suppress", suppressRegex, LatexInspectionIdProvider)
 
-        // List containing tikz/math to autocomplete the begin/end/preamble values in magic comments.
+        // List containing tikz/math to autocomplete the begin/end/preamble values in magic comments
         val beginEndRegex = Regex("""(begin|end|preview) preamble\s*=\s*""", EnumSet.of(RegexOption.IGNORE_CASE))
-        extend(
-                CompletionType.BASIC,
-                PlatformPatterns.psiElement().inside(PsiComment::class.java)
-                        .with(object : PatternCondition<PsiElement>("Magic comment preamble pattern") {
-                            override fun accepts(comment: PsiElement, context: ProcessingContext?): Boolean {
-                                return comment.isMagicComment() && comment.text.contains(beginEndRegex)
-                            }
-                        })
-                        .withLanguage(LatexLanguage.INSTANCE),
-                LatexMagicCommentValueProvider(Magic.Comment.preambleValues)
-        )
+        extendMagicCommentValues("preamble", beginEndRegex, LatexMagicCommentValueProvider(Magic.Comment.preambleValues))
 
+        // List of LaTeX compilers
+        val compilerRegex = Regex("""compiler\s*=\s*""", EnumSet.of(RegexOption.IGNORE_CASE))
+        extendMagicCommentValues("compiler", compilerRegex, LatexMagicCommentValueProvider(LatexCompiler.values().map { it.executableName }.toHashSet()))
+
+        val bibtexCompilerRegex = Regex("""bibtex compiler\s*=\s*""", EnumSet.of(RegexOption.IGNORE_CASE))
+        extendMagicCommentValues("bibtex compiler", bibtexCompilerRegex, LatexMagicCommentValueProvider(BibliographyCompiler.values().map { it.executableName }.toHashSet()))
+        
         // Package names
         extendLatexCommands(LatexPackageNameProvider, "\\usepackage", "\\RequirePackage")
 
@@ -289,6 +278,23 @@ open class TexifyCompletionContributor : CompletionContributor() {
                         })
                         .withLanguage(LatexLanguage.INSTANCE),
                 provider
+        )
+    }
+
+    /**
+     * Adds a completions contributor that gets activated when typing a value for a magic comment.
+     */
+    private fun extendMagicCommentValues(commentName: String, regex: Regex, completionProvider: CompletionProvider<CompletionParameters>) {
+        extend(
+                CompletionType.BASIC,
+                PlatformPatterns.psiElement().inside(PsiComment::class.java)
+                        .with(object : PatternCondition<PsiElement>("Magic comment $commentName pattern") {
+                            override fun accepts(comment: PsiElement, context: ProcessingContext?): Boolean {
+                                return comment.isMagicComment() && comment.text.contains(regex)
+                            }
+                        })
+                        .withLanguage(LatexLanguage.INSTANCE),
+                completionProvider
         )
     }
 }

--- a/src/nl/hannahsten/texifyidea/lang/magic/DefaultMagicKeys.kt
+++ b/src/nl/hannahsten/texifyidea/lang/magic/DefaultMagicKeys.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.lang.magic
 
+import nl.hannahsten.texifyidea.run.compiler.BibliographyCompiler
 import nl.hannahsten.texifyidea.run.compiler.LatexCompiler
 
 /**
@@ -7,74 +8,100 @@ import nl.hannahsten.texifyidea.run.compiler.LatexCompiler
  */
 enum class DefaultMagicKeys(
         override val key: String,
+        val displayKey: String,
         override val documentation: String,
         override val targets: Set<MagicCommentScope> = MagicCommentScope.ALL_SCOPES
 ) : MagicKey<String> {
 
     // TeXworks-esque relevant keys.
-    PROGRAM("Program", """
+    COMPILER("compiler",
+            "Compiler", """
         The name of the typesetting engine to use for the current file.
         The following programs are supported:
         ${LatexCompiler.values().joinToString(", ") { it.executableName }}
-    """.trimIndent().trim(), MagicCommentScope.FILE.singleScope()),
+    """.trimIndent().trim(),
+            MagicCommentScope.FILE.singleScope()
+    ),
 
-    ROOT("Root", """
+    BIBTEXCOMPILER("bibtex compiler",
+            "BibTeX Compiler", """
+        The name of the typesetting engine to use for the current file.
+        The following programs are supported:
+        ${BibliographyCompiler.values()
+            .joinToString(", ") { it.executableName }}
+    """.trimIndent().trim(),
+            MagicCommentScope.FILE.singleScope()),
+
+    ROOT("root",
+            "Root", """
         Indicates that the file with the given name (relative to this file) is the root file of your document.
     """.trimIndent().trim(), MagicCommentScope.FILE.singleScope()),
 
     // TeXiFy functionality.
-    SUPPRESS("Suppress", """
+    SUPPRESS("surpress",
+            "Suppress", """
         Denotes that an inspection in the following scope must be suppressed.
         A value of 'All' means that all inspections will be suppressed.
         You can suppress multiple inspections by separating the name of inspections by a comma.
     """.trimIndent().trim()),
 
-    INJECT_LANGUAGE("language", """
+    INJECT_LANGUAGE("language",
+            "Language", """
         Indicates that a language should be injected in the following environment.
     """.trimIndent().trim(), MagicCommentScope.ENVIRONMENT.singleScope()),
 
-    BEGIN_PREAMBLE("Begin preamble", """
+    BEGIN_PREAMBLE("begin preamble",
+            "Begin preamble", """
         Indicates the start of a (part of) preamble to be included in the preview.
     """.trimIndent().trim(), MagicCommentScope.FILE.singleScope()),
 
-    END_PREAMBLE("End preamble", """
+    END_PREAMBLE("end preamble",
+            "End preamble", """
         Indicates the end of a (part of) preamble to be included in the preview.
     """.trimIndent().trim(), MagicCommentScope.FILE.singleScope()),
 
-    PREVIEW_PREAMBLE("Preview preamble", """
+    PREVIEW_PREAMBLE("preview preamble",
+            "Preview preamble", """
         Indicates that this file has to be included in the preamble of the preview.
     """.trimIndent().trim(), MagicCommentScope.FILE.singleScope()),
 
-    PARSER("Parser", """
+    PARSER("parser",
+            "Parser", """
         Allows for switching parsing off and on.
     """.trimIndent().trim(), MagicCommentScope.FILE.singleScope()),
 
     // TeXdoc.
-    INFO("Info", """
+    INFO("info",
+            "Info", """
         A documentation description for a definition.
     """.trimIndent().trim(), MagicCommentScope.COMMAND.singleScope()),
 
-    PARAM("Param", """
+    PARAM("param",
+            "Param", """
         Adds documentation for the next required parameter.
         The first usage of 'Param' will document the 1st parameter, the second usage of 'Param' the 2nd etc.
     """.trimIndent().trim(), MagicCommentScope.COMMAND.singleScope()),
 
-    OPTIONAL("Optional", """
+    OPTIONAL("optional",
+            "Optional", """
         Adds documentation for the next optional parameter.
         The first usage of 'Optional' will document the 1st parameter, the second usage of 'Optional' the 2nd etc.
         The value starts with the format <tt>fieldname=defaultvalue</tt>.
         After a separating space the documentation description starts.
     """.trimIndent().trim(), MagicCommentScope.COMMAND.singleScope()),
 
-    SINCE("Since", """
+    SINCE("since",
+            "Since", """
         The version number that denotes since when the feature is available.
     """.trimIndent().trim(), MagicCommentScope.COMMAND.singleScope()),
 
-    AUTHOR("Author", """
+    AUTHOR("author",
+            "Author", """
         The name of the author.
     """.trimIndent().trim(), MagicCommentScope.COMMAND.singleScope()),
 
-    SEE("See", """
+    SEE("see",
+            "See", """
         A comma separated list of command names (including backslash) and environments to link to in the documentation.
         These commands and environments are related to the documented command or environment.
     """.trimIndent().trim(), MagicCommentScope.COMMAND.singleScope());

--- a/src/nl/hannahsten/texifyidea/lang/magic/DefaultMagicKeys.kt
+++ b/src/nl/hannahsten/texifyidea/lang/magic/DefaultMagicKeys.kt
@@ -38,7 +38,7 @@ enum class DefaultMagicKeys(
     """.trimIndent().trim(), MagicCommentScope.FILE.singleScope()),
 
     // TeXiFy functionality.
-    SUPPRESS("surpress",
+    SUPPRESS("suppress",
             "Suppress", """
         Denotes that an inspection in the following scope must be suppressed.
         A value of 'All' means that all inspections will be suppressed.

--- a/src/nl/hannahsten/texifyidea/lang/magic/TextBasedMagicCommentParser.kt
+++ b/src/nl/hannahsten/texifyidea/lang/magic/TextBasedMagicCommentParser.kt
@@ -26,7 +26,7 @@ open class TextBasedMagicCommentParser(private val comments: List<String>) : Mag
         /**
          * Matches against a key assignment.
          */
-        private val KEY_ASSIGNMENT = Regex("""^([a-zA-Z]+)\s*=""")
+        private val KEY_ASSIGNMENT = Regex("""^([a-zA-Z\s]+)\s*=""")
     }
 
     override fun parse(): MagicComment<String, String> = MutableMagicComment<String, String>().apply {
@@ -39,7 +39,7 @@ open class TextBasedMagicCommentParser(private val comments: List<String>) : Mag
         /** Adds the current key with converts to the magic comment. Also resets the key and content. */
         fun pushKeyValuePair() {
             if (key == null) return
-            addValue(key!!.asKey(), contentBuffer.toString().trim())
+            addValue(key!!.trim().asKey(), contentBuffer.toString().trim())
             contentBuffer = StringBuilder()
             key = null
         }

--- a/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
+++ b/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
@@ -259,6 +259,18 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
 
     override fun toString() = this.displayName
 
+    companion object {
+        fun byExecutableName(exe: String): LatexCompiler {
+            for (compiler in values()) {
+                if (compiler.executableName.equals(exe, ignoreCase = true)) {
+                    return compiler
+                }
+            }
+
+            return PDFLATEX
+        }
+    }
+
     /**
      * @author Hannah Schellekens
      */

--- a/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
+++ b/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
@@ -261,13 +261,9 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
 
     companion object {
         fun byExecutableName(exe: String): LatexCompiler {
-            for (compiler in values()) {
-                if (compiler.executableName.equals(exe, ignoreCase = true)) {
-                    return compiler
-                }
-            }
-
-            return PDFLATEX
+            return values().firstOrNull {
+                it.executableName.equals(exe, true)
+            } ?: PDFLATEX
         }
     }
 
@@ -285,15 +281,9 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
         companion object {
 
             fun byNameIgnoreCase(name: String?): Format {
-                if (name == null) return PDF
-
-                for (format in values()) {
-                    if (format.name.equals(name, ignoreCase = true)) {
-                        return format
-                    }
-                }
-
-                return PDF
+                return values().firstOrNull {
+                    it.name.equals(name, ignoreCase = true)
+                } ?: PDF
             }
         }
     }

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
@@ -172,7 +172,8 @@ class LatexRunConfiguration constructor(project: Project,
         val compilerName = parent.getChildText(COMPILER)
         try {
             this.compiler = LatexCompiler.valueOf(compilerName)
-        } catch (e: IllegalArgumentException) {
+        }
+        catch (e: IllegalArgumentException) {
             this.compiler = null
         }
 
@@ -227,16 +228,14 @@ class LatexRunConfiguration constructor(project: Project,
                 val usesAuxDir = java.lang.Boolean.parseBoolean(auxDirBoolean)
                 val moduleRoot = ProjectRootManager.getInstance(project).fileIndex.getContentRootForFile(this.mainFile!!)
                 val path = if (usesAuxDir) moduleRoot?.path + "/auxil" else this.mainFile!!.parent.path
-                this.auxilPath = LocalFileSystem.getInstance()
-                        .findFileByPath(path)
+                this.auxilPath = LocalFileSystem.getInstance().findFileByPath(path)
             }
             val outDirBoolean = parent.getChildText(OUT_DIR)
             if (outDirBoolean != null && this.outputPath == null && this.mainFile != null) {
                 val usesOutDir = java.lang.Boolean.parseBoolean(outDirBoolean)
                 val moduleRoot = ProjectRootManager.getInstance(project).fileIndex.getContentRootForFile(this.mainFile!!)
                 val path = if (usesOutDir) moduleRoot?.path + "/out" else this.mainFile!!.parent.path
-                this.outputPath = LocalFileSystem.getInstance()
-                        .findFileByPath(path)
+                this.outputPath = LocalFileSystem.getInstance().findFileByPath(path)
             }
         }
 
@@ -250,8 +249,7 @@ class LatexRunConfiguration constructor(project: Project,
         }
 
         // Read output format.
-        val format = Format
-                .byNameIgnoreCase(parent.getChildText(OUTPUT_FORMAT))
+        val format = Format.byNameIgnoreCase(parent.getChildText(OUTPUT_FORMAT))
         this.outputFormat = format
 
         // Read whether the run config has been run
@@ -261,8 +259,7 @@ class LatexRunConfiguration constructor(project: Project,
         // Read bibliography run configurations, which is a list of ids
         val bibRunConfigElt = parent.getChildText(BIB_RUN_CONFIG)
         // Assume the list is of the form [id 1,id 2]
-        this.bibRunConfigIds = bibRunConfigElt.drop(1).dropLast(1).split(", ")
-                .toMutableSet()
+        this.bibRunConfigIds = bibRunConfigElt.drop(1).dropLast(1).split(", ").toMutableSet()
 
         // Read makeindex run configuration
         val makeindexRunConfigElt = parent.getChildText(MAKEINDEX_RUN_CONFIG)
@@ -412,17 +409,13 @@ class LatexRunConfiguration constructor(project: Project,
 
 
         // When chapterbib is used, every chapter has its own bibliography and needs its own run config
-        val usesChapterbib = psiFile?.includedPackages()
-                ?.contains("chapterbib") == true
-
-
+        val usesChapterbib = psiFile?.includedPackages()?.contains("chapterbib") == true
 
         if (!usesChapterbib) {
             addBibRunConfig(defaultCompiler, mainFile, compilerFromMagicComment?.second)
         }
         else if (psiFile != null) {
-            val allBibliographyCommands = psiFile!!.commandsInFileSet()
-                    .filter { it.name == "\\bibliography" }
+            val allBibliographyCommands = psiFile!!.commandsInFileSet().filter { it.name == "\\bibliography" }
 
             // We know that there can only be one bibliography per top-level \include,
             // however not all of them may contain a bibliography, and the ones
@@ -567,8 +560,7 @@ class LatexRunConfiguration constructor(project: Project,
         var defaultOutputPath: VirtualFile? = null
         runReadAction {
             val moduleRoot = ProjectRootManager.getInstance(project).fileIndex.getContentRootForFile(mainFile!!)
-            defaultOutputPath = LocalFileSystem.getInstance()
-                    .findFileByPath(moduleRoot?.path + "/out")
+            defaultOutputPath = LocalFileSystem.getInstance().findFileByPath(moduleRoot?.path + "/out")
         }
         return defaultOutputPath
     }
@@ -586,8 +578,7 @@ class LatexRunConfiguration constructor(project: Project,
         // -aux-directory pdflatex flag only exists on MiKTeX, so disable auxil otherwise
         if (auxilPath != null || mainFile == null || !LatexDistribution.isMiktex) return
         val moduleRoot = ProjectRootManager.getInstance(project).fileIndex.getContentRootForFile(mainFile!!)
-        this.auxilPath = LocalFileSystem.getInstance()
-                .findFileByPath(moduleRoot?.path + "/auxil")
+        this.auxilPath = LocalFileSystem.getInstance().findFileByPath(moduleRoot?.path + "/auxil")
     }
 
     /**

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfigurationProducer.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfigurationProducer.kt
@@ -42,9 +42,12 @@ class LatexRunConfigurationProducer : LazyRunConfigurationProducer<LatexRunConfi
         runConfiguration.setDefaultOutputPath()
         runConfiguration.setDefaultAuxilPath()
         runConfiguration.setSuggestedName()
+
         val runCommand = container.allParentMagicComments().value(DefaultMagicKeys.COMPILER)
         if (runCommand != null) {
-            val compiler = runCommand.let { it.subSequence(0, it.indexOf(' ')) }.trim().toString()
+            val compiler = if (runCommand.contains(' ')) {
+                runCommand.let { it.subSequence(0, it.indexOf(' ')) }.trim().toString()
+            } else runCommand
             runConfiguration.compiler = LatexCompiler.byExecutableName(compiler)
             runConfiguration.compilerArguments = runCommand.removePrefix(compiler).trim()
         }

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfigurationProducer.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfigurationProducer.kt
@@ -9,6 +9,9 @@ import com.intellij.openapi.util.Ref
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.file.LatexFileType
+import nl.hannahsten.texifyidea.lang.magic.DefaultMagicKeys
+import nl.hannahsten.texifyidea.lang.magic.allParentMagicComments
+import nl.hannahsten.texifyidea.run.compiler.LatexCompiler
 
 /**
  * @author Hannah Schellekens
@@ -39,7 +42,12 @@ class LatexRunConfigurationProducer : LazyRunConfigurationProducer<LatexRunConfi
         runConfiguration.setDefaultOutputPath()
         runConfiguration.setDefaultAuxilPath()
         runConfiguration.setSuggestedName()
-
+        val runCommand = container.allParentMagicComments().value(DefaultMagicKeys.COMPILER)
+        if (runCommand != null) {
+            val compiler = runCommand.let { it.subSequence(0, it.indexOf(' ')) }.trim().toString()
+            runConfiguration.compiler = LatexCompiler.byExecutableName(compiler)
+            runConfiguration.compilerArguments = runCommand.removePrefix(compiler).trim()
+        }
         return true
     }
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->

#### Summary of additions and changes

* Adds magic comments to specify the LaTeX and BibTeX compiler, including compiler arguments.

#### How to test this pull request

```latex
%! Compiler = latexmk -lualatex
```

or
 
```latex
%! BibTeX Compiler = biber
```

Check if I didn't break any of the other magic comments.

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Compilers#using-magic-comments-to-specify-the-compiler-for-new-run-configurations