### PR TITLE
Sectioning commands with label live template

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -388,6 +388,8 @@
         <liveTemplateContext implementation="nl.hannahsten.texifyidea.templates.LatexContext$LatexMathContext"/>
         <liveTemplateContext implementation="nl.hannahsten.texifyidea.templates.BibtexContext"/>
 
+        <liveTemplateMacro implementation="nl.hannahsten.texifyidea.templates.macros.LatexFormatAsLabelMacro"/>
+
         <codeInsight.template.postfixTemplateProvider language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.postfix.LatexPostFixTemplateProvider"/>
         <codeInsight.template.postfixTemplateProvider language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.postfix.LatexPostfixTemplateFromAmsMathProvider"/>
         <codeInsight.template.postfixTemplateProvider language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.postfix.LatexPostfixTemplateFromAmsFontsProvider"/>

--- a/resources/liveTemplates/LaTeX.xml
+++ b/resources/liveTemplates/LaTeX.xml
@@ -33,7 +33,7 @@
         </context>
     </template>
 
-    <template name="\partl" value="\part{$TITLE$} \label{$LABEL$}$END$" description="Part with label" toReformat="false" toShortenFQNames="true">
+    <template name="\partl" value="\part{$TITLE$}\label{$LABEL$}$END$" description="Part with label" toReformat="false" toShortenFQNames="true">
         <variable name="TITLE" expression="" defaultValue="" alwaysStopAt="true" />
         <variable name="LABEL" expression="latexFormatAsLabel(TITLE)" defaultValue="" alwaysStopAt="true" />
         <context>
@@ -42,7 +42,7 @@
         </context>
     </template>
 
-    <template name="\chapl" value="\chapter{$TITLE$} \label{ch:$LABEL$}$END$" description="Chapter with label" toReformat="false" toShortenFQNames="true">
+    <template name="\chapl" value="\chapter{$TITLE$}\label{ch:$LABEL$}$END$" description="Chapter with label" toReformat="false" toShortenFQNames="true">
         <variable name="TITLE" expression="" defaultValue="" alwaysStopAt="true" />
         <variable name="LABEL" expression="latexFormatAsLabel(TITLE)" defaultValue="" alwaysStopAt="true" />
         <context>
@@ -51,7 +51,7 @@
         </context>
     </template>
 
-    <template name="\secl" value="\section{$TITLE$} \label{sec:$LABEL$}$END$" description="Section with label" toReformat="false" toShortenFQNames="true">
+    <template name="\secl" value="\section{$TITLE$}\label{sec:$LABEL$}$END$" description="Section with label" toReformat="false" toShortenFQNames="true">
         <variable name="TITLE" expression="" defaultValue="" alwaysStopAt="true" />
         <variable name="LABEL" expression="latexFormatAsLabel(TITLE)" defaultValue="" alwaysStopAt="true" />
         <context>
@@ -60,7 +60,7 @@
         </context>
     </template>
 
-    <template name="\subsecl" value="\subsection{$TITLE$} \label{subsec:$LABEL$}$END$" description="Subsection with label" toReformat="false" toShortenFQNames="true">
+    <template name="\subsecl" value="\subsection{$TITLE$}\label{subsec:$LABEL$}$END$" description="Subsection with label" toReformat="false" toShortenFQNames="true">
         <variable name="TITLE" expression="" defaultValue="" alwaysStopAt="true" />
         <variable name="LABEL" expression="latexFormatAsLabel(TITLE)" defaultValue="" alwaysStopAt="true" />
         <context>
@@ -69,7 +69,7 @@
         </context>
     </template>
 
-    <template name="\subsubsecl" value="\subsubsection{$TITLE$} \label{subsubsec:$LABEL$}$END$" description="Subsubsection with label" toReformat="false" toShortenFQNames="true">
+    <template name="\subsubsecl" value="\subsubsection{$TITLE$}\label{subsubsec:$LABEL$}$END$" description="Subsubsection with label" toReformat="false" toShortenFQNames="true">
         <variable name="TITLE" expression="" defaultValue="" alwaysStopAt="true" />
         <variable name="LABEL" expression="latexFormatAsLabel(TITLE)" defaultValue="" alwaysStopAt="true" />
         <context>

--- a/resources/liveTemplates/LaTeX.xml
+++ b/resources/liveTemplates/LaTeX.xml
@@ -33,6 +33,51 @@
         </context>
     </template>
 
+    <template name="\partl" value="\part{$TITLE$} \label{$LABEL$}$END$" description="Part with label" toReformat="false" toShortenFQNames="true">
+        <variable name="TITLE" expression="" defaultValue="" alwaysStopAt="true" />
+        <variable name="LABEL" expression="latexFormatAsLabel(TITLE)" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="LATEX" value="true" />
+            <option name="LATEX_MATH" value="false" />
+        </context>
+    </template>
+
+    <template name="\chapl" value="\chapter{$TITLE$} \label{ch:$LABEL$}$END$" description="Chapter with label" toReformat="false" toShortenFQNames="true">
+        <variable name="TITLE" expression="" defaultValue="" alwaysStopAt="true" />
+        <variable name="LABEL" expression="latexFormatAsLabel(TITLE)" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="LATEX" value="true" />
+            <option name="LATEX_MATH" value="false" />
+        </context>
+    </template>
+
+    <template name="\secl" value="\section{$TITLE$} \label{sec:$LABEL$}$END$" description="Section with label" toReformat="false" toShortenFQNames="true">
+        <variable name="TITLE" expression="" defaultValue="" alwaysStopAt="true" />
+        <variable name="LABEL" expression="latexFormatAsLabel(TITLE)" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="LATEX" value="true" />
+            <option name="LATEX_MATH" value="false" />
+        </context>
+    </template>
+
+    <template name="\subsecl" value="\subsection{$TITLE$} \label{subsec:$LABEL$}$END$" description="Subsection with label" toReformat="false" toShortenFQNames="true">
+        <variable name="TITLE" expression="" defaultValue="" alwaysStopAt="true" />
+        <variable name="LABEL" expression="latexFormatAsLabel(TITLE)" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="LATEX" value="true" />
+            <option name="LATEX_MATH" value="false" />
+        </context>
+    </template>
+
+    <template name="\subsubsecl" value="\subsubsection{$TITLE$} \label{subsubsec:$LABEL$}$END$" description="Subsubsection with label" toReformat="false" toShortenFQNames="true">
+        <variable name="TITLE" expression="" defaultValue="" alwaysStopAt="true" />
+        <variable name="LABEL" expression="latexFormatAsLabel(TITLE)" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="LATEX" value="true" />
+            <option name="LATEX_MATH" value="false" />
+        </context>
+    </template>
+
     <!--  Mathematics  -->
     <template name="sum" value="\sum_{$FROM$}^{$TO$} $END$" description="Sum with sub- and superscript" toReformat="false" toShortenFQNames="true">
         <variable name="FROM" expression="" defaultValue="" alwaysStopAt="true"/>

--- a/src/nl/hannahsten/texifyidea/templates/macros/LatexFormatAsLabelMacro.kt
+++ b/src/nl/hannahsten/texifyidea/templates/macros/LatexFormatAsLabelMacro.kt
@@ -1,0 +1,16 @@
+package nl.hannahsten.texifyidea.templates.macros
+
+import com.intellij.codeInsight.template.*
+import com.intellij.codeInsight.template.macro.MacroBase
+import nl.hannahsten.texifyidea.templates.LatexContext
+import nl.hannahsten.texifyidea.util.formatAsLabel
+
+class LatexFormatAsLabelMacro : MacroBase("latexFormatAsLabel", "latexFormatAsLabel(String)") {
+
+    override fun calculateResult(params: Array<out Expression>, context: ExpressionContext?, quick: Boolean): Result? {
+        val text = getTextResult(params, context, true) ?: return null
+        return TextResult(text.formatAsLabel())
+    }
+
+    override fun isAcceptableInContext(context: TemplateContextType?) = context is LatexContext
+}


### PR DESCRIPTION
Add live templates for sectioning commands that automatically also inserts a label.

The prefix with `\` is intentional: as to not bother the user with too many live template popups during normal typing (and accidentally activating them).

Demo: For some reason the GIF is just a bit too slow for comfort (it's definitely not due to my typing speed)
![2021-01-15 00-48-38](https://user-images.githubusercontent.com/11046840/104662959-322c1900-56cc-11eb-9533-d305850bbdc0.gif)

- [x] Wiki is [updated](https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Live-templates).