### PR TITLE
Added my templates to fix #1700

### DIFF
--- a/resources/liveTemplates/LaTeX.xml
+++ b/resources/liveTemplates/LaTeX.xml
@@ -49,5 +49,22 @@
             <option name="LATEX_MATH" value="true"/>
         </context>
     </template>
+    
+    <template name="enq" value="\enquote{$QUOTE$} $END$" description="Enquote" toReformat="false" toShortenFQNames="true">
+        <variable name="QUOTE" expression="" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="LATEX" value="true"/>
+            <option name="LATEX_MATH" value="false"/>
+        </context>
+    </template>
+    
+    <template name="fc" value="\footcite[$PAGE$]{$SOURCE$}$END$" description="footcite" toReformat="false" toShortenFQNames="true">
+        <variable name="PAGE" expression="" defaultValue="" alwaysStopAt="true" />
+        <variable name="SOURCE" expression="" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="LATEX" value="true"/>
+            <option name="LATEX_MATH" value="false"/>
+        </context>
+    </template>
 </templateSet>
 


### PR DESCRIPTION
Copied them from exported IntelliJ settings

<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1700

#### Summary of additions and changes

* Added 2 new live templates for enquote and for footcite

#### How to test this pull request

Write enq, should expand to 
```latex
\enquote{} 
```
and cursor should be convenient.

Write fc, should expand to 
```latex
\footcite[]{}
```
and cursors should be convenient.



#### Wiki

<!-- Add link to updated wiki page -->

Relevant wiki Link would be https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Live-templates, but there is also no description of existing templates so I guess documenting this would not fit
- [ ] Updated the wiki: 