### PR TITLE
Fix file inclusion loop inspection to honor file extensions

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexInclusionLoopInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexInclusionLoopInspection.kt
@@ -8,10 +8,9 @@ import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.index.LatexIncludesIndex
 import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
-import nl.hannahsten.texifyidea.util.files.findFile
-import nl.hannahsten.texifyidea.util.files.getAllRequiredArguments
+import nl.hannahsten.texifyidea.util.files.findIncludedFile
 import nl.hannahsten.texifyidea.util.files.searchFileByImportPaths
-import java.util.HashMap
+import java.util.*
 
 /**
  * This inspection only detects inclusion loops involving two files.
@@ -47,11 +46,7 @@ open class LatexInclusionLoopInspection : TexifyInspectionBase() {
                 inclusions.getOrPut(declaredIn) { mutableSetOf() }.add(fileMaybe)
             }
             else {
-                val includedNames = command.getAllRequiredArguments() ?: continue
-
-                for (includedName in includedNames) {
-                    val referenced = declaredIn.findFile(includedName)
-                            ?: continue
+                for (referenced in declaredIn.findIncludedFile(command)) {
 
                     inclusions.getOrPut(declaredIn) { mutableSetOf() }.add(referenced)
 

--- a/src/nl/hannahsten/texifyidea/util/Magic.kt
+++ b/src/nl/hannahsten/texifyidea/util/Magic.kt
@@ -773,6 +773,11 @@ object Magic {
         @JvmField
         val includeExtensions = hashSetOf("tex", "sty", "cls", "bib")
 
+        val automaticExtensions = mapOf(
+                "\\include" to LatexFileType.defaultExtension,
+                "\\bibliography" to BibtexFileType.defaultExtension
+        )
+
         /**
          * All possible file types.
          */

--- a/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
@@ -137,6 +137,28 @@ fun PsiFile.findFile(path: String, extensions: Set<String>? = null): PsiFile? {
     return psiFile
 }
 
+
+/**
+ * Looks up the file(s) included by a command relative to this file.
+ *
+ * @param command
+ *         The include command
+ * @return The found file(s), or an empty set when no files could not be found.
+ */
+fun PsiFile.findIncludedFile(command: LatexCommands): Set<PsiFile> {
+    val arguments = command.getAllRequiredArguments() ?: return emptySet()
+
+    return arguments.filter { it.isNotEmpty() }.mapNotNull {
+        val extension = Magic.File.automaticExtensions[command.name]
+        if (extension != null) {
+            findFile(it, setOf(extension))
+        }
+        else {
+            findFile(it)
+        }
+    }.toSet()
+}
+
 /**
  * [findFile] but then it scans all content roots.
  *

--- a/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
@@ -137,7 +137,6 @@ fun PsiFile.findFile(path: String, extensions: Set<String>? = null): PsiFile? {
     return psiFile
 }
 
-
 /**
  * Looks up the file(s) included by a command relative to this file.
  *

--- a/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
@@ -143,7 +143,7 @@ fun PsiFile.findFile(path: String, extensions: Set<String>? = null): PsiFile? {
  *
  * @param command
  *         The include command
- * @return The found file(s), or an empty set when no files could not be found.
+ * @return The found file(s), or an empty set when no files could be found.
  */
 fun PsiFile.findIncludedFile(command: LatexCommands): Set<PsiFile> {
     val arguments = command.getAllRequiredArguments() ?: return emptySet()

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LatexInclusionLoopInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LatexInclusionLoopInspectionTest.kt
@@ -18,4 +18,9 @@ class LatexInclusionLoopInspectionTest : TexifyInspectionTestBase(LatexInclusion
         myFixture.configureByFiles("main.tex", "main.sty")
         myFixture.checkHighlighting()
     }
+
+    fun testInspectionIsExtensionAware() {
+        myFixture.configureByFiles("extensioninclusion.tex")
+        myFixture.checkHighlighting()
+    }
 }

--- a/test/resources/inspections/latex/inclusionloop/extensioninclusion.tex
+++ b/test/resources/inspections/latex/inclusionloop/extensioninclusion.tex
@@ -1,0 +1,5 @@
+\documentclass{article}
+\bibliography{extensioninclusion}
+\begin{document}
+
+\end{document}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1560 

#### Summary of additions and changes

* The FileInclusionLoopInspect now takes into account the file extension of include commands

#### How to test this pull request

The example in #1560 now works as expected. A test is included in the P.
