### PR TITLE
Fixed #1706: Gutter icons for file navigation changed to 12x12.

### DIFF
--- a/resources/nl/hannahsten/texifyidea/icons/bibliography-file_smaller.svg
+++ b/resources/nl/hannahsten/texifyidea/icons/bibliography-file_smaller.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Laag_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="12px" height="12px" viewBox="0 0 12 12" enable-background="new 0 0 12 12" xml:space="preserve">
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,3.196h3.204v-3.204L1.594,3.196z"/>
+</g>
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,5.6V3.998H5.6v-4.005h4.005V5.6H1.594z"/>
+</g>
+<g>
+	<g>
+		<g>
+			<rect x="-0.008" y="6.4" opacity="0.698" fill="#E9A055" enable-background="new    " width="12.016" height="5.607"/>
+		</g>
+	</g>
+</g>
+</svg>

--- a/resources/nl/hannahsten/texifyidea/icons/class-file_smaller.svg
+++ b/resources/nl/hannahsten/texifyidea/icons/class-file_smaller.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Laag_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="12px" height="12px" viewBox="0 0 12 12" enable-background="new 0 0 12 12" xml:space="preserve">
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,3.196h3.204v-3.204L1.594,3.196z"/>
+</g>
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,5.6V3.998H5.6v-4.005h4.005V5.6H1.594z"/>
+</g>
+<g>
+	<g>
+		<g>
+			<rect x="-0.008" y="6.4" opacity="0.698" fill="#B99BF8" enable-background="new    " width="12.016" height="5.607"/>
+		</g>
+	</g>
+</g>
+</svg>

--- a/resources/nl/hannahsten/texifyidea/icons/doc-latex-file_smaller.svg
+++ b/resources/nl/hannahsten/texifyidea/icons/doc-latex-file_smaller.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Laag_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="12px" height="12px" viewBox="0 0 12 12" enable-background="new 0 0 12 12" xml:space="preserve">
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,3.196h3.204v-3.204L1.594,3.196z"/>
+</g>
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,5.6V3.998H5.6v-4.005h4.005V5.6H1.594z"/>
+</g>
+<g>
+	<g>
+		<g>
+			<rect x="-0.008" y="6.4" opacity="0.698" fill="#F4AF3D" enable-background="new    " width="12.016" height="5.607"/>
+		</g>
+	</g>
+</g>
+</svg>

--- a/resources/nl/hannahsten/texifyidea/icons/dvi-file_smaller.svg
+++ b/resources/nl/hannahsten/texifyidea/icons/dvi-file_smaller.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Laag_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="12px" height="12px" viewBox="0 0 12 12" enable-background="new 0 0 12 12" xml:space="preserve">
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,3.196h3.204v-3.204L1.594,3.196z"/>
+</g>
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,5.6V3.998H5.6v-4.005h4.005V5.6H1.594z"/>
+</g>
+<g>
+	<g>
+		<g>
+			<rect x="-0.008" y="6.4" opacity="0.698" fill="#40B6E0" enable-background="new    " width="12.016" height="5.607"/>
+		</g>
+	</g>
+</g>
+</svg>

--- a/resources/nl/hannahsten/texifyidea/icons/file_smaller.svg
+++ b/resources/nl/hannahsten/texifyidea/icons/file_smaller.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Laag_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="12px" height="12px" viewBox="0 0 12 12" enable-background="new 0 0 12 12" xml:space="preserve">
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,3.196h3.204v-3.204L1.594,3.196z"/>
+</g>
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,5.6V3.998H5.6v-4.005h4.005V5.6H1.594z"/>
+</g>
+<g>
+	<g>
+		<g>
+			<rect x="-0.008" y="6.4" opacity="0.698" fill="#9AA7B0" enable-background="new    " width="12.016" height="5.607"/>
+		</g>
+	</g>
+</g>
+</svg>

--- a/resources/nl/hannahsten/texifyidea/icons/latex-file_smaller.svg
+++ b/resources/nl/hannahsten/texifyidea/icons/latex-file_smaller.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Laag_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="12px" height="12px" viewBox="0 0 12 12" enable-background="new 0 0 12 12" xml:space="preserve">
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,3.196h3.204v-3.204L1.594,3.196z"/>
+</g>
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,5.6V3.998H5.6v-4.005h4.005V5.6H1.594z"/>
+</g>
+<g>
+	<g>
+		<g>
+			<rect x="-0.008" y="6.4" opacity="0.698" fill="#66B445" width="12.016" height="5.607"/>
+		</g>
+	</g>
+</g>
+</svg>

--- a/resources/nl/hannahsten/texifyidea/icons/pdf-file_smaller.svg
+++ b/resources/nl/hannahsten/texifyidea/icons/pdf-file_smaller.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Laag_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="12px" height="12px" viewBox="0 0 12 12" enable-background="new 0 0 12 12" xml:space="preserve">
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,3.196h3.204v-3.204L1.594,3.196z"/>
+</g>
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,5.6V3.998H5.6v-4.005h4.005V5.6H1.594z"/>
+</g>
+<g>
+	<g>
+		<g>
+			<rect x="-0.008" y="6.4" opacity="0.698" fill="#F26522" enable-background="new    " width="12.016" height="5.607"/>
+		</g>
+	</g>
+</g>
+</svg>

--- a/resources/nl/hannahsten/texifyidea/icons/style-file_smaller.svg
+++ b/resources/nl/hannahsten/texifyidea/icons/style-file_smaller.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Laag_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="12px" height="12px" viewBox="0 0 12 12" enable-background="new 0 0 12 12" xml:space="preserve">
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,3.196h3.204v-3.204L1.594,3.196z"/>
+</g>
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,5.6V3.998H5.6v-4.005h4.005V5.6H1.594z"/>
+</g>
+<g>
+	<g>
+		<g>
+			<rect x="-0.008" y="6.4" opacity="0.698" fill="#40B6E0" enable-background="new    " width="12.016" height="5.607"/>
+		</g>
+	</g>
+</g>
+</svg>

--- a/resources/nl/hannahsten/texifyidea/icons/synctex-file_smaller.svg
+++ b/resources/nl/hannahsten/texifyidea/icons/synctex-file_smaller.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Laag_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="12px" height="12px" viewBox="0 0 12 12" enable-background="new 0 0 12 12" xml:space="preserve">
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,3.196h3.204v-3.204L1.594,3.196z"/>
+</g>
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,5.6V3.998H5.6v-4.005h4.005V5.6H1.594z"/>
+</g>
+<g>
+	<g>
+		<g>
+			<rect x="-0.008" y="6.4" opacity="0.698" fill="#9AA7B0" enable-background="new    " width="12.016" height="5.607"/>
+		</g>
+	</g>
+</g>
+</svg>

--- a/resources/nl/hannahsten/texifyidea/icons/text-file_smaller.svg
+++ b/resources/nl/hannahsten/texifyidea/icons/text-file_smaller.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Laag_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="12px" height="12px" viewBox="0 0 12 12" enable-background="new 0 0 12 12" xml:space="preserve">
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,3.196h3.204v-3.204L1.594,3.196z"/>
+</g>
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,5.6V3.998H5.6v-4.005h4.005V5.6H1.594z"/>
+</g>
+<g>
+	<g>
+		<g>
+			<rect x="-0.008" y="6.4" opacity="0.698" fill="#9AA7B0" enable-background="new    " width="12.016" height="5.607"/>
+		</g>
+	</g>
+</g>
+</svg>

--- a/resources/nl/hannahsten/texifyidea/icons/tikz-file_smaller.svg
+++ b/resources/nl/hannahsten/texifyidea/icons/tikz-file_smaller.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Laag_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="12px" height="12px" viewBox="0 0 12 12" enable-background="new 0 0 12 12" xml:space="preserve">
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,3.196h3.204v-3.204L1.594,3.196z"/>
+</g>
+<g>
+	<path fill="#9AA7B0" fill-opacity="0.8" d="M1.594,5.6V3.998H5.6v-4.005h4.005V5.6H1.594z"/>
+</g>
+<g>
+	<g>
+		<g>
+			<rect x="-0.008" y="6.4" opacity="0.698" fill="#65B344" enable-background="new    " width="12.016" height="5.607"/>
+		</g>
+	</g>
+</g>
+</svg>

--- a/src/nl/hannahsten/texifyidea/TexifyIcons.kt
+++ b/src/nl/hannahsten/texifyidea/TexifyIcons.kt
@@ -24,10 +24,24 @@ object TexifyIcons {
     )
 
     /**
+     * Copyright (c) 2021 Hannah Schellekens
+     */
+    val LATEX_FILE_SMALLER = IconLoader.getIcon(
+        "/nl/hannahsten/texifyidea/icons/latex-file_smaller.svg", TexifyIcons::class.java
+    )
+
+    /**
      * Copyright (c) 2019 Hannah Schellekens
      */
     val TIKZ_FILE = IconLoader.getIcon(
         "/nl/hannahsten/texifyidea/icons/tikz-file.svg", TexifyIcons::class.java
+    )
+
+    /**
+     * Copyright (c) 2021 Hannah Schellekens
+     */
+    val TIKZ_FILE_SMALLER = IconLoader.getIcon(
+        "/nl/hannahsten/texifyidea/icons/tikz-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
@@ -38,10 +52,24 @@ object TexifyIcons {
     )
 
     /**
+     * Copyright (c) 2021 Hannah Schellekens
+     */
+    val PDF_FILE_SMALLER = IconLoader.getIcon(
+        "/nl/hannahsten/texifyidea/icons/pdf-file_smaller.svg", TexifyIcons::class.java
+    )
+
+    /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DVI_FILE = IconLoader.getIcon(
         "/nl/hannahsten/texifyidea/icons/dvi-file.svg", TexifyIcons::class.java
+    )
+
+    /**
+     * Copyright (c) 2021 Hannah Schellekens
+     */
+    val DVI_FILE_SMALLER = IconLoader.getIcon(
+        "/nl/hannahsten/texifyidea/icons/dvi-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
@@ -52,10 +80,24 @@ object TexifyIcons {
     )
 
     /**
+     * Copyright (c) 2021 Hannah Schellekens
+     */
+    val BIBLIOGRAPHY_FILE_SMALLER = IconLoader.getIcon(
+        "/nl/hannahsten/texifyidea/icons/bibliography-file_smaller.svg", TexifyIcons::class.java
+    )
+
+    /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val CLASS_FILE = IconLoader.getIcon(
         "/nl/hannahsten/texifyidea/icons/class-file.svg", TexifyIcons::class.java
+    )
+
+    /**
+     * Copyright (c) 2021 Hannah Schellekens
+     */
+    val CLASS_FILE_SMALLER = IconLoader.getIcon(
+        "/nl/hannahsten/texifyidea/icons/class-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
@@ -66,6 +108,13 @@ object TexifyIcons {
     )
 
     /**
+     * Copyright (c) 2021 Hannah Schellekens
+     */
+    val DOCUMENTED_LATEX_SOURCE_SMALLER = IconLoader.getIcon(
+        "/nl/hannahsten/texifyidea/icons/doc-latex-file_smaller.svg", TexifyIcons::class.java
+    )
+
+    /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val STYLE_FILE = IconLoader.getIcon(
@@ -73,10 +122,24 @@ object TexifyIcons {
     )
 
     /**
+     * Copyright (c) 2021 Hannah Schellekens
+     */
+    val STYLE_FILE_SMALLER = IconLoader.getIcon(
+        "/nl/hannahsten/texifyidea/icons/style-file_smaller.svg", TexifyIcons::class.java
+    )
+
+    /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val FILE = IconLoader.getIcon(
         "/nl/hannahsten/texifyidea/icons/file.svg", TexifyIcons::class.java
+    )
+
+    /**
+     * Copyright (c) 2021 Hannah Schellekens
+     */
+    val FILE_SMALLER = IconLoader.getIcon(
+        "/nl/hannahsten/texifyidea/icons/file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
@@ -91,6 +154,13 @@ object TexifyIcons {
      */
     val SYNCTEX_FILE = IconLoader.getIcon(
         "/nl/hannahsten/texifyidea/icons/synctex-file.svg", TexifyIcons::class.java
+    )
+
+    /**
+     * Copyright (c) 2021 Hannah Schellekens
+     */
+    val SYNCTEX_FILE_SMALLER = IconLoader.getIcon(
+        "/nl/hannahsten/texifyidea/icons/synctex-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
@@ -119,6 +189,13 @@ object TexifyIcons {
      */
     val TEXT_FILE = IconLoader.getIcon(
         "/nl/hannahsten/texifyidea/icons/text-file.svg", TexifyIcons::class.java
+    )
+
+    /**
+     * Copyright (c) 2021 Hannah Schellekens
+     */
+    val TEXT_FILE_SMALLER = IconLoader.getIcon(
+        "/nl/hannahsten/texifyidea/icons/text-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
@@ -379,27 +456,30 @@ object TexifyIcons {
      * This method ignores case.
      *
      * @param extension
-     * The extension of the file to get the icon of without a dot.
+     *              The extension of the file to get the icon of without a dot.
+     * @param smaller
+     *              `true` for a small icon, `false` for a regular sized icon.
      * @return The Icon that corresponds to the given extension.
      * @throws IllegalArgumentException
      * When `extension` is null.
      */
-    fun getIconFromExtension(extension: String?): Icon {
+    fun getIconFromExtension(extension: String?, smaller: Boolean = false): Icon {
         return if (extension == null) {
             FILE
         }
         else when (extension.toLowerCase()) {
-            "tex" -> LATEX_FILE
-            "bib" -> BIBLIOGRAPHY_FILE
-            "cls" -> CLASS_FILE
-            "dtx" -> DOCUMENTED_LATEX_SOURCE
-            "sty" -> STYLE_FILE
-            "txt" -> TEXT_FILE
-            "tikz" -> TIKZ_FILE
-            "log" -> TEXT_FILE
-            "pdf" -> PDF_FILE
-            "synctex.gz" -> SYNCTEX_FILE
-            else -> FILE
+            "tex" -> if (smaller) LATEX_FILE_SMALLER else LATEX_FILE
+            "bib" -> if (smaller) BIBLIOGRAPHY_FILE_SMALLER else BIBLIOGRAPHY_FILE
+            "cls" -> if (smaller) CLASS_FILE_SMALLER else CLASS_FILE
+            "dtx" -> if (smaller) DOCUMENTED_LATEX_SOURCE_SMALLER else DOCUMENTED_LATEX_SOURCE
+            "sty" -> if (smaller) STYLE_FILE_SMALLER else STYLE_FILE
+            "txt" -> if (smaller) TEXT_FILE_SMALLER else TEXT_FILE
+            "tikz" ->if (smaller) TIKZ_FILE_SMALLER else TIKZ_FILE
+            "log" -> if (smaller) TEXT_FILE_SMALLER else TEXT_FILE
+            "pdf" -> if (smaller) PDF_FILE_SMALLER else PDF_FILE
+            "synctex.gz" -> if (smaller) SYNCTEX_FILE_SMALLER else SYNCTEX_FILE
+            "dvi" -> if (smaller) DVI_FILE_SMALLER else DVI_FILE
+            else -> if (smaller) FILE_SMALLER else FILE
         }
     }
 }

--- a/src/nl/hannahsten/texifyidea/TexifyIcons.kt
+++ b/src/nl/hannahsten/texifyidea/TexifyIcons.kt
@@ -13,435 +13,435 @@ object TexifyIcons {
      * Copyright (c) 2017 Hannah Schellekens
      */
     val LATEX_FILE_BIG = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/latex-file-big.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/latex-file-big.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val LATEX_FILE = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/latex-file.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/latex-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val LATEX_FILE_SMALLER = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/latex-file_smaller.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/latex-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2019 Hannah Schellekens
      */
     val TIKZ_FILE = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/tikz-file.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/tikz-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val TIKZ_FILE_SMALLER = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/tikz-file_smaller.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/tikz-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val PDF_FILE = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/pdf-file.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/pdf-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val PDF_FILE_SMALLER = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/pdf-file_smaller.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/pdf-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DVI_FILE = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/dvi-file.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/dvi-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val DVI_FILE_SMALLER = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/dvi-file_smaller.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/dvi-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val BIBLIOGRAPHY_FILE = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/bibliography-file.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/bibliography-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val BIBLIOGRAPHY_FILE_SMALLER = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/bibliography-file_smaller.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/bibliography-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val CLASS_FILE = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/class-file.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/class-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val CLASS_FILE_SMALLER = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/class-file_smaller.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/class-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOCUMENTED_LATEX_SOURCE = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/doc-latex-file.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/doc-latex-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val DOCUMENTED_LATEX_SOURCE_SMALLER = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/doc-latex-file_smaller.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/doc-latex-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val STYLE_FILE = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/style-file.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/style-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val STYLE_FILE_SMALLER = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/style-file_smaller.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/style-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val FILE = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/file.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val FILE_SMALLER = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/file_smaller.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val TEMP_FILE = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/temp.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/temp.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val SYNCTEX_FILE = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/synctex-file.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/synctex-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val SYNCTEX_FILE_SMALLER = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/synctex-file_smaller.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/synctex-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val AUX_FILE = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/aux-file.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/aux-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val TABLE_OF_CONTENTS_FILE = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/toc-file.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/toc-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val BBL_FILE = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/bbl-file.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/bbl-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val TEXT_FILE = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/text-file.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/text-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val TEXT_FILE_SMALLER = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/text-file_smaller.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/text-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val BUILD = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/build.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/build.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val BUILD_BIB = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/bib-build.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/bib-build.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val LATEX_MODULE = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/latex-module.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/latex-module.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_LATEX = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/dot-tex.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/dot-tex.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_COMMAND = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/dot-cmd.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/dot-cmd.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_LABEL = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/dot-lbl.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/dot-lbl.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_BIB = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/dot-bib.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/dot-bib.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_INCLUDE = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/dot-incl.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/dot-incl.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_ENVIRONMENT = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/dot-env.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/dot-env.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2018 Hannah Schellekens
      */
     val DOT_CLASS = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/dot-cls.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/dot-cls.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_NUMBER = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/dot-num.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/dot-num.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_CHAPTER = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/dot-chap.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/dot-chap.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_PART = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/dot-part.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/dot-part.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_SECTION = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/dot-sec.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/dot-sec.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_SUBSECTION = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/dot-subsec.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/dot-subsec.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_SUBSUBSECTION = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/dot-subsubsec.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/dot-subsubsec.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_PARAGRAPH = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/dot-par.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/dot-par.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_SUBPARAGRAPH = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/dot-subpar.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/dot-subpar.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val FONT_BOLD = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/font-bold.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/font-bold.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val FONT_ITALICS = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/font-italics.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/font-italics.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val FONT_UNDERLINE = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/font-underline.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/font-underline.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val FONT_OVERLINE = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/font-overline.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/font-overline.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val FONT_SMALLCAPS = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/font-smallcaps.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/font-smallcaps.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val FONT_TYPEWRITER = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/font-mono.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/font-mono.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val FONT_STRIKETHROUGH = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/font-strike.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/font-strike.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val FONT_SLANTED = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/font-slanted.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/font-slanted.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val SUMATRA = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/sumatra.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/sumatra.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val WORD_COUNT = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/word-count.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/word-count.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val TOGGLE_STAR = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/toggle-star.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/toggle-star.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val STATS = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/stats.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/stats.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val RIGHT = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/right.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/right.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2018 Hannah Schellekens
      */
     val EQUATION_PREVIEW = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/equation-preview.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/equation-preview.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2019 Hannah Schellekens
      */
     val TIKZ_PREVIEW = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/tikz-preview.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/tikz-preview.svg", TexifyIcons::class.java
     )
 
     // From IntelliJ
     val STRING = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/string.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/string.svg", TexifyIcons::class.java
     )
 
     // From IntelliJ (modified)
     val KEY_REQUIRED = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/key-required.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/key-required.svg", TexifyIcons::class.java
     )
 
     // From IntelliJ (modified)
     val KEY_USER_DEFINED = IconLoader.getIcon(
-        "/nl/hannahsten/texifyidea/icons/key-user.svg", TexifyIcons::class.java
+            "/nl/hannahsten/texifyidea/icons/key-user.svg", TexifyIcons::class.java
     )
 
     /**
@@ -474,7 +474,7 @@ object TexifyIcons {
             "dtx" -> if (smaller) DOCUMENTED_LATEX_SOURCE_SMALLER else DOCUMENTED_LATEX_SOURCE
             "sty" -> if (smaller) STYLE_FILE_SMALLER else STYLE_FILE
             "txt" -> if (smaller) TEXT_FILE_SMALLER else TEXT_FILE
-            "tikz" ->if (smaller) TIKZ_FILE_SMALLER else TIKZ_FILE
+            "tikz" -> if (smaller) TIKZ_FILE_SMALLER else TIKZ_FILE
             "log" -> if (smaller) TEXT_FILE_SMALLER else TEXT_FILE
             "pdf" -> if (smaller) PDF_FILE_SMALLER else PDF_FILE
             "synctex.gz" -> if (smaller) SYNCTEX_FILE_SMALLER else SYNCTEX_FILE

--- a/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
+++ b/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
@@ -22,8 +22,8 @@ import javax.swing.Icon
 class LatexNavigationGutter : RelatedItemLineMarkerProvider() {
 
     override fun collectNavigationMarkers(
-        element: PsiElement,
-        result: MutableCollection<in RelatedItemLineMarkerInfo<*>>
+            element: PsiElement,
+            result: MutableCollection<in RelatedItemLineMarkerInfo<*>>
     ) {
 
         // Gutters should only be used with leaf elements.
@@ -53,24 +53,28 @@ class LatexNavigationGutter : RelatedItemLineMarkerProvider() {
         if (referencesList.isEmpty()) return
 
         val files = referencesList.mapNotNull { it.resolve() }
-        val extension = if (files.isNotEmpty()) files.first().name.getFileExtension() else ""
-        val icon = TexifyIcons.getIconFromExtension(extension)
+        val gutterFile = files.firstOrNull()?.virtualFile
+        val extension = gutterFile?.let {
+            if (it.name.endsWith("synctex.gz")) "synctex.gz" else it.extension
+        }
+        // Gutter requires a smaller icon per IJ SDK docs.
+        val icon = TexifyIcons.getIconFromExtension(extension, smaller = true)
 
         val builder = NavigationGutterIconBuilder
-            .create(icon)
-            .setTargets(files)
-            .setPopupTitle("Navigate to Referenced File")
-            .setTooltipText("Go to referenced file")
-            .setCellRenderer(GotoFileCellRenderer(0))
+                .create(icon)
+                .setTargets(files)
+                .setPopupTitle("Navigate to Referenced File")
+                .setTooltipText("Go to referenced file")
+                .setCellRenderer(GotoFileCellRenderer(0))
 
         result.add(builder.createLineMarkerInfo(element))
     }
 
-    override fun getName(): String? {
+    override fun getName(): String {
         return "Navigate to referenced file"
     }
 
-    override fun getIcon(): Icon? {
-        return TexifyIcons.LATEX_FILE
+    override fun getIcon(): Icon {
+        return TexifyIcons.LATEX_FILE_SMALLER
     }
 }

--- a/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
+++ b/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
@@ -11,7 +11,6 @@ import nl.hannahsten.texifyidea.lang.RequiredFileArgument
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexRequiredParamContent
 import nl.hannahsten.texifyidea.reference.InputFileReference
-import nl.hannahsten.texifyidea.util.files.getFileExtension
 import nl.hannahsten.texifyidea.util.parentOfType
 import nl.hannahsten.texifyidea.util.requiredParameters
 import javax.swing.Icon


### PR DESCRIPTION
Fixed #1706: Gutter icons for file navigation changed to 12x12.

- New 'smaller' variants added of file icons: does not feature the extension, but just an empty bar. The colours match the larger variant.
- getIconFromExtension now accepts a smaller flag.
- Added DVI to the getIconFromExtension.
- The icon used for the gutter setting now uses the smaller icon.
- Use the VirtualFile's extension property instead of our util.
- synctex.gz is now recognised as extension by the gutter.

![image](https://user-images.githubusercontent.com/17410729/103559029-c8cf2d80-4eb5-11eb-9efc-e60ed6fe7b2d.png)
