### PR TITLE
Fixed PackageLocationCache calling kpsewhich when the cache contains a null value.

### DIFF
--- a/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
@@ -23,8 +23,14 @@ object LatexPackageLocationCache {
      *
      * @param name Package name with extension.
      */
-    fun getPackageLocation(name: String, project: Project) = cache.getOrPut(name) {
-        runKpsewhich(name, project)
+    fun getPackageLocation(name: String, project: Project): String? {
+        if (cache.containsKey(name).not()) {
+            val path = runKpsewhich(name, project)
+            cache[name] = path
+            return path
+        }
+
+        return cache[name]
     }
 
     private fun runKpsewhich(arg: String, project: Project): String? = try {
@@ -36,7 +42,7 @@ object LatexPackageLocationCache {
             "${LatexSdkUtil.getExecutableName("kpsewhich", project)} $arg"
         }
         BufferedReader(
-            InputStreamReader(Runtime.getRuntime().exec(command).inputStream)
+                InputStreamReader(Runtime.getRuntime().exec(command).inputStream)
         ).readLine() // Returns null if no line read.
     }
     catch (e: IOException) {


### PR DESCRIPTION
Fixes #1424 variant: PackageLocationCache kept calling kpsewhich when the cache contains a null value.

- Replaced the use of 'getOrPut' by custom code using 'containsKey'. getOrPut re-evaluates the defaultValue function when the value is null, which happens when the key is absent, or when there is a key with a null-value => unnecessary kpsewhich calls.
- See https://youtrack.jetbrains.com/issue/KT-21392