### PR TITLE
Fix add label intention for items

### DIFF
--- a/src/nl/hannahsten/texifyidea/intentions/LatexAddLabelIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexAddLabelIntention.kt
@@ -1,5 +1,8 @@
 package nl.hannahsten.texifyidea.intentions
 
+import com.intellij.codeInsight.template.TemplateManager
+import com.intellij.codeInsight.template.impl.TemplateImpl
+import com.intellij.codeInsight.template.impl.TextExpression
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
@@ -45,7 +48,7 @@ open class LatexAddLabelIntention(val command: SmartPsiElementPointer<LatexComma
                 ?: return
 
         // Determine label name.
-        val labelString: String = if (Magic.Command.labelAsParameter.contains(command.name)) {
+        val labelString: String? = if (Magic.Command.labelAsParameter.contains(command.name)) {
             // For parameter labeled commands we use the command name itself
             command.name!!
         }
@@ -56,30 +59,39 @@ open class LatexAddLabelIntention(val command: SmartPsiElementPointer<LatexComma
                 required[0]
             }
             else {
-                command.name ?: return
+                null
             }
         }
 
-        val createdLabel = getUniqueLabelName(
-            labelString.formatAsLabel(),
-            Magic.Command.labeledPrefixes[command.name!!], command.containingFile
-        )
+        val prefix = Magic.Command.labeledPrefixes[command.name!!]
 
-        val factory = LatexPsiHelper(project)
+        if (labelString != null) {
+            val createdLabel = getUniqueLabelName(
+                labelString.formatAsLabel(),
+                prefix, command.containingFile
+            )
 
-        val labelCommand = if (Magic.Command.labelAsParameter.contains(command.name)) {
-            factory.setOptionalParameter(command, "label", "{$createdLabel}")
+            val factory = LatexPsiHelper(project)
+
+            val labelCommand = if (Magic.Command.labelAsParameter.contains(command.name)) {
+                factory.setOptionalParameter(command, "label", "{$createdLabel}")
+            }
+            else {
+                // Insert label
+                // command -> NoMathContent -> Content -> Container containing the command
+                val commandContent = command.parent.parent
+                commandContent.parent.addAfter(factory.createLabelCommand(createdLabel), commandContent)
+            }
+            // Adjust caret offset.
+            val caret = editor.caretModel
+            caret.moveToOffset(labelCommand.endOffset())
         }
         else {
-
-            // Insert label
-            // command -> NoMathContent -> Content -> Container containing the command
-            val commandContent = command.parent.parent
-            commandContent.parent.addAfter(factory.createLabelCommand(createdLabel), commandContent)
+            editor.caretModel.moveToOffset(command.endOffset())
+            val template = TemplateImpl("", "\\label{$prefix:\$__Variable0\$}", "")
+            template.addVariable(TextExpression(""), true)
+            TemplateManager.getInstance(editor.project).startTemplate(editor, template)
         }
-        // Adjust caret offset.
-        val caret = editor.caretModel
-        caret.moveToOffset(labelCommand.endOffset())
     }
 
     private fun getUniqueLabelName(base: String, prefix: String?, file: PsiFile): String {

--- a/src/nl/hannahsten/texifyidea/intentions/LatexAddLabelIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexAddLabelIntention.kt
@@ -56,7 +56,7 @@ open class LatexAddLabelIntention(val command: SmartPsiElementPointer<LatexComma
                 required[0]
             }
             else {
-                return
+                command.name ?: return
             }
         }
 

--- a/test/nl/hannahsten/texifyidea/intentions/LatexAddLabelIntentionTest.kt
+++ b/test/nl/hannahsten/texifyidea/intentions/LatexAddLabelIntentionTest.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.intentions
 
+import com.intellij.codeInsight.template.impl.TemplateManagerImpl
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.testutils.writeCommand
@@ -82,6 +83,7 @@ class LatexAddLabelIntentionTest : BasePlatformTestCase() {
             \end{document}
             """.trimIndent()
         )
+        TemplateManagerImpl.setTemplateTesting(myFixture.projectDisposable)
         val intentions = myFixture.availableIntentions
         writeCommand(myFixture.project) {
             intentions.first { i -> i.text == "Add label" }.invoke(myFixture.project, myFixture.editor, myFixture.file)
@@ -90,7 +92,7 @@ class LatexAddLabelIntentionTest : BasePlatformTestCase() {
             """
             \begin{document}
                 \begin{enumerate}
-                    \item\label{itm:item}<caret> Some item
+                    \item\label{itm:<caret>} Some item
                 \end{enumerate}
             \end{document}
             """.trimIndent()

--- a/test/nl/hannahsten/texifyidea/intentions/LatexAddLabelIntentionTest.kt
+++ b/test/nl/hannahsten/texifyidea/intentions/LatexAddLabelIntentionTest.kt
@@ -70,4 +70,30 @@ class LatexAddLabelIntentionTest : BasePlatformTestCase() {
             """.trimIndent()
         )
     }
+
+    fun testLabelForItem() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \begin{document}
+                \begin{enumerate}
+                    \item<caret> Some item
+                \end{enumerate}
+            \end{document}
+            """.trimIndent()
+        )
+        val intentions = myFixture.availableIntentions
+        writeCommand(myFixture.project) {
+            intentions.first { i -> i.text == "Add label" }.invoke(myFixture.project, myFixture.editor, myFixture.file)
+        }
+        myFixture.checkResult(
+            """
+            \begin{document}
+                \begin{enumerate}
+                    \item\label{itm:item}<caret> Some item
+                \end{enumerate}
+            \end{document}
+            """.trimIndent()
+        )
+    }
 }

--- a/test/nl/hannahsten/texifyidea/intentions/LatexAddLabelIntentionTest.kt
+++ b/test/nl/hannahsten/texifyidea/intentions/LatexAddLabelIntentionTest.kt
@@ -16,7 +16,7 @@ class LatexAddLabelIntentionTest : BasePlatformTestCase() {
         )
         val intentions = myFixture.availableIntentions
         writeCommand(myFixture.project) {
-            intentions.first().invoke(myFixture.project, myFixture.editor, myFixture.file)
+            intentions.first { i -> i.text == "Add label" }.invoke(myFixture.project, myFixture.editor, myFixture.file)
         }
         myFixture.checkResult(
             """
@@ -38,7 +38,7 @@ class LatexAddLabelIntentionTest : BasePlatformTestCase() {
         )
         val intentions = myFixture.availableIntentions
         writeCommand(myFixture.project) {
-            intentions.first().invoke(myFixture.project, myFixture.editor, myFixture.file)
+            intentions.first { i -> i.text == "Add label" }.invoke(myFixture.project, myFixture.editor, myFixture.file)
         }
         myFixture.checkResult(
             """
@@ -60,7 +60,7 @@ class LatexAddLabelIntentionTest : BasePlatformTestCase() {
         )
         val intentions = myFixture.availableIntentions
         writeCommand(myFixture.project) {
-            intentions.first().invoke(myFixture.project, myFixture.editor, myFixture.file)
+            intentions.first { i -> i.text == "Add label" }.invoke(myFixture.project, myFixture.editor, myFixture.file)
         }
         myFixture.checkResult(
             """


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1718

#### Summary of additions and changes

* Fix the test class by specifying the intended intention action. The testcases were failing on my computer because the "Add label" intention was not the first intetion in the list
* Fix the "Add label" intention for commands that are neither labeled with parameters nor have a required parameter to determine the label name.

#### How to test this pull request

See the included testcase and the description in #1718.
