### PR TITLE
Support lstinputlisting label

### DIFF
--- a/gen/nl/hannahsten/texifyidea/parser/LatexParser.java
+++ b/gen/nl/hannahsten/texifyidea/parser/LatexParser.java
@@ -1,16 +1,17 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.parser;
 
+import com.intellij.lang.ASTNode;
+import com.intellij.lang.LightPsiParser;
 import com.intellij.lang.PsiBuilder;
 import com.intellij.lang.PsiBuilder.Marker;
-import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
-import static nl.hannahsten.texifyidea.parser.LatexParserUtil.*;
-import com.intellij.psi.tree.IElementType;
-import com.intellij.lang.ASTNode;
-import com.intellij.psi.tree.TokenSet;
 import com.intellij.lang.PsiParser;
-import com.intellij.lang.LightPsiParser;
-import static com.intellij.lang.WhitespacesBinders.*;
+import com.intellij.psi.tree.IElementType;
+
+import static com.intellij.lang.WhitespacesBinders.GREEDY_LEFT_BINDER;
+import static com.intellij.lang.WhitespacesBinders.GREEDY_RIGHT_BINDER;
+import static nl.hannahsten.texifyidea.parser.LatexParserUtil.*;
+import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
 
 @SuppressWarnings({"SimplifiableIfStatement", "UnusedAssignment"})
 public class LatexParser implements PsiParser, LightPsiParser {
@@ -306,7 +307,7 @@ public class LatexParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // keyval_key (EQUALS keyval_value)?
+  // keyval_key (EQUALS keyval_value?)?
   public static boolean keyval_pair(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "keyval_pair")) return false;
     boolean r;
@@ -317,22 +318,29 @@ public class LatexParser implements PsiParser, LightPsiParser {
     return r;
   }
 
-  // (EQUALS keyval_value)?
+  // (EQUALS keyval_value?)?
   private static boolean keyval_pair_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "keyval_pair_1")) return false;
     keyval_pair_1_0(b, l + 1);
     return true;
   }
 
-  // EQUALS keyval_value
+  // EQUALS keyval_value?
   private static boolean keyval_pair_1_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "keyval_pair_1_0")) return false;
     boolean r;
     Marker m = enter_section_(b);
     r = consumeToken(b, EQUALS);
-    r = r && keyval_value(b, l + 1);
+    r = r && keyval_pair_1_0_1(b, l + 1);
     exit_section_(b, m, null, r);
     return r;
+  }
+
+  // keyval_value?
+  private static boolean keyval_pair_1_0_1(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "keyval_pair_1_0_1")) return false;
+    keyval_value(b, l + 1);
+    return true;
   }
 
   /* ********************************************************** */

--- a/gen/nl/hannahsten/texifyidea/parser/LatexParser.java
+++ b/gen/nl/hannahsten/texifyidea/parser/LatexParser.java
@@ -472,7 +472,7 @@ public class LatexParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // OPEN_BRACKET ( (keyval_pair  (COMMA keyval_pair)*) | optional_param_content*) CLOSE_BRACKET
+  // OPEN_BRACKET ( (keyval_pair  (COMMA keyval_pair)* COMMA?) | optional_param_content*) CLOSE_BRACKET
   public static boolean optional_param(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "optional_param")) return false;
     if (!nextTokenIs(b, OPEN_BRACKET)) return false;
@@ -485,7 +485,7 @@ public class LatexParser implements PsiParser, LightPsiParser {
     return r;
   }
 
-  // (keyval_pair  (COMMA keyval_pair)*) | optional_param_content*
+  // (keyval_pair  (COMMA keyval_pair)* COMMA?) | optional_param_content*
   private static boolean optional_param_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "optional_param_1")) return false;
     boolean r;
@@ -496,13 +496,14 @@ public class LatexParser implements PsiParser, LightPsiParser {
     return r;
   }
 
-  // keyval_pair  (COMMA keyval_pair)*
+  // keyval_pair  (COMMA keyval_pair)* COMMA?
   private static boolean optional_param_1_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "optional_param_1_0")) return false;
     boolean r;
     Marker m = enter_section_(b);
     r = keyval_pair(b, l + 1);
     r = r && optional_param_1_0_1(b, l + 1);
+    r = r && optional_param_1_0_2(b, l + 1);
     exit_section_(b, m, null, r);
     return r;
   }
@@ -527,6 +528,13 @@ public class LatexParser implements PsiParser, LightPsiParser {
     r = r && keyval_pair(b, l + 1);
     exit_section_(b, m, null, r);
     return r;
+  }
+
+  // COMMA?
+  private static boolean optional_param_1_0_2(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "optional_param_1_0_2")) return false;
+    consumeToken(b, COMMA);
+    return true;
   }
 
   // optional_param_content*

--- a/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
+++ b/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
@@ -101,7 +101,7 @@ parameter ::= optional_param | required_param | picture_param {
 // will be seen as simply an open bracket, but '[x]' at the same location will
 // be parsed as optional parameter.
 // https://stackoverflow.com/a/48709143/6629569
-optional_param ::= OPEN_BRACKET ( (keyval_pair  (COMMA keyval_pair)*) | optional_param_content*) CLOSE_BRACKET { pin=3 }
+optional_param ::= OPEN_BRACKET ( (keyval_pair  (COMMA keyval_pair)* COMMA?) | optional_param_content*) CLOSE_BRACKET { pin=3 }
 
 required_param ::= OPEN_BRACE required_param_content* CLOSE_BRACE { pin=1 }
 

--- a/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
+++ b/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
@@ -114,7 +114,7 @@ optional_param_content ::= raw_text | magic_comment | comment | environment | ps
 required_param_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | group | OPEN_PAREN | CLOSE_PAREN | parameter_text | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET | BACKSLASH
 picture_param_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | parameter_text | BACKSLASH | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET
 
-keyval_pair ::= keyval_key (EQUALS keyval_value)?
+keyval_pair ::= keyval_key (EQUALS keyval_value?)?
 keyval_key ::= keyval_content+ {
     methods=[toString]
 }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexDuplicateLabelInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexDuplicateLabelInspection.kt
@@ -4,17 +4,17 @@ import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.refactoring.suggested.startOffset
 import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.lang.CommandManager
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.psi.LatexEnvironment
 import nl.hannahsten.texifyidea.psi.LatexParameter
-import nl.hannahsten.texifyidea.util.findBibitemCommands
-import nl.hannahsten.texifyidea.util.findLabelingCommandsInFileSetAsSequence
-import nl.hannahsten.texifyidea.util.parentOfType
-import nl.hannahsten.texifyidea.util.requiredParameter
+import nl.hannahsten.texifyidea.util.*
 import java.lang.Integer.max
 import java.util.*
 
@@ -36,53 +36,58 @@ open class LatexDuplicateLabelInspection : TexifyInspectionBase() {
      */
     override fun inspectFile(file: PsiFile, manager: InspectionManager, isOntheFly: Boolean): List<ProblemDescriptor> {
 
-        val duplicateLabels = getProblemDescriptors(file.findLabelingCommandsInFileSetAsSequence(), isOntheFly, manager, file) {
-            val name = this.name ?: return@getProblemDescriptors null
-            val position = CommandManager.labelAliasesInfo.getOrDefault(name, null)?.positions?.firstOrNull() ?: return@getProblemDescriptors null
-            this.requiredParameter(position) ?: return@getProblemDescriptors null
-        }
+        val duplicateLabels =
+            getProblemDescriptors(file.findLatexLabelPsiElementsInFileSetAsSequence(), isOntheFly, manager, file) {
+                when (this) {
+                    is LatexCommands -> {
+                        val name = this.name ?: return@getProblemDescriptors null
+                        if (Magic.Command.labelAsParameter.contains(this.name)) {
+                            return@getProblemDescriptors getParameterLabelDescriptor(this)
+                        }
+                        else {
+                            val position =
+                                CommandManager.labelAliasesInfo.getOrDefault(name, null)?.positions?.firstOrNull()
+                                    ?: return@getProblemDescriptors null
+                            return@getProblemDescriptors getCommandLabelDescriptor(this, position)
+                        }
+                    }
+                    is LatexEnvironment -> {
+                        if (Magic.Environment.labelAsParameter.contains(this.environmentName)) {
+                            return@getProblemDescriptors getParameterLabelDescriptor(this)
+                        }
+
+                        return@getProblemDescriptors null
+                    }
+                    else -> return@getProblemDescriptors null
+                }
+            }
 
         val duplicateBibitems = getProblemDescriptors(file.findBibitemCommands(), isOntheFly, manager, file) {
-            this.requiredParameter(0) ?: return@getProblemDescriptors null
+            getCommandLabelDescriptor(this as LatexCommands, 0)
         }
 
         return duplicateLabels + duplicateBibitems
     }
 
     /**
-     * @param getLabel Get the label string given the command in which it is defined.
+     * Creates a LabelDescriptor for an environment that defines a label with an optional parameter
      */
-    private fun getProblemDescriptors(commands: Sequence<LatexCommands>, isOntheFly: Boolean, manager: InspectionManager, file: PsiFile, getLabel: LatexCommands.() -> String?): List<ProblemDescriptor> {
+    private fun getParameterLabelDescriptor(env: LatexEnvironment): LabelDescriptor? {
+        val label =
+            env.beginCommand.optionalParameterMap.entries.firstOrNull() { e -> e.key.toString() == "label" }?.value
+                ?: return null
+        val labelString = label.toString()
+        return LabelDescriptor(env, labelString, TextRange.from(label.startOffset - env.startOffset, label.textLength))
+    }
 
-        // Map labels to commands defining the label
-        val allLabels = hashMapOf<String, MutableSet<LatexCommands>>()
-
-        val result = mutableListOf<ProblemDescriptor>()
-
-        // Treat LaTeX and BibTeX separately because only the first parameter of \bibitem commands counts
-        // First find all duplicate labels
-        commands.forEach { command ->
-            // When the label is defined in \newcommand ignore it, because there could be more than one with #1 as parameter
-            val parent = command.parentOfType(LatexCommands::class)
-            if (parent != null && parent.name == "\\newcommand") {
-                return@forEach
-            }
-
-            allLabels.getOrPut(command.getLabel() ?: return@forEach) { mutableSetOf() }.add(command)
-        }
-
-        val duplicates = allLabels.filter { it.value.size > 1 }
-
-        for ((label, labelCommands) in duplicates) {
-            // We can only mark labels in the current file
-            val currentFileDuplicates = labelCommands.filter { command -> command.containingFile == file }
-
-            for (command in currentFileDuplicates) {
-                result.add(createProblemDescriptor(command, label, isOntheFly, manager))
-            }
-        }
-
-        return result
+    /**
+     * Creates a LabelDescriptor for a command that defines a label with an optional parameter
+     */
+    private fun getParameterLabelDescriptor(cmd: LatexCommands): LabelDescriptor? {
+        val label =
+            cmd.optionalParameterMap.entries.firstOrNull() { e -> e.key.toString() == "label" }?.value ?: return null
+        val labelString = label.toString()
+        return LabelDescriptor(cmd, labelString, TextRange.from(label.startOffset - cmd.startOffset, label.textLength))
     }
 
     /**
@@ -98,17 +103,67 @@ open class LatexDuplicateLabelInspection : TexifyInspectionBase() {
     }
 
     /**
+     * Creates a LabelDescriptor for a command that defines a label with a required parameter at the specified position
+     */
+    private fun getCommandLabelDescriptor(cmd: LatexCommands, position: Int): LabelDescriptor? {
+        val label = cmd.requiredParameter(position) ?: return null
+        val offset = cmd.commandToken.textLength + skippedParametersLength(cmd.parameterList, label) + 1
+        return LabelDescriptor(cmd, label, TextRange.from(offset, label.length))
+    }
+
+    data class LabelDescriptor(val element: PsiElement, val label: String, val textRange: TextRange)
+
+    /**
+     * @param getLabelDescriptor Get the label string given the command in which it is defined.
+     */
+    private fun getProblemDescriptors(
+        commands: Sequence<PsiElement>, isOntheFly: Boolean, manager: InspectionManager, file: PsiFile,
+        getLabelDescriptor: PsiElement.() -> LabelDescriptor?
+    ): List<ProblemDescriptor> {
+
+        // Map labels to commands defining the label
+        val labelDescriptors = mutableListOf<LabelDescriptor>()
+
+        val result = mutableListOf<ProblemDescriptor>()
+
+        // Treat LaTeX and BibTeX separately because only the first parameter of \bibitem commands counts
+        // First find all duplicate labels
+        commands.forEach { command ->
+            // When the label is defined in \newcommand ignore it, because there could be more than one with #1 as parameter
+            val parent = command.parentOfType(LatexCommands::class)
+            if (parent != null && parent.name == "\\newcommand") {
+                return@forEach
+            }
+
+            val labelDescriptor = command.getLabelDescriptor() ?: return@forEach
+            labelDescriptors.add(labelDescriptor)
+        }
+
+        val duplicates = labelDescriptors.groupBy { d -> d.label }.filter { g -> g.value.size > 1 }
+
+        for (group in duplicates) {
+            // We can only mark labels in the current file
+            val currentFileDuplicates = group.value.filter { descriptor -> descriptor.element.containingFile == file }
+
+            for (labelDescriptor in currentFileDuplicates) {
+                result.add(createProblemDescriptor(labelDescriptor, isOntheFly, manager))
+            }
+        }
+
+        return result
+    }
+
+    /**
      * make the mapping from command etc. to ProblemDescriptor
      */
-    private fun createProblemDescriptor(cmd: LatexCommands, label: String, isOntheFly: Boolean, manager: InspectionManager):
-        ProblemDescriptor {
-            val offset = cmd.commandToken.textLength + skippedParametersLength(cmd.parameterList, label) + 1
-            return manager.createProblemDescriptor(
-                cmd,
-                TextRange.from(offset, label.length),
-                "Duplicate label '$label'",
-                ProblemHighlightType.GENERIC_ERROR,
-                isOntheFly
-            )
-        }
+    private fun createProblemDescriptor(desc: LabelDescriptor, isOntheFly: Boolean, manager: InspectionManager):
+            ProblemDescriptor {
+        return manager.createProblemDescriptor(
+            desc.element,
+            desc.textRange,
+            "Duplicate label '${desc.label}'",
+            ProblemHighlightType.GENERIC_ERROR,
+            isOntheFly
+        )
+    }
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LatexDuplicateLabelInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LatexDuplicateLabelInspectionTest.kt
@@ -40,4 +40,40 @@ class LatexDuplicateLabelInspectionTest : TexifyInspectionTestBase(LatexDuplicat
         CommandManager.updateAliases(setOf("\\label"), project)
         myFixture.checkHighlighting()
     }
+
+    fun testDuplicateLabelWithEnvironmentAndCommand() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \label{<error descr="Duplicate label 'some-label'">some-label</error>}
+            \begin{lstlisting}[label=<error descr="Duplicate label 'some-label'">{some-label}</error>]
+            \end{lstlisting}
+            """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun testDuplicateLabelWithCommandAndCommand() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \label{<error descr="Duplicate label 'some-label'">some-label</error>}
+            \lstinputlisting[label=<error descr="Duplicate label 'some-label'">some-label</error>]{some/file}
+            """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun testDuplicateLabelBetweenEnvironments() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \begin{lstlisting}[label=<error descr="Duplicate label 'some-label'">some-label</error>]
+            \end{lstlisting}
+            \begin{lstlisting}[label=<error descr="Duplicate label 'some-label'">some-label</error>]
+            \end{lstlisting}                        
+            """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
 }

--- a/test/nl/hannahsten/texifyidea/psi/LatexCommandsImplUtilTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/LatexCommandsImplUtilTest.kt
@@ -191,4 +191,30 @@ class LatexCommandsImplUtilTest : BasePlatformTestCase() {
         assertEquals("", map["param2"])
         assertEquals("value", map["param3"])
     }
+
+    @Test
+    fun `test parameters ending with comma`() {
+        // given
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \begin{document}
+                \lstinputlisting[param1=value1,param2=value2,]{some/file}
+            \end{document}
+            """.trimIndent()
+        )
+
+        // when
+        val parameters = PsiDocumentManager.getInstance(myFixture.project)
+            .getPsiFile(myFixture.editor.document)!!
+            .children
+            .first()
+            .firstChildOfType(LatexCommands::class)!!
+            .parameterList
+
+        val map = getOptionalParameterMap(parameters).toStringMap()
+        assertSize(2, map.keys)
+        assertEquals("value1", map["param1"])
+        assertEquals("value2", map["param2"])
+    }
 }

--- a/test/nl/hannahsten/texifyidea/psi/LatexCommandsImplUtilTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/LatexCommandsImplUtilTest.kt
@@ -164,4 +164,31 @@ class LatexCommandsImplUtilTest : BasePlatformTestCase() {
         assertSize(1, map.keys)
         assertEquals("\\textwidth", map["linewidth"])
     }
+
+    @Test
+    fun `test empty value parameters map`() {
+        // given
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \begin{document}
+                \lstinputlisting[param1=,param2,param3=value]{some/file}
+            \end{document}
+            """.trimIndent()
+        )
+
+        // when
+        val parameters = PsiDocumentManager.getInstance(myFixture.project)
+            .getPsiFile(myFixture.editor.document)!!
+            .children
+            .first()
+            .firstChildOfType(LatexCommands::class)!!
+            .parameterList
+
+        val map = getOptionalParameterMap(parameters).toStringMap()
+        assertSize(3, map.keys)
+        assertEquals("", map["param1"])
+        assertEquals("", map["param2"])
+        assertEquals("value", map["param3"])
+    }
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Addresses additions suggested in #1698

#### Summary of additions and changes

* Allow empty keyval values (e.g., `\lstinputlisting[caption=,label=somelabel]`)
* Correctly parse trailing comma in optional parameters (e.g., `\lstinputlisting[label=somelabel,]`)
* Support labels in optional parameters in duplicate label inspection

#### How to test this pull request

Observe the inspection error in 
```latex
\begin{document}
\lstinputlisting[label=somelabel]{some/file}
\begin{lstlisting}[label=somelabel]

\end{lstlisting}
\end{document}
```

No more errors in 
```latex
\begin{document}
\lstinputlisting[caption=,label=somelabel]{some/file}
\lstinputlisting[label=someotherlabel,]{some/file}
\end{document}
```

See also the included test cases.

#### Wiki

The PR only fixes issues / extends existing features.