### PR TITLE
Cache for LaTeX package locations

### DIFF
--- a/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
+++ b/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
@@ -4,6 +4,7 @@ import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
 import com.intellij.ide.util.gotoByName.GotoFileCellRenderer
+import com.intellij.openapi.util.SystemInfo
 import com.intellij.psi.PsiElement
 import nl.hannahsten.texifyidea.TexifyIcons
 import nl.hannahsten.texifyidea.lang.LatexCommand
@@ -49,7 +50,14 @@ class LatexNavigationGutter : RelatedItemLineMarkerProvider() {
 
         val referencesList = command.references.filterIsInstance<InputFileReference>()
         if (referencesList.isEmpty()) return
-        val files = referencesList.mapNotNull { it.resolve() }
+
+        // Since kpsewhich is too slow on Windows, we only enable file resolving on non-Windows systems (for the gutter icon targets)
+        val files = if (!SystemInfo.isWindows) {
+            referencesList.mapNotNull { it.resolve() }
+        }
+        else {
+            emptyList()
+        }
 
         val defaultIcon = TexifyIcons.getIconFromExtension(referencesList.first().defaultExtension)
         val extension = if (files.isNotEmpty()) { files.first().name.getFileExtension() } else ""

--- a/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
+++ b/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
@@ -4,7 +4,6 @@ import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
 import com.intellij.ide.util.gotoByName.GotoFileCellRenderer
-import com.intellij.openapi.util.SystemInfo
 import com.intellij.psi.PsiElement
 import nl.hannahsten.texifyidea.TexifyIcons
 import nl.hannahsten.texifyidea.lang.LatexCommand
@@ -51,22 +50,9 @@ class LatexNavigationGutter : RelatedItemLineMarkerProvider() {
         val referencesList = command.references.filterIsInstance<InputFileReference>()
         if (referencesList.isEmpty()) return
 
-        // Since kpsewhich is too slow on Windows, we only enable file resolving on non-Windows systems (for the gutter icon targets)
-        val files = if (!SystemInfo.isWindows) {
-            referencesList.mapNotNull { it.resolve() }
-        }
-        else {
-            emptyList()
-        }
-
-        val defaultIcon = TexifyIcons.getIconFromExtension(referencesList.first().defaultExtension)
+        val files = referencesList.mapNotNull { it.resolve() }
         val extension = if (files.isNotEmpty()) { files.first().name.getFileExtension() } else ""
-        val icon = if (!files.isNullOrEmpty() && TexifyIcons.getIconFromExtension(extension) == TexifyIcons.FILE) {
-            defaultIcon
-        }
-        else {
-            TexifyIcons.getIconFromExtension(extension)
-        }
+        val icon = TexifyIcons.getIconFromExtension(extension)
 
         val builder = NavigationGutterIconBuilder
                 .create(icon)

--- a/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
@@ -1,0 +1,39 @@
+package nl.hannahsten.texifyidea.util.files
+
+import java.io.BufferedReader
+import java.io.IOException
+import java.io.InputStreamReader
+
+/**
+ * Cache locations of LaTeX packages in memory, because especially on Windows they can be expensive to retrieve
+ * (requires a run of kpsewhich).
+ */
+object LatexPackageLocationCache {
+
+    private val cache = mutableMapOf<String, String?>()
+
+    /**
+     * Get the full path to the location of the package with the given name, or null in case there was any problem.
+     * Note that if the package is not yet in the cache and multiple callers try to get it concurrently, then
+     * the kpsewhich method will still be executed as much as there are callers.
+     * If needed, this can be avoided using coroutines with a mutex (see [ReferencedFileSetCache]).
+     *
+     * @param name Package name with extension.
+     */
+    fun getPackageLocation(name: String) = cache.getOrPut(name) {
+        runKpsewhich(
+            name
+        )
+    }
+
+    private fun runKpsewhich(arg: String): String? = try {
+        BufferedReader(
+            InputStreamReader(Runtime.getRuntime().exec(
+            "kpsewhich $arg"
+        ).inputStream)
+        ).readLine()  // Returns null if no line read.
+    }
+    catch (e: IOException) {
+        null
+    }
+}

--- a/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.util.files
 
+import nl.hannahsten.texifyidea.run.latex.LatexDistribution
 import java.io.BufferedReader
 import java.io.IOException
 import java.io.InputStreamReader
@@ -27,10 +28,15 @@ object LatexPackageLocationCache {
     }
 
     private fun runKpsewhich(arg: String): String? = try {
-        BufferedReader(
-            InputStreamReader(Runtime.getRuntime().exec(
+        val command = if (LatexDistribution.isMiktexAvailable) {
+            // Don't install the package if not present
+            "miktex-kpsewhich --miktex-disable-installer $arg"
+        }
+        else {
             "kpsewhich $arg"
-        ).inputStream)
+        }
+        BufferedReader(
+            InputStreamReader(Runtime.getRuntime().exec(command).inputStream)
         ).readLine()  // Returns null if no line read.
     }
     catch (e: IOException) {


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fixes #1424

#### Summary of additions and changes

* Cache locations in memory (as String)
* Multiple calls to kpsewhich may still occur while adding to the cache concurrently

#### How to test this pull request

Have lots of usepackages, I guess

