### PR TITLE
Avoid empty output paths

### DIFF
--- a/src/nl/hannahsten/texifyidea/run/latex/LatexOutputPath.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexOutputPath.kt
@@ -34,7 +34,7 @@ class LatexOutputPath(private val variant: String, var contentRoot: VirtualFile?
     }
 
     fun clone(): LatexOutputPath {
-        return LatexOutputPath(variant, contentRoot, mainFile, project).apply { this.pathString = this@LatexOutputPath.pathString }
+        return LatexOutputPath(variant, contentRoot, mainFile, project).apply { if (this@LatexOutputPath.pathString.isNotBlank()) this.pathString = this@LatexOutputPath.pathString }
     }
 
     // Acts as a sort of cache
@@ -49,6 +49,11 @@ class LatexOutputPath(private val variant: String, var contentRoot: VirtualFile?
         // No auxil directory should be present/created when there's no MiKTeX around, assuming that TeX Live does not support this
         if (!LatexDistribution.isMiktexAvailable && variant == "auxil") {
             return null
+        }
+
+        // Just to be sure, avoid using jetbrains /bin path as output
+        if (pathString.isBlank()) {
+            pathString = "$projectDirString/$variant"
         }
 
         // Caching of the result


### PR DESCRIPTION
... because that leads to using the Jetbrains /bin folder as output path.