### PR TITLE
Add support for latexmkrc files, 

### DIFF
--- a/src/nl/hannahsten/texifyidea/action/preview/PreviewAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/preview/PreviewAction.kt
@@ -48,7 +48,8 @@ abstract class PreviewAction(name: String, val icon: Icon?) : EditorAction(name,
         val toolWindowManager = ToolWindowManager.getInstance(project)
 
         val task = RegisterToolWindowTask(toolWindowId, contentFactory = PreviewToolWindowFactory(), icon = icon)
-        val toolWindow = toolWindowManager.registerToolWindow(task)
+        // Avoid adding it twice
+        val toolWindow = toolWindowManager.getToolWindow(toolWindowId) ?: toolWindowManager.registerToolWindow(task)
 
         val containingFile = element.containingFile
         val psiDocumentManager = PsiDocumentManager.getInstance(project)

--- a/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
+++ b/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.VirtualFile
 import nl.hannahsten.texifyidea.run.latex.LatexDistributionType
 import nl.hannahsten.texifyidea.run.latex.LatexRunConfiguration
+import nl.hannahsten.texifyidea.util.LatexmkRcFileFinder
 import nl.hannahsten.texifyidea.util.runCommand
 import nl.hannahsten.texifyidea.util.splitWhitespace
 
@@ -90,12 +91,17 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
         ): MutableList<String> {
             val command = mutableListOf(runConfig.compilerPath ?: "latexmk")
 
-            // Adding the -pdf flag makes latexmk run with pdflatex, which is definitely preferred over running with just latex
-            command.add("-pdf")
-            command.add("-file-line-error")
-            command.add("-interaction=nonstopmode")
-            command.add("-synctex=1")
-            command.add("-output-format=${runConfig.outputFormat.name.toLowerCase()}")
+            val isLatexmkRcFilePresent = LatexmkRcFileFinder.isLatexmkRcFilePresent(runConfig.compilerArguments, runConfig.mainFile?.parent?.path)
+
+            // If it is present, assume that it will handle everything (command line options would overwrite latexmkrc options)
+            if (!isLatexmkRcFilePresent) {
+                // Adding the -pdf flag makes latexmk run with pdflatex, which is definitely preferred over running with just latex
+                command.add("-pdf")
+                command.add("-file-line-error")
+                command.add("-interaction=nonstopmode")
+                command.add("-synctex=1")
+                command.add("-output-format=${runConfig.outputFormat.name.toLowerCase()}")
+            }
 
             command.add("-output-directory=$outputPath")
 

--- a/src/nl/hannahsten/texifyidea/util/LatexmkRcFileFinder.kt
+++ b/src/nl/hannahsten/texifyidea/util/LatexmkRcFileFinder.kt
@@ -1,0 +1,75 @@
+package nl.hannahsten.texifyidea.util
+
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.vfs.LocalFileSystem
+import java.io.File
+
+/**
+ * Try to find a latexmkrc file (see the latexmk man page).
+ */
+object LatexmkRcFileFinder {
+    private val isSystemLatexmkRcFilePresent: Boolean by lazy {
+        // 1
+        if (SystemInfo.isLinux) {
+            listOf(
+                    "/opt/local/share/latexmk/LatexMk",
+                    "/usr/local/share/latexmk/LatexMk",
+                    "/usr/local/lib/latexmk/LatexMk",
+                    "/cygdrive/local/share/latexmk/LatexMk"
+            ).forEach {
+                if (LocalFileSystem.getInstance().findFileByPath(it) != null) return@lazy true
+                if (LocalFileSystem.getInstance().findFileByPath(it.replace("LatexMk", "latexmkrc")) != null) return@lazy true
+            }
+        }
+        else if (SystemInfo.isWindows) {
+            listOf(
+                    "C:\\latexmk\\LatexMk",
+                    "C:\\latexmk\\latexmkrc"
+            ).forEach {
+                if (LocalFileSystem.getInstance().findFileByPath(it) != null) return@lazy true
+            }
+        }
+        System.getenv("LATEXMKRCSYS")?.let {
+            if (LocalFileSystem.getInstance().findFileByPath(it) != null) return@lazy true
+        }
+
+        // 2
+        listOf(
+                "${System.getenv("XDG_CONFIG_HOME")}/latexmk/latexmkrc",
+                "${System.getenv("HOME")}/.latexmkrc",
+                "${System.getenv("USERPROFILE")}/.latexmkrc",
+                "${System.getenv("HOME")}/.config/.latexmkrc"
+        ).forEach {
+            if (LocalFileSystem.getInstance().findFileByPath(it) != null) return@lazy true
+        }
+
+        false
+    }
+
+    private fun isLocalLatexmkRcFilePresent(compilerArguments: String?, workingDir: String?): Boolean {
+        // 3
+        if (workingDir != null) {
+            listOf(
+                    workingDir + File.separator + "latexmkrc",
+                    workingDir + File.separator + ".latexmkrc"
+            ).forEach {
+                if (LocalFileSystem.getInstance().findFileByPath(it) != null) return true
+            }
+        }
+
+        // 4
+        if (compilerArguments != null) {
+            val arguments = compilerArguments.splitWhitespace().dropWhile { it.isBlank() }
+            if (arguments.contains("-r") && arguments.last() != "-r") {
+                val path = arguments[arguments.indexOf("-r") + 1]
+                if (LocalFileSystem.getInstance().findFileByPath(path) != null) return true
+            }
+        }
+
+        return false
+    }
+
+    fun isLatexmkRcFilePresent(compilerArguments: String?, workingDir: String?): Boolean {
+        return isSystemLatexmkRcFilePresent || isLocalLatexmkRcFilePresent(compilerArguments, workingDir)
+    }
+}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1586

#### Summary of additions and changes

* Don't add compiler arguments for latexmk if latexmkrc file is found

#### How to test this pull request

Create .latexmkrc with for example `$pdf_mode = 5;` and check it builds with xelatex

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Compilers#latexmk