### PR TITLE
Disable non-ascii inspection in non-identifiers

### DIFF
--- a/src/nl/hannahsten/texifyidea/psi/LatexParameterTextUtil.kt
+++ b/src/nl/hannahsten/texifyidea/psi/LatexParameterTextUtil.kt
@@ -13,15 +13,14 @@ import nl.hannahsten.texifyidea.util.firstParentOfType
  */
 @Suppress("RemoveExplicitTypeArguments") // Somehow they are needed
 fun getReferences(element: LatexParameterText): Array<PsiReference> {
-    val command = element.firstParentOfType(LatexCommands::class) ?: return emptyArray<PsiReference>()
     // If the command is a label reference
     // NOTE When adding options here, also update getNameIdentifier below
     return when {
-        Magic.Command.labelReferenceWithoutCustomCommands.contains(command.name) -> {
+        Magic.Command.labelReferenceWithoutCustomCommands.contains(element.firstParentOfType(LatexCommands::class)?.name) -> {
             arrayOf<PsiReference>(LatexLabelParameterReference(element))
         }
         // If the command is a bibliography reference
-        Magic.Command.bibliographyReference.contains(command.name) -> {
+        Magic.Command.bibliographyReference.contains(element.firstParentOfType(LatexCommands::class)?.name) -> {
             arrayOf<PsiReference>(BibtexIdReference(element))
         }
         // If the command is an \end command (references to \begin)

--- a/src/nl/hannahsten/texifyidea/psi/LatexParameterTextUtil.kt
+++ b/src/nl/hannahsten/texifyidea/psi/LatexParameterTextUtil.kt
@@ -15,6 +15,7 @@ import nl.hannahsten.texifyidea.util.firstParentOfType
 fun getReferences(element: LatexParameterText): Array<PsiReference> {
     val command = element.firstParentOfType(LatexCommands::class) ?: return emptyArray<PsiReference>()
     // If the command is a label reference
+    // NOTE When adding options here, also update getNameIdentifier below
     return when {
         Magic.Command.labelReferenceWithoutCustomCommands.contains(command.name) -> {
             arrayOf<PsiReference>(LatexLabelParameterReference(element))
@@ -46,7 +47,16 @@ fun getReference(element: LatexParameterText): PsiReference? {
     }
 }
 
-fun getNameIdentifier(element: LatexParameterText): PsiElement {
+fun getNameIdentifier(element: LatexParameterText): PsiElement? {
+    // Because we do not want to trigger the NonAsciiCharactersInspection when the LatexParameterText is not an identifier
+    // (think non-ASCII characters in a \section command), we return null here when the element is not an identifier
+    val name = element.firstParentOfType(LatexCommands::class)?.name
+    if (!Magic.Command.labelReferenceWithoutCustomCommands.contains(name) &&
+        !Magic.Command.labelDefinitionsWithoutCustomCommands.contains(name) &&
+        !Magic.Command.bibliographyReference.contains(name) &&
+        element.firstParentOfType(LatexEndCommand::class) == null) {
+        return null
+    }
     return element
 }
 

--- a/src/nl/hannahsten/texifyidea/util/Magic.kt
+++ b/src/nl/hannahsten/texifyidea/util/Magic.kt
@@ -445,16 +445,16 @@ object Magic {
          */
         @JvmField
         val redefinitions = hashSetOf(
-                "\\" + RENEWCOMMAND.command,
-                "\\" + RENEWCOMMAND_STAR.command,
-                "\\" + PROVIDECOMMAND.command, // Does nothing if command exists
-                "\\" + PROVIDECOMMAND_STAR.command,
-                "\\" + PROVIDEDOCUMENTCOMMAND.command, // Does nothing if command exists
-                "\\" + DECLAREDOCUMENTCOMMAND.command,
-                "\\" + DEF.command,
-                "\\" + LET.command,
-                "\\" + RENEWENVIRONMENT.command
-        )
+                RENEWCOMMAND,
+                RENEWCOMMAND_STAR,
+                PROVIDECOMMAND, // Does nothing if command exists
+                PROVIDECOMMAND_STAR,
+                PROVIDEDOCUMENTCOMMAND, // Does nothing if command exists
+                DECLAREDOCUMENTCOMMAND,
+                DEF,
+                LET,
+                RENEWENVIRONMENT
+        ).map { "\\" + it.command }
 
         /**
          * All commands that define or redefine regular commands.
@@ -496,12 +496,12 @@ object Magic {
          */
         @JvmField
         val environmentDefinitions = hashSetOf(
-                "\\newenvironment",
-                "\\newtheorem",
-                "\\NewDocumentEnvironment",
-                "\\ProvideDocumentEnvironment",
-                "\\DeclareDocumentEnvironment"
-        )
+            NEWENVIRONMENT,
+            NEWTHEOREM,
+            NEWDOCUMENTENVIRONMENT,
+            PROVIDEDOCUMENTENVIRONMENT,
+            DECLAREDOCUMENTENVIRONMENT
+        ).map { "\\" + it.command }
 
         /**
          * All commands that define stuff like classes, environments, and definitions.
@@ -510,7 +510,7 @@ object Magic {
         val definitions = commandDefinitions + classDefinitions + packageDefinitions + environmentDefinitions
 
         /**
-         * Commands for which TeXiFy-IDEA has custom behaviour.
+         * Commands for which TeXiFy-IDEA has essential custom behaviour and which should not be redefined.
          */
         @JvmField
         val fragile = hashSetOf(
@@ -533,9 +533,9 @@ object Magic {
          */
         @JvmField
         val illegalExtensions = mapOf(
-                "\\include" to listOf(".tex"),
-                "\\subfileinclude" to listOf(".tex"),
-                "\\bibliography" to listOf(".bib")
+                "\\" + INCLUDE.command to listOf(".tex"),
+                "\\" + SUBFILEINCLUDE.command to listOf(".tex"),
+                "\\" + BIBLIOGRAPHY.command to listOf(".bib")
         )
 
         /**
@@ -543,7 +543,7 @@ object Magic {
          */
         @JvmField
         val requiredExtensions = mapOf(
-                "\\addbibresource" to listOf("bib")
+                "\\" + ADDBIBRESOURCE.command to listOf("bib")
         )
 
         /**

--- a/test/nl/hannahsten/texifyidea/inspections/latex/NonAsciiCharactersInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/NonAsciiCharactersInspectionTest.kt
@@ -1,0 +1,15 @@
+package nl.hannahsten.texifyidea.inspections.latex
+
+import com.intellij.codeInspection.NonAsciiCharactersInspection
+import nl.hannahsten.texifyidea.file.LatexFileType
+import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
+
+class NonAsciiCharactersInspectionTest : TexifyInspectionTestBase(NonAsciiCharactersInspection()) {
+    fun testWarning() {
+        myFixture.configureByText(LatexFileType, """
+            \textbf{erhöhen}
+            \label{<warning descr="Identifier contains symbols from different languages: [LATIN, CYRILLIC]"><warning descr="Non-ASCII characters in an identifier">sec:Название</warning></warning>}
+        """.trimIndent())
+        myFixture.checkHighlighting()
+    }
+}

--- a/test/nl/hannahsten/texifyidea/reference/LatexEnvironmentReferenceTest.kt
+++ b/test/nl/hannahsten/texifyidea/reference/LatexEnvironmentReferenceTest.kt
@@ -1,0 +1,19 @@
+package nl.hannahsten.texifyidea.reference
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import nl.hannahsten.texifyidea.file.LatexFileType
+
+class LatexEnvironmentReferenceTest : BasePlatformTestCase() {
+
+    fun testEnvironmentRename() {
+        myFixture.configureByText(LatexFileType, """
+            \begin{document}
+            \end{document<caret>}
+        """.trimIndent())
+        myFixture.renameElementAtCaret("nodocument")
+        myFixture.checkResult("""
+            \begin{nodocument}
+            \end{nodocument<caret>}
+        """.trimIndent())
+    }
+}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1499

#### Summary of additions and changes

* Return null in `getNameIdentifier` for commands that do not have identifiers as parameter 
* Fix environment rename and add test for it