### PR TITLE
Fix a race condition in ReferencedFileSetCache

### DIFF
--- a/src/nl/hannahsten/texifyidea/util/files/ReferencedFileSetCache.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/ReferencedFileSetCache.kt
@@ -3,8 +3,7 @@ package nl.hannahsten.texifyidea.util.files
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import nl.hannahsten.texifyidea.file.listeners.VfsChangeListener
@@ -61,7 +60,7 @@ class ReferencedFileSetCache {
             // getOrPut cannot be used because it will still execute the defaultValue function even if the key is already in the map (see its javadoc)
             // Wrapping the code with synchronized (myLock) { ... } also didn't work
             // Hence we use a mutex to make sure the expensive findReferencedFileSet function is only executed when needed
-            GlobalScope.launch {
+            runBlocking {
                 mutex.withLock {
                     if (!fileSetCache.containsKey(file.virtualFile) || numberOfIncludesChanged) {
                         runReadAction {

--- a/test/nl/hannahsten/texifyidea/reference/LatexLabelCompletionTest.kt
+++ b/test/nl/hannahsten/texifyidea/reference/LatexLabelCompletionTest.kt
@@ -1,11 +1,11 @@
 package nl.hannahsten.texifyidea.reference
 
 import com.intellij.codeInsight.completion.CompletionType
-import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import nl.hannahsten.texifyidea.file.LatexFileType
 import org.junit.Test
 
-class LatexLabelCompletionTest : LightJavaCodeInsightFixtureTestCase() {
+class LatexLabelCompletionTest : BasePlatformTestCase() {
     override fun getTestDataPath(): String {
         return "test/resources/completion/cite"
     }
@@ -56,23 +56,16 @@ class LatexLabelCompletionTest : LightJavaCodeInsightFixtureTestCase() {
     private fun runCompletion() {
         myFixture.configureByFiles("${getTestName(false)}.tex", "bibtex.bib")
 
-        // Seems like this also helps making sure the file is indexed before using autocompletion
-        assertTrue(myFixture.findAllGutters().size > 0)
-
         // when
         myFixture.complete(CompletionType.BASIC)
     }
 
-//    @Test
-//    fun testCompleteBibtexWithCorrectCase() {
-    // Using the following failed sometimes
-//        myFixture.testCompletion("${testName}_before.tex", "${testName}_after.tex", "$testName.bib")
-//        val testName = getTestName(false)
-//        myFixture.configureByFiles("${testName}_before.tex", "$testName.bib")
-//        myFixture.complete(CompletionType.BASIC)
-//        myFixture.findAllGutters() // This seems to allow the completion to complete, and to make the test pass
-//        myFixture.checkResultByFile("${testName}_after.tex")
-//    }
+    @Test
+    fun testCompleteBibtexWithCorrectCase() {
+        // Using the following failed sometimes
+        val testName = getTestName(false)
+        myFixture.testCompletion("${testName}_before.tex", "${testName}_after.tex", "$testName.bib")
+    }
 
     @Test
     fun testLabelReferenceCompletion() {


### PR DESCRIPTION
Fix #1543

#### Summary of additions and changes

* ReferencedFileSetCache now waits for the ReadAction to complete before returning the cache result. As the result is required directly after the coroutine operation, running in a non blocking way does not bring any advantages.

#### How to test this pull request

Completion tests should not be flaky anymore.
