### PR TITLE
Root files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 [*.{kt,kts}]
-disabled_rules = final-newline,no-wildcard-imports,parameter-list-wrapping,import-ordering,keyword-spacing
-indent_size = unset  # Temporary fix to overcome ktlint's new lack of support for continuation indent (https://github.com/pinterest/ktlint/issues/816)
+# Enable indent once ktlint supports continuation indent again.
+disabled_rules = final-newline,no-wildcard-imports,parameter-list-wrapping,import-ordering,keyword-spacing,indent
 insert_final_newline = false
 
 ij_kotlin_else_on_new_line = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,6 @@
 [*.{kt,kts}]
 disabled_rules = final-newline,no-wildcard-imports,parameter-list-wrapping,import-ordering,keyword-spacing
+indent_size = unset  # Temporary fix to overcome ktlint's new lack of support for continuation indent (https://github.com/pinterest/ktlint/issues/816)
 insert_final_newline = false
 
 ij_kotlin_else_on_new_line = true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 group = "nl.hannahsten"
-version = "0.7.1-alpha.7"
+version = "0.7.1-alpha.8"
 
 repositories {
     mavenCentral()

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -644,6 +644,9 @@
         <localInspection language="Latex" implementationClass="nl.hannahsten.texifyidea.inspections.latex.LatexEscapeAmpersandInspection"
                          groupName="LaTeX" displayName="Unescaped &amp; character"
                          enabledByDefault="true"/>
+        <localInspection language="Latex" implementationClass="nl.hannahsten.texifyidea.inspections.latex.LatexDocumentclassNotInRootInspection"
+                         groupName="LaTeX" displayName="File that contains a document environment should contain a \documentclass command"
+                         enabledByDefault="true"/>
 
         <!-- Element manipulator -->
         <lang.elementManipulator forClass="nl.hannahsten.texifyidea.psi.impl.LatexEnvironmentImpl"

--- a/resources/inspectionDescriptions/LatexDocumentclassNotInRoot.html
+++ b/resources/inspectionDescriptions/LatexDocumentclassNotInRoot.html
@@ -1,10 +1,9 @@
 <html>
 <body>
-File that contains a document environment should contain a <tt>\documentclass</tt> command.
-<!-- tooltip end -->
 <p>
     The root file of a LaTeX document should contain a <tt>\documentclass</tt> command, then the document preamble, and finally the <tt>document</tt> environment.
 </p>
+<!-- tooltip end -->
 <p>
     See the <a href="https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/LaTeX-recommendations#ins:documentclass">wiki</a> for more information.
 </p>

--- a/resources/inspectionDescriptions/LatexDocumentclassNotInRoot.html
+++ b/resources/inspectionDescriptions/LatexDocumentclassNotInRoot.html
@@ -1,0 +1,12 @@
+<html>
+<body>
+File that contains a document environment should contain a <tt>\documentclass</tt> command.
+<!-- tooltip end -->
+<p>
+    The root file of a LaTeX document should contain a <tt>\documentclass</tt> command, then the document preamble, and finally the <tt>document</tt> environment.
+</p>
+<p>
+    See the <a href="https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/LaTeX-recommendations#ins:documentclass">wiki</a> for more information.
+</p>
+</body>
+</html>

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexDocumentclassNotInRootInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexDocumentclassNotInRootInspection.kt
@@ -17,7 +17,7 @@ class LatexDocumentclassNotInRootInspection : TexifyInspectionBase() {
 
     @Nls
     override fun getDisplayName(): String {
-        return "File that contains a document environment should contain a \\documentclass command"
+        return "Documentclass command should be in the same file as the document environment"
     }
 
     override val inspectionId: String

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexDocumentclassNotInRootInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexDocumentclassNotInRootInspection.kt
@@ -7,8 +7,8 @@ import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.psi.LatexEnvironment
+import nl.hannahsten.texifyidea.util.childrenOfType
 import nl.hannahsten.texifyidea.util.files.commandsInFile
-import nl.hannahsten.texifyidea.util.firstChildOfType
 import org.jetbrains.annotations.Nls
 
 class LatexDocumentclassNotInRootInspection : TexifyInspectionBase() {
@@ -26,7 +26,7 @@ class LatexDocumentclassNotInRootInspection : TexifyInspectionBase() {
     override fun inspectFile(file: PsiFile, manager: InspectionManager, isOntheFly: Boolean): List<ProblemDescriptor> {
         val documentClass = file.commandsInFile().find { it.name == "\\documentclass" } ?: return emptyList()
 
-        val hasDocumentEnvironment = file.firstChildOfType(LatexEnvironment::class)?.environmentName == "document"
+        val hasDocumentEnvironment = file.childrenOfType<LatexEnvironment>().any { it.environmentName == "document" }
 
         if (!hasDocumentEnvironment) {
             return listOf(

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexDocumentclassNotInRootInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexDocumentclassNotInRootInspection.kt
@@ -1,0 +1,44 @@
+package nl.hannahsten.texifyidea.inspections.latex
+
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.psi.PsiFile
+import nl.hannahsten.texifyidea.insight.InsightGroup
+import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
+import nl.hannahsten.texifyidea.psi.LatexEnvironment
+import nl.hannahsten.texifyidea.util.files.commandsInFile
+import nl.hannahsten.texifyidea.util.firstChildOfType
+import org.jetbrains.annotations.Nls
+
+class LatexDocumentclassNotInRootInspection : TexifyInspectionBase() {
+    override val inspectionGroup: InsightGroup
+        get() = InsightGroup.LATEX
+
+    @Nls
+    override fun getDisplayName(): String {
+        return "File that contains a document environment should contain a \\documentclass command"
+    }
+
+    override val inspectionId: String
+        get() = "DocumentclassNotInRoot"
+
+    override fun inspectFile(file: PsiFile, manager: InspectionManager, isOntheFly: Boolean): List<ProblemDescriptor> {
+        val documentClass = file.commandsInFile().find { it.name == "\\documentclass" } ?: return emptyList()
+
+        val hasDocumentEnvironment = file.firstChildOfType(LatexEnvironment::class)?.environmentName == "document"
+
+        if (!hasDocumentEnvironment) {
+            return listOf(
+                    manager.createProblemDescriptor(
+                            documentClass,
+                            displayName,
+                            true,
+                            ProblemHighlightType.WARNING,
+                            isOntheFly
+                    )
+            )
+        }
+        return emptyList()
+    }
+}

--- a/src/nl/hannahsten/texifyidea/util/files/FileSet.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/FileSet.kt
@@ -25,9 +25,9 @@ import nl.hannahsten.texifyidea.util.isDefinition
  * @return All the files that are cross referenced between each other.
  */
 // Internal because only ReferencedFileSetCache should call this
-internal fun findReferencedFileSetWithoutCache(baseFile: PsiFile): Set<PsiFile> {
+internal fun PsiFile.findReferencedFileSetWithoutCache(): Set<PsiFile> {
     // Setup.
-    val project = baseFile.project
+    val project = this.project
     val includes = LatexIncludesIndex.getItems(project)
 
     // Find all root files.
@@ -42,8 +42,8 @@ internal fun findReferencedFileSetWithoutCache(baseFile: PsiFile): Set<PsiFile> 
     for (root in roots) {
         val referenced = root.referencedFiles(root.virtualFile) + root
 
-        if (referenced.contains(baseFile)) {
-            return referenced + baseFile
+        if (referenced.contains(this)) {
+            return referenced + this
         }
 
         sets[root] = referenced
@@ -51,12 +51,12 @@ internal fun findReferencedFileSetWithoutCache(baseFile: PsiFile): Set<PsiFile> 
 
     // Look for matching root.
     for (referenced in sets.values) {
-        if (referenced.contains(baseFile)) {
-            return referenced + baseFile
+        if (referenced.contains(this)) {
+            return referenced + this
         }
     }
 
-    return setOf(baseFile)
+    return setOf(this)
 }
 
 /**

--- a/src/nl/hannahsten/texifyidea/util/files/ReferencedFileSetService.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/ReferencedFileSetService.kt
@@ -22,6 +22,8 @@ interface ReferencedFileSetService {
      */
     fun referencedFileSetOf(psiFile: PsiFile): Set<PsiFile>
 
+    fun rootFilesOf(psiFile: PsiFile): Set<PsiFile>
+
     /**
      * Invalidates the caches for the given file.
      */

--- a/src/nl/hannahsten/texifyidea/util/files/RootFile.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/RootFile.kt
@@ -13,7 +13,7 @@ import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexEnvironment
 import nl.hannahsten.texifyidea.run.latex.LatexRunConfiguration
 import nl.hannahsten.texifyidea.util.firstChildOfType
-import java.util.HashMap
+import java.util.*
 
 /**
  * Scans all file inclusions and finds the files that are at the base of all inclusions.
@@ -66,7 +66,6 @@ fun PsiFile.findRootFilesWithoutCache(): Set<PsiFile> {
  * Note: LaTeX Files can have more than one * root file, so using [findRootFiles] and explicitly handling the cases of
  * multiple root files is preferred over using [findRootFile].
  */
-@Deprecated("LaTeX files can actually have more than one root file.", replaceWith = ReplaceWith("PsiFile.findRootFiles()"))
 fun PsiFile.findRootFile(): PsiFile = findRootFiles().firstOrNull() ?: this
 
 /**

--- a/src/nl/hannahsten/texifyidea/util/files/RootFile.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/RootFile.kt
@@ -16,19 +16,22 @@ import nl.hannahsten.texifyidea.util.firstChildOfType
 import java.util.HashMap
 
 /**
- * Scans all file inclusions and finds the file that is at the base of all inclusions.
+ * Scans all file inclusions and finds the files that are at the base of all inclusions.
+ * Note that this can be multiple files.
  *
  * When no file is included, `this` file will be returned.
  */
-fun PsiFile.findRootFile(): PsiFile {
+fun PsiFile.findRootFilesWithoutCache(): Set<PsiFile> {
     val magicComment = magicComment()
+    val roots = mutableSetOf<PsiFile>()
+
     if (magicComment.contains(DefaultMagicKeys.ROOT)) {
         val path = magicComment.value(DefaultMagicKeys.ROOT) ?: ""
-        this.findFile(path)?.let { return it }
+        this.findFile(path)?.let { roots.add(it) }
     }
 
     if (this.isRoot()) {
-        return this
+        roots.add(this)
     }
 
     // We need to scan all file inclusions in the project, because any file could include the current file
@@ -48,12 +51,28 @@ fun PsiFile.findRootFile(): PsiFile {
 
         // If the root file contains this, we have found the root file
         if (file.contains(this, inclusions)) {
-            return file
+            roots.add(file)
         }
     }
 
-    return this
+    return if (roots.isEmpty()) setOf(this) else roots
 }
+
+/**
+ * Gets the first file from the root files found by [findRootFilesWithoutCache] which is stored in the cache.
+ *
+ * As a best guess, get the first of the root files returned by [findRootFiles].
+ *
+ * Note: LaTeX Files can have more than one * root file, so using [findRootFiles] and explicitly handling the cases of
+ * multiple root files is preferred over using [findRootFile].
+ */
+@Deprecated("LaTeX files can actually have more than one root file.", replaceWith = ReplaceWith("PsiFile.findRootFiles()"))
+fun PsiFile.findRootFile(): PsiFile = findRootFiles().firstOrNull() ?: this
+
+/**
+ * Gets the set of files that are the root files of `this` file.
+ */
+fun PsiFile.findRootFiles(): Set<PsiFile> = ReferencedFileSetService.getInstance().rootFilesOf(this)
 
 /**
  * Checks if the given file is included by `this` file.

--- a/src/nl/hannahsten/texifyidea/util/files/impl/ReferencedFileSetServiceImpl.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/impl/ReferencedFileSetServiceImpl.kt
@@ -14,6 +14,8 @@ class ReferencedFileSetServiceImpl : ReferencedFileSetService {
 
     override fun referencedFileSetOf(psiFile: PsiFile) = cache.fileSetFor(psiFile)
 
+    override fun rootFilesOf(psiFile: PsiFile): Set<PsiFile> = cache.rootFilesFor(psiFile)
+
     override fun dropCaches(file: VirtualFile) = cache.dropCaches(file)
 
     override fun dropAllCaches() = cache.dropAllCaches()

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LatexDocumentclassNotInRootInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LatexDocumentclassNotInRootInspectionTest.kt
@@ -1,0 +1,29 @@
+package nl.hannahsten.texifyidea.inspections.latex
+
+import nl.hannahsten.texifyidea.file.LatexFileType
+import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
+
+class LatexDocumentclassNotInRootInspectionTest : TexifyInspectionTestBase(LatexDocumentclassNotInRootInspection()) {
+    override fun getTestDataPath(): String {
+        return "test/resources/inspections/latex/documentclassnotinroot"
+    }
+
+    fun testNoWarning() {
+        myFixture.configureByText(
+                LatexFileType,
+                """
+                    \documentclass{article}
+                    
+                    \begin{document}
+                        bla
+                    \end{document}
+            """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun testWarning() {
+        myFixture.configureByFiles("preamble.sty", "main.tex")
+        myFixture.checkHighlighting()
+    }
+}

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LatexDocumentclassNotInRootInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LatexDocumentclassNotInRootInspectionTest.kt
@@ -22,6 +22,22 @@ class LatexDocumentclassNotInRootInspectionTest : TexifyInspectionTestBase(Latex
         myFixture.checkHighlighting()
     }
 
+    fun `test no warning with environment in preamble`() {
+        myFixture.configureByText(LatexFileType,
+        """
+            \documentclass{article}
+            
+            \begin{filecontents}{a}
+                bla
+            \end
+            
+            \begin{document}
+                contents
+            \end{document}
+        """.trimIndent())
+        myFixture.checkHighlighting()
+    }
+
     fun testWarning() {
         myFixture.configureByFiles("preamble.sty", "main.tex")
         myFixture.checkHighlighting()

--- a/test/resources/inspections/latex/documentclassnotinroot/main.tex
+++ b/test/resources/inspections/latex/documentclassnotinroot/main.tex
@@ -1,0 +1,5 @@
+\usepackage{preamble}
+
+\begin{document}
+    Bla.
+\end{document}

--- a/test/resources/inspections/latex/documentclassnotinroot/preamble.sty
+++ b/test/resources/inspections/latex/documentclassnotinroot/preamble.sty
@@ -1,0 +1,5 @@
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{preamble}
+
+<warning>\documentclass{article}</warning>
+


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1612. 

#### Summary of additions and changes

* Use the document environment to determine root files instead of the document class.
* Add an inspection that warns you when you have separated the document environment and document class.
* Introduces a cache to store the root file**s** for each file. Note that it is perfectly fine for LaTeX documents to have multiple root files. Other than the introduction of this cache, TeXiFy does not handle multiple root files anywhere (yet). However, the function `PsiFile.findRootFile()` is now deprecated in favor of `PsiFile.findRootFiles()` to encourage/force us to explicitly handle the cases of multiple root files. E.g., including a use package in all root files instead of in just one of the root files.
* To my knowledge, the `root` magic comment works fine at the moment, see the example below.

#### How to test this pull request

* Verify that stuff that needs the root file still works.
* Verify that the magic comment works. Create **main.tex** as below and try the following:
  1. Without the magic root comment: use autocompletion to complete the `\includegraphics` command. A `\usepackage{graphicx}` will be inserted in **test.tex**.
  2. With the magic comment: use autocompletion to complete the `\includegraphics` command. A `\usepackage{graphicx}` will be inserted in **main.tex**.

**main.tex**
```latex
\documentclass{article}

\newcommand{\includebla}[1]{\include{#1}}

\begin{document}
    \includebla{test}
\end{document}
```

**test.tex***
```latex
%! root = main.tex
\includegr<caret>
```

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: 
  - https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/LaTeX-recommendations#-file-that-contains-a-document-environment-should-contain-a-documentclass-command
  - https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Magic-comments#root-file
