### PR TITLE
Include optional parameters in position when looking for labels from redefined commands

### DIFF
--- a/src/nl/hannahsten/texifyidea/run/latex/logtab/LatexFileStack.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/logtab/LatexFileStack.kt
@@ -95,7 +95,7 @@ class LatexFileStack(
                 if (notClosedNonFileOpenParentheses > 0) notClosedNonFileOpenParentheses--
                 else {
                     if (isEmpty()) {
-                        throw TeXception("Extra closing parenthesis: could not close a file which was not opened. Please report the log output to the issue tracker.")
+                        throw TeXception("Extra closing parenthesis: could not close a file which was not opened. Please report the log output to the issue tracker. Line content: $line")
                     }
                     pop()
                 }

--- a/src/nl/hannahsten/texifyidea/util/Labels.kt
+++ b/src/nl/hannahsten/texifyidea/util/Labels.kt
@@ -164,7 +164,8 @@ fun PsiElement.extractLabelName(): String {
             val info = CommandManager.labelAliasesInfo.getOrDefault(name, null)
             val position = info?.positions?.firstOrNull() ?: 0
             val prefix = info?.prefix ?: ""
-            prefix + this.requiredParameter(position)
+            // Optional and required parameters both count as parameters
+            prefix + this.parameterList.getOrNull(position)?.text?.drop(1)?.dropLast(1)
         }
         is LatexEnvironment -> this.label ?: ""
         else -> text


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1575
