### PR TITLE
#1405: confines underscore inspection to fewer places

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexEscapeUnderscoreInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexEscapeUnderscoreInspection.kt
@@ -4,10 +4,10 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.psi.PsiElement
 import nl.hannahsten.texifyidea.inspections.TexifyRegexInspection
 import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.psi.LatexNormalText
 import nl.hannahsten.texifyidea.util.Magic
 import nl.hannahsten.texifyidea.util.firstParentOfType
 import nl.hannahsten.texifyidea.util.inMathContext
-import nl.hannahsten.texifyidea.util.isComment
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
@@ -29,21 +29,13 @@ class LatexEscapeUnderscoreInspection : TexifyRegexInspection(
     }
 
     private fun PsiElement.isUnderscoreAllowed(): Boolean {
-        if (this.isComment()) return true
         if (this.inMathContext()) return true
-        if (this.firstParentOfType(LatexCommands::class)?.name in commandsAllowingUnderscore) return true
-        return false
+        if (this.firstParentOfType(LatexNormalText::class) != null) return false
+        if (this.firstParentOfType(LatexCommands::class)?.name in commandsDisallowingUnderscore) return false
+        return true
     }
 
     companion object {
-        val commandsAllowingUnderscore = Magic.Command.urls +
-                Magic.Command.labelDefinition +
-                Magic.Command.reference +
-                Magic.Command.absoluteImportCommands +
-                Magic.Command.relativeImportCommands +
-                Magic.Command.classDefinitions +
-                Magic.Command.packageDefinitions +
-                Magic.Command.regularCommandDefinitions +
-                setOf("\\input", "\\bibliography", "\\documentclass", "\\usepackage")
+        private val commandsDisallowingUnderscore = Magic.Command.sectionMarkers + Magic.Command.textStyles + setOf("""\caption""")
     }
 }

--- a/src/nl/hannahsten/texifyidea/util/Magic.kt
+++ b/src/nl/hannahsten/texifyidea/util/Magic.kt
@@ -498,6 +498,16 @@ object Magic {
         )
 
         /**
+         * Set of text styling commands
+         */
+        @JvmField
+        val textStyles = setOf(
+                "\\textrm", "\\textsf", "\\texttt", "\\textit",
+                "\\textsl", "\\textsc", "\\textbf", "\\emph",
+                "\\textup", "\\textmd"
+        )
+
+        /**
          * All commands that mark some kind of section.
          */
         @JvmField

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LatexEscapeUnderscoreInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LatexEscapeUnderscoreInspectionTest.kt
@@ -5,10 +5,39 @@ import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
 
 internal class LatexEscapeUnderscoreInspectionTest : TexifyInspectionTestBase(LatexEscapeUnderscoreInspection()) {
 
-    fun `test unescaped _ character warning`() {
+    fun `test unescaped _ character triggers warning in normal text`() {
         myFixture.configureByText(LatexFileType, """
             \begin{document}
-                some text <warning descr="Escape character \ expected">_</warning> with unescaped special character
+                some text <warning descr="Escape character \ expected">_</warning> with unescaped underscore character
+            \end{document}
+        """.trimIndent())
+        myFixture.checkHighlighting(true, false, false, false)
+    }
+
+    fun `test unescaped _ character triggers warning in section title`() {
+        myFixture.configureByText(LatexFileType, """
+            \begin{document}
+                \section{some title <warning descr="Escape character \ expected">_</warning> with unescaped underscore character}
+            \end{document}
+        """.trimIndent())
+        myFixture.checkHighlighting(true, false, false, false)
+    }
+
+    fun `test unescaped _ character triggers warning in captions`() {
+        myFixture.configureByText(LatexFileType, """
+            \begin{document}
+                \begin{figure}
+                  \caption{A picture of a <warning descr="Escape character \ expected">_</warning>}
+                \end{figure}
+            \end{document}
+        """.trimIndent())
+        myFixture.checkHighlighting(true, false, false, false)
+    }
+
+    fun `test unescaped _ character triggers warning in textit`() {
+        myFixture.configureByText(LatexFileType, """
+            \begin{document}
+                italic \textit{<warning descr="Escape character \ expected">_</warning>} underscore
             \end{document}
         """.trimIndent())
         myFixture.checkHighlighting(true, false, false, false)
@@ -24,7 +53,7 @@ internal class LatexEscapeUnderscoreInspectionTest : TexifyInspectionTestBase(La
         myFixture.checkHighlighting(true, false, false, false)
     }
 
-    fun `test unescaped _ character triggers no warning in math`() {
+    fun `test unescaped _ character triggers no warning in math environments`() {
         myFixture.configureByText(LatexFileType, """
             \begin{document}
                 \[ a_b \]
@@ -51,6 +80,7 @@ internal class LatexEscapeUnderscoreInspectionTest : TexifyInspectionTestBase(La
                 \ProvidesClass{my_class}
                 \documentclass[my_option]{my_class}
                 \usepackage[my_option]{my_package}
+                \include{my_file}
             \end{document}
         """.trimIndent())
         myFixture.checkHighlighting(true, false, false, false)
@@ -60,6 +90,15 @@ internal class LatexEscapeUnderscoreInspectionTest : TexifyInspectionTestBase(La
         myFixture.configureByText(LatexFileType, """
             \begin{document}
                 \url{web_site}
+            \end{document}
+        """.trimIndent())
+        myFixture.checkHighlighting(true, false, false, false)
+    }
+
+    fun `test unescaped _ character triggers no warning in comment`() {
+        myFixture.configureByText(LatexFileType, """
+            \begin{document}
+                % this is a comment _
             \end{document}
         """.trimIndent())
         myFixture.checkHighlighting(true, false, false, false)


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fixes #1405 

#### Summary of additions and changes

Rather than having the inspection everywhere and only disallowing it in certain places I switched it now to be the other way around. I think it is a lot simpler now and will not trigger false positives but rather only miss some cases, which is a better trade-off imo.

It now only triggers the unescaped underscore inspection in normal text, and commands like `\section`, `\textit`, `\caption`, etc.


#### How to test this pull request

I added some tests, but I might have missed cases, so please have a look and tell me what you think.

#### Wiki

No need to update the wiki