### PR TITLE
Add support for label prefixing to commandmanager

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexFigureNotReferencedInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexFigureNotReferencedInspection.kt
@@ -10,7 +10,7 @@ import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.util.*
 import nl.hannahsten.texifyidea.util.files.commandsInFileSet
-import java.util.*
+import java.util.EnumSet
 
 open class LatexFigureNotReferencedInspection : TexifyInspectionBase() {
 
@@ -36,8 +36,11 @@ open class LatexFigureNotReferencedInspection : TexifyInspectionBase() {
     }
 
     private fun removeReferencedLabels(file: PsiFile, figureLabels: MutableMap<String?, LatexCommands>) {
+        val referenceCommands = Magic.Command.getLabelReferenceCommands(file.project)
         for (command in file.commandsInFileSet()) {
-            if (Magic.Command.labelReferenceWithoutCustomCommands.contains(command.name)) {
+            // Don't resolve references in command definitions
+            if (command.parent.firstParentOfType(LatexCommands::class)?.name in Magic.Command.commandDefinitions ||
+                referenceCommands.contains(command.name)) {
                 command.referencedLabelNames.forEach { figureLabels.remove(it) }
             }
         }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexFileNotFoundInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexFileNotFoundInspection.kt
@@ -12,17 +12,14 @@ import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.reference.InputFileReference
 import nl.hannahsten.texifyidea.ui.CreateFileDialog
+import nl.hannahsten.texifyidea.util.*
 import nl.hannahsten.texifyidea.util.Magic.Command.illegalExtensions
-import nl.hannahsten.texifyidea.util.PackageUtils
-import nl.hannahsten.texifyidea.util.appendExtension
 import nl.hannahsten.texifyidea.util.files.commandsInFile
 import nl.hannahsten.texifyidea.util.files.createFile
 import nl.hannahsten.texifyidea.util.files.findRootFile
 import nl.hannahsten.texifyidea.util.files.getFileExtension
-import nl.hannahsten.texifyidea.util.formatAsFilePath
-import nl.hannahsten.texifyidea.util.runWriteAction
 import java.io.File
-import java.util.*
+import java.util.EnumSet
 
 /**
  * @author Hannah Schellekens
@@ -45,6 +42,11 @@ open class LatexFileNotFoundInspection : TexifyInspectionBase() {
 
         // Loop through commands of file
         for (command in commands) {
+            // Don't resolve references in command definitions, as in \cite{#1} the #1 is not a reference
+            if (command.parent.firstParentOfType(LatexCommands::class)?.name in Magic.Command.commandDefinitions) {
+                continue
+            }
+
             val referencesList = command.references.filterIsInstance<InputFileReference>()
             for (reference in referencesList) {
                 if (reference.resolve() == null) {

--- a/src/nl/hannahsten/texifyidea/lang/CommandManager.kt
+++ b/src/nl/hannahsten/texifyidea/lang/CommandManager.kt
@@ -309,8 +309,18 @@ object CommandManager : Iterable<String?>, Serializable {
                     parameterCommands.takeWhile { it.name !in Magic.Command.labelDefinitionsWithoutCustomCommands }
                         .any { it.name in Magic.Command.increasesCounter }
 
+                val prefix = parameterCommands.filter { it.name in Magic.Command.labelDefinitionsWithoutCustomCommands }
+                    .mapNotNull { it.requiredParameter(0) }
+                    .map {
+                        if (it.indexOf('#') != -1) {
+                            val prefix = it.substring(0, it.indexOf('#'))
+                            if (prefix.isNotBlank()) prefix else ""
+                        }
+                        else ""
+                    }.firstOrNull() ?: ""
+
                 labelAliasesInfo[definedCommand] =
-                    LabelingCommandInformation(positions, !definitionContainsIncreaseCounterCommand)
+                    LabelingCommandInformation(positions, !definitionContainsIncreaseCounterCommand, prefix)
             }
         }
     }

--- a/src/nl/hannahsten/texifyidea/lang/CommandManager.kt
+++ b/src/nl/hannahsten/texifyidea/lang/CommandManager.kt
@@ -4,10 +4,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.search.GlobalSearchScope
 import nl.hannahsten.texifyidea.index.LatexCommandsIndex
 import nl.hannahsten.texifyidea.psi.LatexCommands
-import nl.hannahsten.texifyidea.util.Magic
-import nl.hannahsten.texifyidea.util.containsAny
-import nl.hannahsten.texifyidea.util.requiredParameter
-import nl.hannahsten.texifyidea.util.requiredParameters
+import nl.hannahsten.texifyidea.util.*
 import java.io.Serializable
 import java.util.Collections
 import java.util.HashSet
@@ -284,8 +281,9 @@ object CommandManager : Iterable<String?>, Serializable {
 
                 val parameterCommands = commandDefinition.requiredParameters().getOrNull(1)
                     ?.requiredParamContentList
+                    ?.flatMap { it.childrenOfType(LatexCommands::class) }
                     ?.asSequence()
-                    ?.mapNotNull { it.commands }
+                    ?.filterNotNull()
 
                 val positions = parameterCommands
                     ?.filter { it.name in Magic.Command.labelDefinitionsWithoutCustomCommands }

--- a/src/nl/hannahsten/texifyidea/lang/LabelingCommandInformation.kt
+++ b/src/nl/hannahsten/texifyidea/lang/LabelingCommandInformation.kt
@@ -1,10 +1,15 @@
 package nl.hannahsten.texifyidea.lang
 
+/**
+ * Information about a custom commands which has a \label command in the definition.
+ */
 data class LabelingCommandInformation(
         /** Parameter positions which define a label, starting from 0 (note: LaTeX starts from 1).
          * For example in \newcommand{\mylabel}[2]{\section{#1}\label{#2}} it is position 1. */
         var positions: List<Int>,
         /** True if the first label parameter labels a previous command, for example in \newcommand{\mylabel}[1]{\label{#1}}
          * but not in \newcommand{\mylabel}[2]{\section{#1}\label{#2}} */
-        var labelsPreviousCommand: Boolean
+        var labelsPreviousCommand: Boolean,
+        /** Default label prefix, for example in \newcommand{\mylabel}[1]{\label{sec:#1}} it would be sec: */
+        var prefix: String = ""
 )

--- a/src/nl/hannahsten/texifyidea/psi/LatexParameterTextUtil.kt
+++ b/src/nl/hannahsten/texifyidea/psi/LatexParameterTextUtil.kt
@@ -6,6 +6,7 @@ import nl.hannahsten.texifyidea.reference.BibtexIdReference
 import nl.hannahsten.texifyidea.reference.LatexEnvironmentReference
 import nl.hannahsten.texifyidea.reference.LatexLabelParameterReference
 import nl.hannahsten.texifyidea.util.Magic
+import nl.hannahsten.texifyidea.util.extractLabelName
 import nl.hannahsten.texifyidea.util.firstParentOfType
 
 /**
@@ -57,7 +58,9 @@ fun setName(element: LatexParameterText, name: String): PsiElement {
         // Get a new psi element for the complete label command (\label included),
         // because if we replace the complete command instead of just the normal text
         // then the indices will be updated, which is necessary for the reference resolve to work
-        val labelText = "${command?.name}{$name}"
+        val oldLabel = element.extractLabelName()
+        // This could go wrong in so many cases
+        val labelText = command?.text?.replaceFirst(oldLabel, name) ?: "${command?.name}{$name}"
         val newElement = LatexPsiHelper(element.project).createFromText(labelText).firstChild
         val oldNode = command?.node
         val newNode = newElement.node

--- a/src/nl/hannahsten/texifyidea/util/Labels.kt
+++ b/src/nl/hannahsten/texifyidea/util/Labels.kt
@@ -160,9 +160,6 @@ fun PsiElement.extractLabelName(): String {
     return when (this) {
         is BibtexEntry -> identifier() ?: ""
         is LatexCommands -> {
-            // Skip labels in command definitions
-            if (this.parent.firstParentOfType(LatexCommands::class)?.name in Magic.Command.commandDefinitions) return ""
-
             // For now just take the first label name (may be multiple for user defined commands)
             val info = CommandManager.labelAliasesInfo.getOrDefault(name, null)
             val position = info?.positions?.firstOrNull() ?: 0

--- a/src/nl/hannahsten/texifyidea/util/Labels.kt
+++ b/src/nl/hannahsten/texifyidea/util/Labels.kt
@@ -164,8 +164,10 @@ fun PsiElement.extractLabelName(): String {
             if (this.parent.firstParentOfType(LatexCommands::class)?.name in Magic.Command.commandDefinitions) return ""
 
             // For now just take the first label name (may be multiple for user defined commands)
-            val position = CommandManager.labelAliasesInfo.getOrDefault(name, null)?.positions?.firstOrNull() ?: 0
-            this.requiredParameter(position) ?: ""
+            val info = CommandManager.labelAliasesInfo.getOrDefault(name, null)
+            val position = info?.positions?.firstOrNull() ?: 0
+            val prefix = info?.prefix ?: ""
+            prefix + this.requiredParameter(position)
         }
         is LatexEnvironment -> this.label ?: ""
         else -> text

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LatexFigureNotReferencedInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LatexFigureNotReferencedInspectionTest.kt
@@ -2,6 +2,7 @@ package nl.hannahsten.texifyidea.inspections.latex
 
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
+import nl.hannahsten.texifyidea.lang.CommandManager
 
 class LatexFigureNotReferencedInspectionTest : TexifyInspectionTestBase(LatexFigureNotReferencedInspection()) {
 
@@ -46,6 +47,7 @@ class LatexFigureNotReferencedInspectionTest : TexifyInspectionTestBase(LatexFig
         
             some text~\ref{fig:test.png} more text.
         """.trimIndent())
+        CommandManager.updateAliases(setOf("\\label"), project)
         myFixture.checkHighlighting(false, false, true, false)
     }
 

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LatexFigureNotReferencedInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LatexFigureNotReferencedInspectionTest.kt
@@ -31,6 +31,24 @@ class LatexFigureNotReferencedInspectionTest : TexifyInspectionTestBase(LatexFig
         myFixture.checkHighlighting(false, false, true, false)
     }
 
+    fun testFigureReferencedCustomCommand() {
+        myFixture.configureByText(LatexFileType, """
+            \newcommand{\includenamedimage}[2]{
+            \begin{figure}
+                \centering
+                \includegraphics[width=\textwidth]{#1}
+                \caption{#2}
+                \label{fig:#1}
+            \end{figure}
+            }
+        
+            \includenamedimage{test.png}{fancy caption}
+        
+            some text~\ref{fig:test.png} more text.
+        """.trimIndent())
+        myFixture.checkHighlighting(false, false, true, false)
+    }
+
     fun testFigureReferencedMultipleReferencesNoWarning() {
         myFixture.configureByText(LatexFileType, """
             \documentclass{article}

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LatexLabelConventionInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LatexLabelConventionInspectionTest.kt
@@ -25,6 +25,20 @@ class LatexLabelConventionInspectionTest : TexifyInspectionTestBase(LatexLabelCo
         myFixture.checkHighlighting(false, false, true, false)
     }
 
+    fun testFigureLabelConventionWarningInNewcommand() {
+        myFixture.configureByText(LatexFileType, """
+            \newcommand{\includenamedimage}[2]{
+            \begin{figure}
+                \centering
+                \includegraphics[width=\textwidth]{#1}
+                \caption{#2}
+                \label{fig:#1} 
+            \end{figure}
+            }
+        """.trimIndent())
+        myFixture.checkHighlighting(false, false, true, false)
+    }
+
     fun testListingLabelConventionWarning() {
         myFixture.configureByText(LatexFileType, """
             \begin{document}

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LatexUnresolvedReferenceInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LatexUnresolvedReferenceInspectionTest.kt
@@ -38,6 +38,16 @@ class LatexUnresolvedReferenceInspectionTest : TexifyInspectionTestBase(LatexUnr
         myFixture.checkHighlighting()
     }
 
+    fun testNoWarningCustomCommandWithPrefix() {
+        myFixture.configureByText(LatexFileType, """
+            \newcommand{\mylabel}[1]{\label{sec:#1}}
+            \section{some sec}\mylabel{some-sec}
+            ~\ref{sec:some-sec}
+        """.trimIndent())
+        CommandManager.updateAliases(setOf("\\label"), project)
+        myFixture.checkHighlighting()
+    }
+
     // Test randomly fails
     // fun testBibtexReference() {
     //     myFixture.configureByFile("references.bib")

--- a/test/nl/hannahsten/texifyidea/psi/LatexParameterTextUtilTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/LatexParameterTextUtilTest.kt
@@ -1,0 +1,20 @@
+package nl.hannahsten.texifyidea.psi
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import nl.hannahsten.texifyidea.file.LatexFileType
+import nl.hannahsten.texifyidea.lang.CommandManager
+
+class LatexParameterTextUtilTest : BasePlatformTestCase() {
+
+    fun testLabelRename() {
+        myFixture.configureByText(LatexFileType, """
+                \label{mylabel<caret>}{I redefined \label}
+        """.trimIndent())
+        CommandManager.updateAliases(setOf("\\label"), project)
+
+        myFixture.renameElementAtCaret("nolabel")
+        myFixture.checkResult("""
+            \label{nolabel<caret>}{I redefined \label}
+        """.trimIndent())
+    }
+}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1493

#### Summary of additions and changes

* Handle label prefixes
* Fix some other false positives in newcommand definitions

#### How to test this pull request

```latex
\documentclass{article}
\usepackage{graphicx}
\begin{document}
    \newcommand{\includenamedimage}[2]{
    \begin{figure}
        \centering
        \includegraphics[width=\textwidth]{#1}
        \caption{#2}
        \label{fig:#1}
    \end{figure}
    }

    \includenamedimage{test2.png}{caption}

    some text~\ref{fig:test2.png} more text.
\end{document}
```