### PR TITLE
Fixed certain inspections triggering inside comments

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexEllipsisInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexEllipsisInspection.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
+import com.intellij.refactoring.suggested.startOffset
 import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.lang.Package.Companion.AMSMATH
@@ -33,6 +34,11 @@ open class LatexEllipsisInspection : TexifyInspectionBase() {
             ProgressManager.checkCanceled()
 
             for (match in Magic.Pattern.ellipsis.findAll(text.text)) {
+                // Ignore the inspection when the ellipsis is inside a comment.
+                if (file.findElementAt(match.range.first + text.startOffset)?.isComment() == true) {
+                    continue
+                }
+
                 descriptors.add(manager.createProblemDescriptor(
                         text,
                         match.range.toTextRange(),

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexEscapeAmpersandInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexEscapeAmpersandInspection.kt
@@ -25,7 +25,7 @@ class LatexEscapeAmpersandInspection : TexifyRegexInspection(
 ) {
     override fun checkContext(matcher: Matcher, element: PsiElement): Boolean {
         if (element.isAmpersandAllowed()) return false
-        return checkContext(element)
+        return super.checkContext(matcher, element)
     }
 
     private fun PsiElement.isAmpersandAllowed(): Boolean {

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexEscapeAmpersandInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexEscapeAmpersandInspection.kt
@@ -25,7 +25,8 @@ class LatexEscapeAmpersandInspection : TexifyRegexInspection(
 ) {
     override fun checkContext(matcher: Matcher, element: PsiElement): Boolean {
         if (element.isAmpersandAllowed()) return false
-        return super.checkContext(matcher, element)
+        if (element.isComment()) return false
+        return checkContext(element)
     }
 
     private fun PsiElement.isAmpersandAllowed(): Boolean {

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexEscapeUnderscoreInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexEscapeUnderscoreInspection.kt
@@ -23,6 +23,7 @@ class LatexEscapeUnderscoreInspection : TexifyRegexInspection(
         replacement = { _, _ -> """\_""" },
         quickFixName = { """Change to \_""" }
 ) {
+
     override fun checkContext(matcher: Matcher, element: PsiElement): Boolean {
         if (element.isUnderscoreAllowed()) return false
         return checkContext(element)
@@ -36,6 +37,7 @@ class LatexEscapeUnderscoreInspection : TexifyRegexInspection(
     }
 
     companion object {
+
         private val commandsDisallowingUnderscore = Magic.Command.sectionMarkers + Magic.Command.textStyles + setOf("""\caption""")
     }
 }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexEscapeUnderscoreInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexEscapeUnderscoreInspection.kt
@@ -26,7 +26,7 @@ class LatexEscapeUnderscoreInspection : TexifyRegexInspection(
 
     override fun checkContext(matcher: Matcher, element: PsiElement): Boolean {
         if (element.isUnderscoreAllowed()) return false
-        return checkContext(element)
+        return super.checkContext(matcher, element)
     }
 
     private fun PsiElement.isUnderscoreAllowed(): Boolean {

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexLineBreakInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexLineBreakInspection.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
-import nl.hannahsten.texifyidea.psi.LatexComment
 import nl.hannahsten.texifyidea.psi.LatexNormalText
 import nl.hannahsten.texifyidea.util.*
 import nl.hannahsten.texifyidea.util.files.document
@@ -30,9 +29,11 @@ open class LatexLineBreakInspection : TexifyInspectionBase() {
         val descriptors = descriptorList()
         val document = file.document() ?: return descriptors
 
+        // Target all regular text for this inspection.
         val texts = file.childrenOfType(LatexNormalText::class)
-        for (text: LatexNormalText in texts) {
-            if (text.inMathContext() || text.hasParent(LatexComment::class)) {
+        for (text in texts) {
+            // Do not trigger the inspection in math mode.
+            if (text.inMathContext()) {
                 continue
             }
 
@@ -42,9 +43,17 @@ open class LatexLineBreakInspection : TexifyInspectionBase() {
                 val lineNumber = document.getLineNumber(offset)
                 val endLine = document.getLineEndOffset(lineNumber)
 
+                val startOffset = matcher.start()
+                val endOffset = matcher.end() + (endLine - offset)
+
+                // Do not trigger the inspection when in a comment.
+                if (file.findElementAt(startOffset)?.isComment() == true) {
+                    continue
+                }
+
                 descriptors.add(manager.createProblemDescriptor(
                         text,
-                        TextRange(matcher.start(), min(text.textLength, matcher.end() + (endLine - offset))),
+                        TextRange(startOffset, min(text.textLength, endOffset)),
                         "Sentence does not start on a new line",
                         ProblemHighlightType.WEAK_WARNING,
                         isOntheFly,
@@ -66,17 +75,13 @@ open class LatexLineBreakInspection : TexifyInspectionBase() {
         override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
             val textElement = descriptor.psiElement
             val document = textElement.containingFile.document() ?: return
-            val matcher = Magic.Pattern.sentenceEnd.matcher(textElement.text)
             val range = descriptor.textRangeInElement
             val textOffset = textElement.textOffset
             val textInElement = document.getText(TextRange(textOffset + range.startOffset, textOffset + range.endOffset))
 
-            if (!matcher.find()) {
-                return
-            }
-
+            // Do not apply the fix when there is no break point.
             val signMarker = Magic.Pattern.sentenceSeparator.matcher(textInElement)
-            if (!signMarker.find()) {
+            if (signMarker.find().not()) {
                 return
             }
 

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexLineBreakInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexLineBreakInspection.kt
@@ -7,6 +7,7 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFile
+import com.intellij.refactoring.suggested.startOffset
 import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.psi.LatexNormalText
@@ -47,7 +48,7 @@ open class LatexLineBreakInspection : TexifyInspectionBase() {
                 val endOffset = matcher.end() + (endLine - offset)
 
                 // Do not trigger the inspection when in a comment.
-                if (file.findElementAt(startOffset)?.isComment() == true) {
+                if (file.findElementAt(startOffset + text.startOffset)?.isComment() == true) {
                     continue
                 }
 

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LatexEscapeUnderscoreInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LatexEscapeUnderscoreInspectionTest.kt
@@ -99,6 +99,12 @@ internal class LatexEscapeUnderscoreInspectionTest : TexifyInspectionTestBase(La
         myFixture.configureByText(LatexFileType, """
             \begin{document}
                 % this is a comment _
+                
+                \begin{center}
+                    text
+                    % this is a comment with a _
+                    text
+                \end{center}
             \end{document}
         """.trimIndent())
         myFixture.checkHighlighting(true, false, false, false)

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LatexLineBreakInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LatexLineBreakInspectionTest.kt
@@ -1,0 +1,34 @@
+package nl.hannahsten.texifyidea.inspections.latex
+
+import nl.hannahsten.texifyidea.file.LatexFileType
+import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
+import nl.hannahsten.texifyidea.testutils.writeCommand
+
+class LatexLineBreakInspectionTest : TexifyInspectionTestBase(LatexLineBreakInspection()) {
+    fun testWarning() {
+        myFixture.configureByText(LatexFileType, """
+            Not this, b<weak_warning descr="Sentence does not start on a new line">ut. This starts a new line.</weak_warning>
+This e<weak_warning descr="Sentence does not start on a new line">tc. is missing a normal space, but i.e. this etc.</weak_warning>\ is not.
+            % not. in. comments
+        """.trimIndent())
+        myFixture.checkHighlighting()
+    }
+
+    fun testQuickfix() {
+        myFixture.configureByText(LatexFileType,
+        """
+            I end. a sentence.
+        """.trimIndent())
+
+        val quickFixes = myFixture.getAllQuickFixes()
+        assertEquals(1, quickFixes.size)
+        writeCommand(myFixture.project) {
+            quickFixes.first().invoke(myFixture.project, myFixture.editor, myFixture.file)
+        }
+
+        myFixture.checkResult("""
+            I end.
+            a sentence.
+        """.trimIndent())
+    }
+}


### PR DESCRIPTION
Fixes #1417

Edit: Currently fixing build.

#### Summary of additions and changes

* The LatexLineBreakInspection does no longer trigger in comments.
* The LatexEllipsisInspection does no longer trigger in comments.
* The LatexEscapeUnderscoreInspection does no longer trigger in comments.
* The LatexEscapeAmpersandInspection does no longer trigger incomments.

#### How to test this pull request

```latex
\begin{document}

    % Starting. Comment...
    % Some text. Break trigger.

    Something... Of nie a.u.b. of wat. \csname one_two \endcsname or H&M

    % Text comment... ofnie. Of wa. Hehe. a.u.b. of wat? H&M
    % Of niet \"i \csname one_two \endcsname
    % Of toch wel... one_two

    Meer tekst...
    OF niet, soms?

\end{document}
```

![image](https://user-images.githubusercontent.com/17410729/82192611-82ac6600-98f4-11ea-8a22-aa4894c6457a.png)
