### PR TITLE
Support for \subfileinclude

### DIFF
--- a/src/nl/hannahsten/texifyidea/lang/LatexRegularCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/LatexRegularCommand.kt
@@ -261,6 +261,7 @@ enum class LatexRegularCommand(
     STOP("stop"),
     STRETCH("stretch", "factor".asRequired()),
     SUBFILE("subfile", RequiredFileArgument("sourcefile", "tex"), dependency = SUBFILES),
+    SUBFILEINCLUDE("subfileinclude", RequiredFileArgument("sourcefile", "tex"), dependency = SUBFILES),
     SUBIMPORT("subimport", RequiredFolderArgument("relative path"), RequiredFileArgument("filename", false, "tex"), dependency = Package.IMPORT),
     SUBINCLUDEFROM("subincludefrom", RequiredFolderArgument("relative path"), RequiredFileArgument("filename", false, "tex"), dependency = Package.IMPORT),
     SUBITEM("subitem"),

--- a/src/nl/hannahsten/texifyidea/util/Magic.kt
+++ b/src/nl/hannahsten/texifyidea/util/Magic.kt
@@ -470,6 +470,7 @@ object Magic {
         @JvmField
         val illegalExtensions = mapOf(
                 "\\include" to listOf(".tex"),
+                "\\subfileinclude" to listOf(".tex"),
                 "\\bibliography" to listOf(".bib")
         )
 
@@ -489,6 +490,7 @@ object Magic {
                 "\\include" to hashSetOf("tex"),
                 "\\includeonly" to hashSetOf("tex"),
                 "\\subfile" to hashSetOf("tex"),
+                "\\subfileinclude" to hashSetOf("tex"),
                 "\\bibliography" to hashSetOf("bib"),
                 "\\addbibresource" to hashSetOf("bib"),
                 "\\RequirePackage" to hashSetOf("sty"),


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fixes #1435

#### Summary of additions and changes

- Add `\subfileinclude` as include command, with supported extension `.tex`.
- As for `\include`, the file extension should not be provided (only the base name).

#### How to test this pull request

Create a `main.tex` file with `\subfileinclude{test}`, and another file `test.tex` with
```latex
\documentclass[main.tex]{subfiles}

\begin{document}
    Test!
\end{document}
```