### PR TITLE
Temporarily disable punctuation rulegroup to avoid false positive

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/LatexGrammarCheckingStrategy.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/LatexGrammarCheckingStrategy.kt
@@ -2,14 +2,14 @@ package nl.hannahsten.texifyidea.inspections
 
 import com.intellij.grazie.grammar.strategy.GrammarCheckingStrategy
 import com.intellij.grazie.grammar.strategy.StrategyUtils
+import com.intellij.grazie.grammar.strategy.impl.RuleGroup
 import com.intellij.grazie.utils.parents
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import nl.hannahsten.texifyidea.psi.*
 
 class LatexGrammarCheckingStrategy : GrammarCheckingStrategy {
-    // Avoid "Please add punctuation at the end of a paragraph" before inline math
-    private fun PsiElement.isNotInMathEnvironment() = parents().any { it is LatexMathEnvironment }
+    private fun PsiElement.isNotInMathEnvironment() = parents().none { it is LatexMathEnvironment }
 
     private fun PsiElement.isNotInSquareBrackets() = parents().find { it is LatexGroup || it is LatexOptionalParam }
         ?.let { it is LatexGroup } ?: true
@@ -29,5 +29,9 @@ class LatexGrammarCheckingStrategy : GrammarCheckingStrategy {
             is LatexParameter -> GrammarCheckingStrategy.TextDomain.LITERALS
             else -> GrammarCheckingStrategy.TextDomain.NON_TEXT
         }
+    }
+
+    override fun getIgnoredRuleGroup(root: PsiElement, child: PsiElement): RuleGroup? {
+        return RuleGroup.PUNCTUATION
     }
 }


### PR DESCRIPTION
@fberlakovich The problem is that (if you remove the `getIgnoredRuleGroup` method I just added) this is a false positive:

`Text before $\alpha$ inline math`

because LatexNormalText is a context root, which ends right before the inline math. If this is the only text in a file, there is no psi element which spans everything, so I don't know a good context root candidate. But perhaps it can be solved in a different way.