### PR TITLE
Fixed \begin AC inserting extra Package{}

### DIFF
--- a/src/nl/hannahsten/texifyidea/completion/LatexCommandProvider.kt
+++ b/src/nl/hannahsten/texifyidea/completion/LatexCommandProvider.kt
@@ -66,7 +66,8 @@ class LatexCommandProvider internal constructor(private val mode: LatexMode) :
             // Add spaces to the lookup text to distinguish different versions of commands within the same package (optional parameters).
             // Add the package name to the lookup text so we can distinguish between the same commands that come from different packages.
             // This 'extra' text will be automatically inserted by intellij and is removed by the LatexCommandArgumentInsertHandler after insertion.
-            LookupElementBuilder.create(cmd, cmd.command + List(index) { " " }.joinToString("") + " ${cmd.dependency}")
+            val default = cmd.dependency.isDefault
+            LookupElementBuilder.create(cmd, cmd.command + " ".repeat(index + default.not().int) + cmd.dependency.displayString)
                 .withPresentableText(cmd.commandWithSlash)
                 .bold()
                 .withTailText(args.joinToString("") + " " + packageName(cmd), true)

--- a/src/nl/hannahsten/texifyidea/lang/LatexPackage.kt
+++ b/src/nl/hannahsten/texifyidea/lang/LatexPackage.kt
@@ -86,6 +86,11 @@ open class LatexPackage @JvmOverloads constructor(
         get() = equals(DEFAULT)
 
     /**
+     * The name of the package, or the empty string when this is the default package.
+     */
+    val displayString = if (isDefault) "" else name
+
+    /**
      * Creates a new package object with the same name and with the given parameters.
      */
     fun with(vararg parameters: String) = LatexPackage(name, *parameters)

--- a/src/nl/hannahsten/texifyidea/util/General.kt
+++ b/src/nl/hannahsten/texifyidea/util/General.kt
@@ -5,6 +5,12 @@ import com.intellij.openapi.util.TextRange
 import java.util.regex.Pattern
 
 /**
+ * Returns `1` when `true`, returns `0` when `false`.
+ */
+val Boolean.int: Int
+    get() = if (this) 1 else 0
+
+/**
  * Creates a pair of two objects, analogous to [to].
  */
 infix fun <T1, T2> T1.and(other: T2) = Pair(this, other)

--- a/src/nl/hannahsten/texifyidea/util/Strings.kt
+++ b/src/nl/hannahsten/texifyidea/util/Strings.kt
@@ -34,7 +34,7 @@ fun String.camelCase(): String {
  */
 fun String.repeat(count: Int) = buildString(count * this.length) {
     for (i in 0 until count) {
-        append(this)
+        append(this@repeat)
     }
 }
 


### PR DESCRIPTION
[TEX-96](https://texify-idea.myjetbrains.com/youtrack/issue/TEX-96). @`master` bde9600650292d1896862c2a218ee3ab17a3c91f

Not an issue on `b0.7.3`.

See video. Autocompletion of `\begin` results in:
```latex
    \begin Package{}{<caret>}
    \end{}
```

#### Summary of additions and changes

* Fixed \begin AC inserting extra Package{}
* Fixed GeneralKt String.repeat().

#### Demo

What went wrong:

https://user-images.githubusercontent.com/17410729/106025044-aef5c480-60c8-11eb-8082-279f5565e635.mp4

