### PR TITLE
Add 'default' option to run config UI for latexmkrc

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingLabelInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingLabelInspection.kt
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.Nls
 import java.util.EnumSet
 
 /**
- * Currently only works for Chapters, Sections and Subsections.
+ * Check for commands which should have a label but don't.
  *
  * @author Hannah Schellekens
  */

--- a/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
+++ b/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
@@ -82,6 +82,8 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
 
         override val handlesNumberOfCompiles = true
 
+        override val outputFormats = arrayOf(Format.DEFAULT, Format.PDF, Format.DVI)
+
         override fun createCommand(
             runConfig: LatexRunConfiguration,
             auxilPath: String?,
@@ -91,7 +93,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
         ): MutableList<String> {
             val command = mutableListOf(runConfig.compilerPath ?: "latexmk")
 
-            val isLatexmkRcFilePresent = LatexmkRcFileFinder.isLatexmkRcFilePresent(runConfig.compilerArguments, runConfig.mainFile?.parent?.path)
+            val isLatexmkRcFilePresent = LatexmkRcFileFinder.isLatexmkRcFilePresent(runConfig)
 
             // If it is present, assume that it will handle everything (command line options would overwrite latexmkrc options)
             if (!isLatexmkRcFilePresent) {
@@ -100,6 +102,9 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
                 command.add("-file-line-error")
                 command.add("-interaction=nonstopmode")
                 command.add("-synctex=1")
+            }
+
+            if (runConfig.outputFormat != Format.DEFAULT) {
                 command.add("-output-format=${runConfig.outputFormat.name.toLowerCase()}")
             }
 
@@ -377,6 +382,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
      */
     enum class Format {
 
+        DEFAULT, // Means: don't overwite the default, e.g. a default from the latexmkrc, i.e. don't add any command line parameters
         PDF,
         DVI,
         HTML,

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
@@ -487,7 +487,7 @@ class LatexRunConfiguration constructor(project: Project,
     override fun getOutputFilePath(): String {
         val outputDir = outputPath.getAndCreatePath()
         return "${outputDir?.path}/" + mainFile!!
-                .nameWithoutExtension + "." + outputFormat.toString()
+                .nameWithoutExtension + "." + if (outputFormat == Format.DEFAULT) "pdf" else outputFormat.toString()
                 .toLowerCase()
     }
 

--- a/src/nl/hannahsten/texifyidea/util/LatexmkRcFileFinder.kt
+++ b/src/nl/hannahsten/texifyidea/util/LatexmkRcFileFinder.kt
@@ -2,6 +2,8 @@ package nl.hannahsten.texifyidea.util
 
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.LocalFileSystem
+import nl.hannahsten.texifyidea.run.compiler.LatexCompiler
+import nl.hannahsten.texifyidea.run.latex.LatexRunConfiguration
 import java.io.File
 
 /**
@@ -69,7 +71,13 @@ object LatexmkRcFileFinder {
         return false
     }
 
-    fun isLatexmkRcFilePresent(compilerArguments: String?, workingDir: String?): Boolean {
-        return isSystemLatexmkRcFilePresent || isLocalLatexmkRcFilePresent(compilerArguments, workingDir)
+    fun isLatexmkRcFilePresent(runConfig: LatexRunConfiguration): Boolean {
+        val isPresent = isSystemLatexmkRcFilePresent || isLocalLatexmkRcFilePresent(runConfig.compilerArguments, runConfig.mainFile?.parent?.path)
+
+        // The first time, by default don't override what's in the latexmkrc (but avoid resetting the user chosen output format)
+        if (isPresent && !runConfig.hasBeenRun) {
+            runConfig.outputFormat = LatexCompiler.Format.DEFAULT
+        }
+        return isPresent
     }
 }

--- a/src/nl/hannahsten/texifyidea/util/Magic.kt
+++ b/src/nl/hannahsten/texifyidea/util/Magic.kt
@@ -235,7 +235,7 @@ object Magic {
         val figures = hashSetOf("figure")
 
         @JvmField
-        val verbatim = hashSetOf("verbatim", "Verbatim", "lstlisting", "plantuml", "luacode", "luacode*")
+        val verbatim = hashSetOf("verbatim", "Verbatim", "lstlisting", "plantuml", "luacode", "luacode*", "sagesilent", "sageblock", "sagecommandline", "sageverbatim", "sageexample")
 
         @JvmField
         val algorithmEnvironments = setOf("algorithmic")
@@ -249,7 +249,7 @@ object Magic {
                 "matrix*", "pmatrix*", "bmatrix*", "vmatrix*", "Bmatrix*", "Vmatrix*",
                 "smallmatrix", "psmallmatrix", "bsmallmatrix", "vsmallmatrix", "Bsmallmatrix", "Vsmallmatrix",
                 "smallmatrix*", "psmallmatrix*", "bsmallmatrix*", "vsmallmatrix*", "Bsmallmatrix*", "Vsmallmatrix*",
-                "gmatrix"
+                "gmatrix", "tikz-cd"
         )
 
         @JvmField


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1592

#### Summary of additions and changes

* Default to 'default' when latexmkrc is used, but keeps possibility to override output format

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki