### PR TITLE
Closing $ and escaping math operator

### DIFF
--- a/src/nl/hannahsten/texifyidea/highlighting/LatexTypedHandler.kt
+++ b/src/nl/hannahsten/texifyidea/highlighting/LatexTypedHandler.kt
@@ -49,7 +49,7 @@ class LatexTypedHandler : TypedHandlerDelegate() {
                 val element = file.findElementAt(caret.offset)
                 val parent = PsiTreeUtil.getParentOfType(element, LatexInlineMath::class.java) ?: return Result.CONTINUE
                 val endOffset = parent.textRange.endOffset
-                if (caret.offset == endOffset - 1) {
+                if (caret.offset == endOffset - 1 && parent.text.last() == c) {
                     // Caret is at the end of the environment, so run over the closing $
                     caret.moveCaretRelatively(1, 0, false, false, true)
                     return Result.STOP

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LatexMathOperatorEscapeInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LatexMathOperatorEscapeInspectionTest.kt
@@ -1,0 +1,17 @@
+package nl.hannahsten.texifyidea.inspections.latex
+
+import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
+
+class LatexMathOperatorEscapeInspectionTest : TexifyInspectionTestBase(LatexMathOperatorEscapeInspection()) {
+    fun `test inspection triggered in inline math`() {
+        testHighlighting("""Hallo ${'$'}y = <warning descr="Non-escaped math operator">cos</warning>(x)${'$'}""")
+    }
+
+    fun `test no trigger outside math mode`() {
+        testHighlighting("cos")
+    }
+
+    fun `test no trigger inside text in inline math`() {
+        testHighlighting("""Hallo ${'$'}\text{cos}(x)${'$'}""")
+    }
+}

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LatexMathOperatorEscapeInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LatexMathOperatorEscapeInspectionTest.kt
@@ -11,6 +11,17 @@ class LatexMathOperatorEscapeInspectionTest : TexifyInspectionTestBase(LatexMath
         testHighlighting("cos")
     }
 
+    fun `test trigger in math inside text`() {
+        testHighlighting("""
+            \[
+                \begin{cases}
+                    1 & \text{if ${'$'}<warning descr="Non-escaped math operator">cos</warning>(x) = 1${'$'}} \\
+                    0 & \text{otherwise}
+                \end{cases}
+            \]
+        """.trimIndent())
+    }
+
     fun `test no trigger inside text in inline math`() {
         testHighlighting("""Hallo ${'$'}\text{cos}(x)${'$'}""")
     }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->

#### Summary of additions and changes

* `$bl<caret>a`, type <kbd>$</kbd> now produces `$bl$<caret>a` instead of `$bla<caret>`
* Fix that `$\text{max}$` triggered the unescaped math operator inspection even though `max` is inside text and does not have to be escaped.

#### How to test this pull request

```latex
$cos$
$\cos$
$\text{cos}$
\[
    \begin{cases}
        1 & \text{if $cos(x) = 1$} \\
        0 & \text{otherwise}
    \end{cases}
\]
```