### PR TITLE
Fix the fix all problems in file for the missing label inspection

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 group = "nl.hannahsten"
-version = "0.7.1-rc1"
+version = "0.7.1-rc2"
 
 repositories {
     mavenCentral()

--- a/src/nl/hannahsten/texifyidea/inspections/TexifyRegexInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/TexifyRegexInspection.kt
@@ -254,11 +254,13 @@ abstract class TexifyRegexInspection(
         return mathMode == element.inMathContext() && checkContext(element)
     }
 
+    /**
+     * We assume the quickfix of this inspection replaces text (like <<) by
+     * content with a different length (like \ll), so we have to make
+     * sure it is run for the whole file at once.
+     * It can be disabled by overriding this method.
+     */
     override fun runForWholeFile(): Boolean {
-        // We assume the quickfix of this inspection replaces text (like <<) by
-        // content with a different length (like \ll), so we have to make
-        // sure it is run for the whole file at once.
-        // It can be disabled by overriding this method.
         return true
     }
 

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingLabelInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingLabelInspection.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.refactoring.suggested.createSmartPointer
 import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.intentions.LatexAddLabelIntention
@@ -155,7 +156,7 @@ open class LatexMissingLabelInspection : TexifyInspectionBase() {
 
         override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
             val command = descriptor.psiElement as LatexCommands
-            LatexAddLabelIntention().invoke(project, command.containingFile.openedEditor(), command.containingFile)
+            LatexAddLabelIntention(command.createSmartPointer()).invoke(project, command.containingFile.openedEditor(), command.containingFile)
         }
     }
 

--- a/src/nl/hannahsten/texifyidea/intentions/LatexAddLabelIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexAddLabelIntention.kt
@@ -3,6 +3,7 @@ package nl.hannahsten.texifyidea.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
+import com.intellij.psi.SmartPsiElementPointer
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexPsiHelper
 import nl.hannahsten.texifyidea.util.*
@@ -12,7 +13,7 @@ import kotlin.math.max
 /**
  * @author Hannah Schellekens
  */
-open class LatexAddLabelIntention : TexifyIntentionBase("Add label") {
+open class LatexAddLabelIntention(val command: SmartPsiElementPointer<LatexCommands>? = null) : TexifyIntentionBase("Add label") {
 
     private fun findCommand(editor: Editor?, file: PsiFile?): LatexCommands? {
         val offset = editor?.caretModel?.offset ?: return null
@@ -21,7 +22,6 @@ open class LatexAddLabelIntention : TexifyIntentionBase("Add label") {
         return element as? LatexCommands ?: element.parentOfType(LatexCommands::class)
             ?: file.findElementAt(max(0, offset - 1)) as? LatexCommands
             ?: file.findElementAt(max(0, offset - 1))?.parentOfType(LatexCommands::class)
-            ?: return null
     }
 
     override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean {
@@ -39,7 +39,10 @@ open class LatexAddLabelIntention : TexifyIntentionBase("Add label") {
             return
         }
 
-        val command = findCommand(editor, file) ?: return
+        // When no this.command is provided, use the command at the caret as the best guess.
+        val command: LatexCommands = this.command?.element
+                ?: findCommand(editor, file)
+                ?: return
 
         // Determine label name.
         val required = command.requiredParameters

--- a/test/nl/hannahsten/texifyidea/inspections/TexifyInspectionTestBase.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/TexifyInspectionTestBase.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.inspections
 
+import com.intellij.codeInspection.InspectionsBundle
 import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import nl.hannahsten.texifyidea.file.LatexFileType
@@ -37,6 +38,19 @@ abstract class TexifyInspectionTestBase(vararg val inspections: LocalInspectionT
         writeCommand(myFixture.project) {
             selectedFix?.invoke(myFixture.project, myFixture.editor, myFixture.file)
         }
+
+        myFixture.checkResult(after)
+    }
+
+    protected fun testQuickFixAll(before: String, after: String, quickFixName: String, numberOfFixes: Int) {
+        myFixture.configureByText(LatexFileType, before)
+        assertEquals("Expected number of quick fixes:", numberOfFixes, myFixture.getAllQuickFixes().size)
+
+        // Find the fix all problems in this file intention for this inspection.
+        val fixAllIntention = myFixture.getAvailableIntention(
+                InspectionsBundle.message("fix.all.inspection.problems.in.file", quickFixName)
+        ) ?: return
+        myFixture.launchAction(fixAllIntention)
 
         myFixture.checkResult(after)
     }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LatexMissingLabelInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LatexMissingLabelInspectionTest.kt
@@ -2,7 +2,6 @@ package nl.hannahsten.texifyidea.inspections.latex
 
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
-import nl.hannahsten.texifyidea.intentions.LatexAddLabelIntention
 import nl.hannahsten.texifyidea.lang.CommandManager
 
 class LatexMissingLabelInspectionTest : TexifyInspectionTestBase(LatexMissingLabelInspection()) {
@@ -159,5 +158,20 @@ class LatexMissingLabelInspectionTest : TexifyInspectionTestBase(LatexMissingLab
             \end{lstlisting}
         \end{document}
         """.trimIndent()
+    )
+
+    fun `test fix all missing label problems in this file`() = testQuickFixAll(
+            before = """
+                \section{one}
+                \section{two}
+            """.trimIndent(),
+            after = """
+                \section{one}\label{sec:one}
+                
+                
+                \section{two}\label{sec:two}
+            """.trimIndent(),
+            quickFixName = "Add label for this command",
+            numberOfFixes = 4
     )
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LatexMissingLabelInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LatexMissingLabelInspectionTest.kt
@@ -2,15 +2,14 @@ package nl.hannahsten.texifyidea.inspections.latex
 
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
+import nl.hannahsten.texifyidea.intentions.LatexAddLabelIntention
 import nl.hannahsten.texifyidea.lang.CommandManager
-import org.junit.Test
 
 class LatexMissingLabelInspectionTest : TexifyInspectionTestBase(LatexMissingLabelInspection()) {
     override fun getTestDataPath(): String {
         return "test/resources/inspections/latex/missinglabel"
     }
 
-    @Test
     fun `test missing label warnings`() {
         myFixture.configureByFile("MissingLabelWarnings.tex")
         myFixture.checkHighlighting(false, false, true, false)
@@ -115,7 +114,6 @@ class LatexMissingLabelInspectionTest : TexifyInspectionTestBase(LatexMissingLab
             """.trimIndent()
         )
 
-    @Test
     fun `test quick fix in listings with no other parameters`() = testQuickFix(
         before = """
         \begin{document}
@@ -131,7 +129,6 @@ class LatexMissingLabelInspectionTest : TexifyInspectionTestBase(LatexMissingLab
         """.trimIndent()
     )
 
-    @Test
     fun `test quick fix in listings when label already exists`() = testQuickFix(
         before = """
         \begin{document}
@@ -149,7 +146,6 @@ class LatexMissingLabelInspectionTest : TexifyInspectionTestBase(LatexMissingLab
         """.trimIndent()
     )
 
-    @Test
     fun `test quick fix in listings with other parameters`() = testQuickFix(
         before = """
         \begin{document}


### PR DESCRIPTION
#### Summary of additions and changes

* Pass the command from the inspection to the `LatexAddLabelIntention`. Before, the intention could only guess which command to apply the fix to by looking at the position of the cursor. As a result, when using the fix all intention, it would try to fix all the missing label warnings on the command the cursor is currently on.

#### How to test this pull request

```latex
\section{one<caret>}
\section{two}
```

Use the `fix all ... problems in file` intention of the missing label inspection.