### PR TITLE
Performance improvement for fileset cache creation

### DIFF
--- a/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
@@ -24,7 +24,12 @@ import nl.hannahsten.texifyidea.util.files.*
  *
  * @param defaultExtension Default extension of the command in which this reference is.
  */
-class InputFileReference(element: LatexCommands, val range: TextRange, val extensions: Set<String>, val defaultExtension: String) : PsiReferenceBase<LatexCommands>(element) {
+class InputFileReference(
+        element: LatexCommands,
+        val range: TextRange,
+        val extensions: Set<String>,
+        val defaultExtension: String
+) : PsiReferenceBase<LatexCommands>(element) {
 
     init {
         rangeInElement = range
@@ -39,13 +44,22 @@ class InputFileReference(element: LatexCommands, val range: TextRange, val exten
     }
 
     /**
-     * @param lookForInstalledPackages Whether to look for packages installed elsewhere on the filesystem.
-     * Set to false when it would make the operation too expensive, for example when trying to calculate the fileset of many files.
-     * @param includeGraphicsFiles True if we also need to resolve to graphics files. Doing so is really expensive at the moment (at least until the implementation in LatexGraphicsPathProvider is improved): for projects with 500+ include commands in hundreds of files this can take 10 seconds in total if you call this function for every include command.
-     * However, note that doing only one resolve is not too expensive at all (10 seconds divided by 500 commands/resolves) so this is not a problem when doing only one resolve (if requested by the user).
+     * @param lookForInstalledPackages
+     *              Whether to look for packages installed elsewhere on the filesystem.
+     *              Set to false when it would make the operation too expensive, for example when trying to
+     *              calculate the fileset of many files.
+     * @param includeGraphicsFiles
+     *              True if we also need to resolve to graphics files. Doing so is really expensive at
+     *              the moment (at least until the implementation in LatexGraphicsPathProvider is improved):
+     *              for projects with 500 include commands in hundreds of files this can take 10 seconds in total if
+     *              you call this function for every include command.
+     *              However, note that doing only one resolve is not too expensive at all
+     *              (10 seconds divided by 500 commands/resolves) so this is not a problem when doing only one resolve
+     *              (if requested by the user).
      */
     fun resolve(lookForInstalledPackages: Boolean, givenRootFile: VirtualFile? = null, includeGraphicsFiles: Boolean = true): PsiFile? {
-        // IMPORTANT In this method, do not use any functionality which makes use of the file set, because this function is used to find the file set so that would cause an infinite loop
+        // IMPORTANT In this method, do not use any functionality which makes use of the file set,
+        // because this function is used to find the file set so that would cause an infinite loop
 
         // Get a list of extra paths to search in for the file, absolute or relative (to the directory containing the root file)
         val searchPaths = mutableListOf<String>()
@@ -60,11 +74,11 @@ class InputFileReference(element: LatexCommands, val range: TextRange, val exten
         // Check environment variables
         val runManager = RunManagerImpl.getInstanceImpl(element.project) as RunManager
         val texInputPath = runManager.allConfigurationsList
-            .filterIsInstance<LatexRunConfiguration>()
-            .firstOrNull { it.mainFile == rootFile }
-            ?.environmentVariables
-            ?.envs
-            ?.getOrDefault("TEXINPUTS", null)
+                .filterIsInstance<LatexRunConfiguration>()
+                .firstOrNull { it.mainFile == rootFile }
+                ?.environmentVariables
+                ?.envs
+                ?.getOrDefault("TEXINPUTS", null)
         if (texInputPath != null) {
             val path = texInputPath.trimEnd(':')
             searchPaths.add(path.trimEnd('/'))
@@ -72,9 +86,9 @@ class InputFileReference(element: LatexCommands, val range: TextRange, val exten
             if (path.endsWith("//")) {
                 LocalFileSystem.getInstance().findFileByPath(path.trimEnd('/'))?.let { parent ->
                     searchPaths.addAll(
-                        parent.allChildDirectories()
-                            .filter { it.isDirectory }
-                            .map { it.path }
+                            parent.allChildDirectories()
+                                    .filter { it.isDirectory }
+                                    .map { it.path }
                     )
                 }
             }
@@ -111,9 +125,9 @@ class InputFileReference(element: LatexCommands, val range: TextRange, val exten
         // Look for packages/files elsewhere using the kpsewhich command.
         if (targetFile == null && lookForInstalledPackages) {
             targetFile = element.getFileNameWithExtensions(processedKey)
-                .mapNotNull { LatexPackageLocationCache.getPackageLocation(it, element.project) }
-                .mapNotNull { getExternalFile(it) }
-                .firstOrNull()
+                    .mapNotNull { LatexPackageLocationCache.getPackageLocation(it, element.project) }
+                    .mapNotNull { getExternalFile(it) }
+                    .firstOrNull()
         }
 
         if (targetFile == null) targetFile = searchFileByImportPaths(element)?.virtualFile
@@ -150,7 +164,7 @@ class InputFileReference(element: LatexCommands, val range: TextRange, val exten
         // Recall that \ is a file separator on Windows
         val newText = if (elementNameIsJustFilename) {
             oldNode?.text?.trimStart('\\')?.replaceAfterLast('/', "$newName}", default.trimStart('\\'))
-                ?.let { "\\" + it } ?: default
+                    ?.let { "\\" + it } ?: default
         }
         else {
             default

--- a/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
@@ -11,6 +11,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiReferenceBase
 import nl.hannahsten.texifyidea.completion.pathcompletion.LatexGraphicsPathProvider
+import nl.hannahsten.texifyidea.lang.LatexRegularCommand
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexPsiHelper
 import nl.hannahsten.texifyidea.run.latex.LatexRunConfiguration
@@ -36,6 +37,13 @@ class InputFileReference(element: LatexCommands, val range: TextRange, val exten
 
     override fun resolve(): PsiFile? {
         return resolve(true)
+    }
+
+    /**
+     * Return true if this reference refers to a graphics file, so that this reference may need the \graphicspath command in the file set to resolve correctly.
+     */
+    fun referencesGraphicsFile(): Boolean {
+        return key == LatexRegularCommand.INCLUDEGRAPHICS.commandDisplay
     }
 
     /**

--- a/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
@@ -11,7 +11,6 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiReferenceBase
 import nl.hannahsten.texifyidea.completion.pathcompletion.LatexGraphicsPathProvider
-import nl.hannahsten.texifyidea.lang.LatexRegularCommand
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexPsiHelper
 import nl.hannahsten.texifyidea.run.latex.LatexRunConfiguration
@@ -37,13 +36,6 @@ class InputFileReference(element: LatexCommands, val range: TextRange, val exten
 
     override fun resolve(): PsiFile? {
         return resolve(true)
-    }
-
-    /**
-     * Return true if this reference refers to a graphics file, so that this reference may need the \graphicspath command in the file set to resolve correctly.
-     */
-    fun referencesGraphicsFile(): Boolean {
-        return key == LatexRegularCommand.INCLUDEGRAPHICS.commandDisplay
     }
 
     /**

--- a/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
@@ -49,8 +49,10 @@ class InputFileReference(element: LatexCommands, val range: TextRange, val exten
     /**
      * @param lookForInstalledPackages Whether to look for packages installed elsewhere on the filesystem.
      * Set to false when it would make the operation too expensive, for example when trying to calculate the fileset of many files.
+     * @param includeGraphicsFiles True if we also need to resolve to graphics files. Doing so is really expensive at the moment (at least until the implementation in LatexGraphicsPathProvider is improved): for projects with 500+ include commands in hundreds of files this can take 10 seconds in total if you call this function for every include command.
+     * However, note that doing only one resolve is not too expensive at all (10 seconds divided by 500 commands/resolves) so this is not a problem when doing only one resolve (if requested by the user).
      */
-    fun resolve(lookForInstalledPackages: Boolean, givenRootFile: VirtualFile? = null): PsiFile? {
+    fun resolve(lookForInstalledPackages: Boolean, givenRootFile: VirtualFile? = null, includeGraphicsFiles: Boolean = true): PsiFile? {
         // IMPORTANT In this method, do not use any functionality which makes use of the file set, because this function is used to find the file set so that would cause an infinite loop
 
         // Get a list of extra paths to search in for the file, absolute or relative (to the directory containing the root file)
@@ -103,8 +105,10 @@ class InputFileReference(element: LatexCommands, val range: TextRange, val exten
 
         // Try search paths
         if (targetFile == null) {
-            // Add the graphics paths to the search paths
-            searchPaths.addAll(LatexGraphicsPathProvider().getGraphicsPathsWithoutFileSet(element))
+            if (includeGraphicsFiles) {
+                // Add the graphics paths to the search paths
+                searchPaths.addAll(LatexGraphicsPathProvider().getGraphicsPathsWithoutFileSet(element))
+            }
             for (searchPath in searchPaths) {
                 val path = if (!searchPath.endsWith("/")) "$searchPath/" else searchPath
                 targetFile = rootDirectory.findFile(path + processedKey, extensions)

--- a/src/nl/hannahsten/texifyidea/util/files/FileSet.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/FileSet.kt
@@ -17,7 +17,7 @@ import nl.hannahsten.texifyidea.util.isDefinition
  * values are cached.
  *
  * @receiver The file to find the reference set of.
- * @return All the files that are cross referenced between each other.
+ * @return All the LaTeX and BibTeX files that are cross referenced between each other.
  */
 // Internal because only ReferencedFileSetCache should call this
 internal fun PsiFile.findReferencedFileSetWithoutCache(): Set<PsiFile> {

--- a/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
@@ -98,40 +98,22 @@ fun PsiFile.isUsed(`package`: LatexPackage) = isUsed(`package`.name)
  */
 internal fun PsiFile.referencedFiles(rootFile: VirtualFile): Set<PsiFile> {
     val result = HashSet<PsiFile>()
-    referencedFiles(result, rootFile, mutableSetOf())
+    referencedFiles(result, rootFile)
     return result
 }
 
 /**
- * Assuming that all given references point to graphics files, resolve them.
- */
-private fun resolveGraphicsReferences(references: Set<InputFileReference>) {
-
-}
-
-/**
  * Recursive implementation of [referencedFiles].
- *
- * @param remainingGraphicsReferences References that need to be resolved after completing the fileset for all LaTeX files.
  */
-private fun PsiFile.referencedFiles(files: MutableCollection<PsiFile>, rootFile: VirtualFile, remainingGraphicsReferences: MutableSet<InputFileReference>) {
+private fun PsiFile.referencedFiles(files: MutableCollection<PsiFile>, rootFile: VirtualFile) {
     LatexIncludesIndex.getItems(project, fileSearchScope).forEach command@{ command ->
         command.references.filterIsInstance<InputFileReference>()
-            .mapNotNull {
-                // When resolving graphics references, we need the fileset in order to find the \graphicspath command in that fileset, so we can only resolve them at the end.
-                if (it.referencesGraphicsFile()) {
-                    remainingGraphicsReferences.add(it)
-                    null
-                }
-                else {
-                    it.resolve(false, rootFile, false)
-                }
-            }
+            .mapNotNull { it.resolve(false, rootFile, false) }
             .forEach {
                 // Do not re-add all referenced files if we already did that
                 if (it in files) return@forEach
                 files.add(it)
-                it.referencedFiles(files, rootFile, remainingGraphicsReferences)
+                it.referencedFiles(files, rootFile)
             }
     }
 }

--- a/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
@@ -124,7 +124,7 @@ private fun PsiFile.referencedFiles(files: MutableCollection<PsiFile>, rootFile:
                     null
                 }
                 else {
-                    it.resolve(false, rootFile)
+                    it.resolve(false, rootFile, false)
                 }
             }
             .forEach {

--- a/src/nl/hannahsten/texifyidea/util/files/ReferencedFileSetCache.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/ReferencedFileSetCache.kt
@@ -1,6 +1,9 @@
 package nl.hannahsten.texifyidea.util.files
 
 import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
@@ -106,15 +109,19 @@ class ReferencedFileSetCache {
             // getOrPut cannot be used because it will still execute the defaultValue function even if the key is already in the map (see its javadoc)
             // Wrapping the code with synchronized (myLock) { ... } also didn't work
             // Hence we use a mutex to make sure the expensive findReferencedFileSet function is only executed when needed
-            runBlocking {
-                mutex.withLock {
-                    if (!cache.containsKey(file.virtualFile) || numberOfIncludesChanged) {
-                        runReadAction {
-                            updateCachesFor(file)
+            ProgressManager.getInstance().run(object : Task.Backgroundable(file.project, "Refreshing fileset cache...") {
+                override fun run(indicator: ProgressIndicator) {
+                    runBlocking {
+                        mutex.withLock {
+                            if (!cache.containsKey(file.virtualFile) || numberOfIncludesChanged) {
+                                runReadAction {
+                                    updateCachesFor(file)
+                                }
+                            }
                         }
                     }
                 }
-            }
+            })
             cache[file.virtualFile] ?: setOf(file)
         }
         else {

--- a/test/nl/hannahsten/texifyidea/run/logtab/LatexOutputListenerTest.kt
+++ b/test/nl/hannahsten/texifyidea/run/logtab/LatexOutputListenerTest.kt
@@ -528,7 +528,7 @@ class LatexOutputListenerTest : BasePlatformTestCase() {
             """.trimIndent()
 
         val expectedMessages = setOf(
-            // todo possible improvement: detecting line 4
+            // Possible improvement: detecting line 4
             LatexLogMessage("unexpected symbol near '3'.", "./main.tex", -1, ERROR)
         )
 


### PR DESCRIPTION
#### Summary of additions and changes

* Previously, refreshing fileset cache was taking about 10 seconds for my test project (460 include commands in hundreds of files), but I found out 9 seconds of that were taken by the code which resolves graphics files (because of finding `\graphicspath` commands in the file set), however I don't think we use graphics files being in the file set anywhere, so I disabled it for file set resolves. 
