### PR TITLE
Fix: #1505 Added folding behavior to escaped symbols

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -367,6 +367,7 @@
         <lang.foldingBuilder language="Latex" implementationClass="nl.hannahsten.texifyidea.folding.LatexEnvironmentFoldingBuilder"/>
         <lang.foldingBuilder language="Latex" implementationClass="nl.hannahsten.texifyidea.folding.LatexImportFoldingBuilder"/>
         <lang.foldingBuilder language="Latex" implementationClass="nl.hannahsten.texifyidea.folding.LatexSectionFoldingBuilder"/>
+        <lang.foldingBuilder language="Latex" implementationClass="nl.hannahsten.texifyidea.folding.LatexEscapedSymbolFoldingBuilder"/>
         <lang.foldingBuilder language="Bibtex" implementationClass="nl.hannahsten.texifyidea.folding.BibtexEntryFoldingBuilder"/>
         <lang.formatter language="Latex" implementationClass="nl.hannahsten.texifyidea.formatting.LatexFormattingModelBuilder"/>
         <lang.formatter language="Bibtex" implementationClass="nl.hannahsten.texifyidea.formatting.BibtexFormattingModelBuilder"/>

--- a/src/nl/hannahsten/texifyidea/folding/LatexEscapedSymbolFoldingBuilder.kt
+++ b/src/nl/hannahsten/texifyidea/folding/LatexEscapedSymbolFoldingBuilder.kt
@@ -1,0 +1,34 @@
+package nl.hannahsten.texifyidea.folding
+
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.FoldingBuilderEx
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.FoldingGroup
+import com.intellij.psi.PsiElement
+import nl.hannahsten.texifyidea.util.files.commandsInFile
+
+
+/**
+ * @author Johannes Berger
+ */
+class LatexEscapedSymbolFoldingBuilder : FoldingBuilderEx() {
+
+    override fun isCollapsedByDefault(node: ASTNode) = true
+
+    override fun getPlaceholderText(node: ASTNode): String? = null
+
+    override fun buildFoldRegions(root: PsiElement, document: Document, quick: Boolean): Array<FoldingDescriptor> {
+        val group = FoldingGroup.newGroup("EscapedSymbolFoldingGroup")
+        val file = root.containingFile
+
+        return file.commandsInFile()
+                .filter { it.commandToken.text in commandsToFold }
+                .map { FoldingDescriptor(it.node, it.textRange, group, it.commandToken.text.substringAfter("\\")) }
+                .toTypedArray()
+    }
+
+    companion object {
+        val commandsToFold = setOf("%", "#", "&", "_", "$").map { "\\" + it }
+    }
+}

--- a/src/nl/hannahsten/texifyidea/folding/LatexEscapedSymbolFoldingBuilder.kt
+++ b/src/nl/hannahsten/texifyidea/folding/LatexEscapedSymbolFoldingBuilder.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.editor.FoldingGroup
 import com.intellij.psi.PsiElement
 import nl.hannahsten.texifyidea.util.files.commandsInFile
 
-
 /**
  * @author Johannes Berger
  */


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1505

#### Summary of additions and changes

* Added code folding for `\$`, `\#`, `\%`, `\&` and `\_`
* Each command will be folded to the character it is producing 

#### How to test this pull request

The commands in the following snipped are all foldable (pressing <kbd>cmd</kbd> + <kbd>-</kbd> on one of them)

```latex
100\% 
H\&M
\#hashtag
\$50
some\_thing
```

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: [here](https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Features#reading)