### PR TITLE
Speed up LatexPackageNotInstalledInspection.kt

### DIFF
--- a/src/nl/hannahsten/texifyidea/util/Packages.kt
+++ b/src/nl/hannahsten/texifyidea/util/Packages.kt
@@ -294,6 +294,9 @@ object PackageUtils {
 }
 
 object TexLivePackages {
+    /**
+     * List of installed packages.
+     */
     var packageList: MutableList<String> = mutableListOf()
 
     /**
@@ -314,6 +317,7 @@ object TexLivePackages {
     fun findTexLiveName(task: Task.Backgroundable, packageName: String): String? {
         // Find the package name for tlmgr.
         task.title = "Searching for $packageName..."
+        // Assume that you can not use the bundle name in a \usepackage if it is different from the package name (otherwise this search won't work and we would need to use tlmgr search --global $packageName
         val searchResult = "tlmgr search --file --global /$packageName.sty".runCommand()
                 ?: return null
 

--- a/test/nl/hannahsten/texifyidea/reference/LatexEnvironmentReferenceTest.kt
+++ b/test/nl/hannahsten/texifyidea/reference/LatexEnvironmentReferenceTest.kt
@@ -16,4 +16,16 @@ class LatexEnvironmentReferenceTest : BasePlatformTestCase() {
             \end{nodocument<caret>}
         """.trimIndent())
     }
+
+    fun testEnvironmentRenameBegin() {
+        myFixture.configureByText(LatexFileType, """
+            \begin{document<caret>}
+            \end{document}
+        """.trimIndent())
+        myFixture.renameElementAtCaret("nodocument")
+        myFixture.checkResult("""
+            \begin{nodocument<caret>}
+            \end{nodocument}
+        """.trimIndent())
+    }
 }


### PR DESCRIPTION
Previously, the inspection was running `tlmgr search` on every inspection run when there was a \usepackage statement in the file containing a package which was not installed.