### PR TITLE
Don't only use kpsewhich for sty/cls files

### DIFF
--- a/src/nl/hannahsten/texifyidea/util/Magic.kt
+++ b/src/nl/hannahsten/texifyidea/util/Magic.kt
@@ -562,7 +562,7 @@ object Magic {
          * Extensions that should only be scanned for the provided include commands.
          */
         @JvmField
-        val includeOnlyExtensions: Map<String, HashSet<String>> = mapOf(
+        val includeOnlyExtensions: Map<String, Set<String>> = mapOf(
             "\\include" to hashSetOf("tex"),
             "\\includeonly" to hashSetOf("tex"),
             "\\subfile" to hashSetOf("tex"),

--- a/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
@@ -8,6 +8,7 @@ import java.io.InputStreamReader
 /**
  * Cache locations of LaTeX packages in memory, because especially on Windows they can be expensive to retrieve
  * (requires a run of kpsewhich).
+ * Can also be used for tex/bib files and whatever can be used with kpsewhich.
  */
 object LatexPackageLocationCache {
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1616 

#### Summary of additions and changes

* kpsewhich was only used for sty/cls files, but it actually works for other file types like bib/tex as well

#### How to test this pull request

Create a LaTeX file, for example `~/texmf/tex/latex/included.tex` and input it.