### PR TITLE
Negative offset and unclosed \if inspection

### DIFF
--- a/resources/inspectionDescriptions/LatexNonMatchingIf.html
+++ b/resources/inspectionDescriptions/LatexNonMatchingIf.html
@@ -1,6 +1,7 @@
 <html>
 <body>
 If-else-then control sequences should start with <tt>\if</tt> (or variants) and should end with <tt>\fi</tt>.
+Commands starting with <tt>\if</tt> are usually LaTeX control commands, for example defined with <tt>\newif\ifsomething</tt> (but consider using <tt>\newtoggle</tt> from <tt>etoolbox</tt> instead).
 <!-- tooltip end -->
 </body>
 </html>

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexNonMatchingIfInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexNonMatchingIfInspection.kt
@@ -49,7 +49,7 @@ open class LatexNonMatchingIfInspection : TexifyInspectionBase() {
 
                 stack.pop()
             }
-            else if (Magic.Pattern.ifCommand.matches(name) && name !in Magic.Command.ignoredIfs && command.previousCommand()?.name != "\\newif") {
+            else if (Magic.Pattern.ifCommand.matches(name) && name in Magic.Command.startIfs && command.previousCommand()?.name != "\\newif") {
                 stack.push(command)
             }
         }
@@ -59,7 +59,7 @@ open class LatexNonMatchingIfInspection : TexifyInspectionBase() {
             descriptors.add(
                 manager.createProblemDescriptor(
                     cmd,
-                    "If statement is not closed",
+                    "If statement may not be closed with \\fi",
                     Magic.General.noQuickFix,
                     ProblemHighlightType.GENERIC_ERROR,
                     isOntheFly

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexNonMatchingIfInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexNonMatchingIfInspection.kt
@@ -49,7 +49,7 @@ open class LatexNonMatchingIfInspection : TexifyInspectionBase() {
 
                 stack.pop()
             }
-            else if (Magic.Pattern.ifCommand.matches(name) && name in Magic.Command.startIfs && command.previousCommand()?.name != "\\newif") {
+            else if (Magic.Pattern.ifCommand.matches(name) && name !in Magic.Command.ignoredIfs && command.previousCommand()?.name != "\\newif") {
                 stack.push(command)
             }
         }
@@ -59,9 +59,9 @@ open class LatexNonMatchingIfInspection : TexifyInspectionBase() {
             descriptors.add(
                 manager.createProblemDescriptor(
                     cmd,
-                    "If statement may not be closed with \\fi",
+                    "If statement should probably be closed with \\fi",
                     Magic.General.noQuickFix,
-                    ProblemHighlightType.GENERIC_ERROR,
+                    ProblemHighlightType.WARNING,
                     isOntheFly
                 )
             )

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexUnresolvedReferenceInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexUnresolvedReferenceInspection.kt
@@ -13,6 +13,7 @@ import nl.hannahsten.texifyidea.util.Magic
 import nl.hannahsten.texifyidea.util.files.commandsInFile
 import nl.hannahsten.texifyidea.util.findLatexAndBibtexLabelStringsInFileSet
 import nl.hannahsten.texifyidea.util.firstParentOfType
+import java.lang.Integer.max
 import java.util.*
 
 /**
@@ -70,7 +71,7 @@ open class LatexUnresolvedReferenceInspection : TexifyInspectionBase() {
                     descriptors.add(
                         manager.createProblemDescriptor(
                             command,
-                            TextRange.from(offset, part.length),
+                            TextRange.from(max(offset, 0), part.length),
                             "Unresolved reference '$part'",
                             ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
                             isOntheFly

--- a/src/nl/hannahsten/texifyidea/lang/LatexRegularCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/LatexRegularCommand.kt
@@ -525,7 +525,31 @@ enum class LatexRegularCommand(
     FUNCTION("Function", "name".asRequired(), "params".asRequired(), dependency = ALGPSEUDOCODE),
     ENDFUNCTION("EndFunction", dependency = ALGPSEUDOCODE),
     PROCEDURE("Procedure", "name".asRequired(), "params".asRequired(), dependency = ALGPSEUDOCODE),
-    ENDPROCEDURE("EndProcedure", dependency = ALGPSEUDOCODE);
+    ENDPROCEDURE("EndProcedure", dependency = ALGPSEUDOCODE),
+
+    /*
+     * If- commands
+     * Source: http://mirrors.ctan.org/info/texbytopic/TeXbyTopic.pdf chapter Conditionals
+     */
+    IFCAT("ifcat"),
+    IFX("ifx"),
+    IFCASE("ifcase"),
+    IFNUM("ifnum"),
+    IFODD("ifodd"),
+    IFHMODE("ifhmode"),
+    IFVMODE("ifvmode"),
+    IFMMODE("ifmmode"),
+    IFINNER("ifinner"),
+    IFDIM("ifdim"),
+    IFVOID("ifvoid"),
+    IFHBOX("ifhbox"),
+    IFVBOX("ifvbox"),
+    IFEOF("ifeof"),
+    IFTRUE("iftrue"),
+    IFFALSE("iffalse"),
+    FI("fi"),
+    ELSE("else"),
+    OR("or");
 
     companion object {
 

--- a/src/nl/hannahsten/texifyidea/lang/LatexRegularCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/LatexRegularCommand.kt
@@ -513,7 +513,7 @@ enum class LatexRegularCommand(
     FOR("For", "condition".asRequired(), dependency = ALGPSEUDOCODE),
     FORALL("ForAll", "condition".asRequired(), dependency = ALGPSEUDOCODE),
     ENDFOR("EndFor", dependency = ALGPSEUDOCODE),
-    IF("If", "condition".asRequired(), dependency = ALGPSEUDOCODE),
+    IF_ALGPSEUDOCODE("If", "condition".asRequired(), dependency = ALGPSEUDOCODE),
     ELSIF("ElsIf", "condition".asRequired(), dependency = ALGPSEUDOCODE),
     ENDIF("EndIf", dependency = ALGPSEUDOCODE),
     WHILE("While", "condition".asRequired(), dependency = ALGPSEUDOCODE),
@@ -531,6 +531,7 @@ enum class LatexRegularCommand(
      * If- commands
      * Source: http://mirrors.ctan.org/info/texbytopic/TeXbyTopic.pdf chapter Conditionals
      */
+    IF("if"),
     IFCAT("ifcat"),
     IFX("ifx"),
     IFCASE("ifcase"),

--- a/src/nl/hannahsten/texifyidea/util/Magic.kt
+++ b/src/nl/hannahsten/texifyidea/util/Magic.kt
@@ -576,6 +576,15 @@ object Magic {
             "\\" + EXTERNALDOCUMENT.command to hashSetOf("tex") // Not completely true, as it only includes labels
         )
 
+        val startIfs = hashSetOf(
+            IF, IFCAT, IFX,
+            IFCASE, IFNUM, IFODD,
+            IFHMODE, IFVMODE, IFMMODE,
+            IFINNER, IFDIM, IFVOID,
+            IFHBOX, IFVBOX, IFEOF,
+            IFTRUE, IFFALSE
+        ).map { "\\" + it.command }
+
         /**
          * All commands that end if.
          */

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LatexNonMatchingIfInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LatexNonMatchingIfInspectionTest.kt
@@ -10,7 +10,7 @@ class LatexNonMatchingIfInspectionTest : TexifyInspectionTestBase(LatexNonMatchi
         """.trimIndent()
     )
 
-    fun `test if not closed`() = testHighlighting("<error descr=\"If statement is not closed\">\\if</error>")
+    fun `test if not closed`() = testHighlighting("<warning descr=\"If statement should probably be closed with \\fi\">\\if</warning>")
 
     fun `test fi not opened`() = testHighlighting("<error descr=\"No matching \\if-command found\">\\fi</error>")
 
@@ -25,7 +25,7 @@ class LatexNonMatchingIfInspectionTest : TexifyInspectionTestBase(LatexNonMatchi
     fun `test newif not closed`() = testHighlighting(
         """
         \newif\ifpaper
-        <error descr="If statement is not closed">\ifpaper</error>
+        <warning descr="If statement should probably be closed with \fi">\ifpaper</warning>
         """.trimIndent()
     )
 
@@ -35,4 +35,11 @@ class LatexNonMatchingIfInspectionTest : TexifyInspectionTestBase(LatexNonMatchi
         <error descr="No matching \if-command found">\fi</error>
         """.trimIndent()
     )
+
+//    fun `test fake custom if-like command`() = testHighlighting(
+//        """
+//        \newcommand{\iflam}{if something}
+//        \iflam
+//        """.trimIndent()
+//    )
 }


### PR DESCRIPTION
* Fix #1635 negative offset in LatexUnresolvedReferenceInspection
* Fix #1628 by only requiring known \if-like commands to be closed