### PR TITLE
Only register equation and tikz preview tool windows when needed

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -401,10 +401,6 @@
         <lang.findUsagesProvider language="Bibtex" implementationClass="nl.hannahsten.texifyidea.reference.BibtexUsagesProvider"/>
         <lang.refactoringSupport language="Bibtex" implementationClass="nl.hannahsten.texifyidea.refactoring.BibtexRefactoringSupportProvider" />
 
-        <!-- Tool windows -->
-        <toolWindow id="Equation Preview" anchor="bottom" factoryClass="nl.hannahsten.texifyidea.action.preview.PreviewToolWindowFactory" icon="/nl/hannahsten/texifyidea/icons/equation-preview.svg" canCloseContents="true" />
-        <toolWindow id="Tikz Picture Preview" anchor="bottom" factoryClass="nl.hannahsten.texifyidea.action.preview.PreviewToolWindowFactory" icon="/nl/hannahsten/texifyidea/icons/tikz-preview.svg" canCloseContents="true" />
-
         <!-- Navigation -->
         <gotoSymbolContributor implementation="nl.hannahsten.texifyidea.navigation.GotoLabelSymbolContributor"/>
         <gotoSymbolContributor implementation="nl.hannahsten.texifyidea.navigation.GotoCommandDefinitionSymbolContributor"/>

--- a/src/nl/hannahsten/texifyidea/action/preview/PreviewAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/preview/PreviewAction.kt
@@ -2,6 +2,7 @@ package nl.hannahsten.texifyidea.action.preview
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
+import com.intellij.openapi.wm.RegisterToolWindowTask
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
@@ -11,7 +12,7 @@ import nl.hannahsten.texifyidea.action.EditorAction
 import nl.hannahsten.texifyidea.ui.EquationPreviewToolWindow
 import nl.hannahsten.texifyidea.ui.PreviewFormUpdater
 import nl.hannahsten.texifyidea.util.files.referencedFileSet
-import java.util.*
+import java.util.EnumSet
 import javax.swing.Icon
 
 /**
@@ -46,7 +47,8 @@ abstract class PreviewAction(name: String, val icon: Icon?) : EditorAction(name,
         val toolWindowId = name
         val toolWindowManager = ToolWindowManager.getInstance(project)
 
-        val toolWindow = toolWindowManager.getToolWindow(toolWindowId) ?: throw IllegalStateException("ToolWindow not found")
+        val task = RegisterToolWindowTask(toolWindowId, contentFactory = PreviewToolWindowFactory(), icon = icon)
+        val toolWindow = toolWindowManager.registerToolWindow(task)
 
         val containingFile = element.containingFile
         val psiDocumentManager = PsiDocumentManager.getInstance(project)


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1503

I didn't check whether we need to unregister them on plugin unload, and how we would need to do that.