### PR TITLE
Add commands defined with \def to autocompletion

### DIFF
--- a/src/nl/hannahsten/texifyidea/completion/LatexCommandProvider.kt
+++ b/src/nl/hannahsten/texifyidea/completion/LatexCommandProvider.kt
@@ -85,7 +85,14 @@ class LatexCommandProvider internal constructor(private val mode: LatexMode) :
                         // Avoid duplicates of commands defined in LaTeX base, because they are often very similar commands defined in different document classes so it makes not
                         // much sense at the moment to have them separately in the autocompletion.
                         // Effectively this results in just taking the first one we found
-                        .filter { newBuilder -> if ( cmd.dependency.isDefault) commands.none {it.lookupString == newBuilder.lookupString } else true }
+                        .filter { newBuilder ->
+                            if (cmd.dependency.isDefault) {
+                                commands.none { it.lookupString == newBuilder.lookupString }
+                            }
+                            else {
+                                true
+                            }
+                        }
                         .forEach { commands.add(it) }
                 }
             }

--- a/src/nl/hannahsten/texifyidea/completion/LatexCommandProvider.kt
+++ b/src/nl/hannahsten/texifyidea/completion/LatexCommandProvider.kt
@@ -76,15 +76,20 @@ class LatexCommandProvider internal constructor(private val mode: LatexMode) :
     }
 
     private fun addIndexedCommands(result: CompletionResultSet, parameters: CompletionParameters) {
-        result.addAllElements(
-            FileBasedIndex.getInstance().getAllKeys(LatexExternalCommandIndex.id, parameters.editor.project ?: return)
-                .flatMap { cmdWithSlash ->
-                    val cmdWithoutSlash = cmdWithSlash.substring(1)
-                    LatexCommand.lookupInIndex(cmdWithoutSlash, parameters.editor.project ?: return).flatMap { cmd ->
-                        createCommandLookupElements(cmd)
-                    }
+        val commands = mutableSetOf<LookupElementBuilder>()
+        FileBasedIndex.getInstance().getAllKeys(LatexExternalCommandIndex.id, parameters.editor.project ?: return)
+            .forEach { cmdWithSlash ->
+                val cmdWithoutSlash = cmdWithSlash.substring(1)
+                LatexCommand.lookupInIndex(cmdWithoutSlash, parameters.editor.project ?: return).forEach { cmd ->
+                    createCommandLookupElements(cmd)
+                        // Avoid duplicates of commands defined in LaTeX base, because they are often very similar commands defined in different document classes so it makes not
+                        // much sense at the moment to have them separately in the autocompletion.
+                        // Effectively this results in just taking the first one we found
+                        .filter { newBuilder -> if ( cmd.dependency.isDefault) commands.none {it.lookupString == newBuilder.lookupString } else true }
+                        .forEach { commands.add(it) }
                 }
-        )
+            }
+        result.addAllElements(commands)
     }
 
     private fun addNormalCommands(result: CompletionResultSet, project: Project) {
@@ -93,7 +98,9 @@ class LatexCommandProvider internal constructor(private val mode: LatexMode) :
         result.addAllElements(
             LatexRegularCommand.values().flatMap { cmd ->
                 /** True if there is a package for which we already have the [cmd] command indexed.  */
-                fun alreadyIndexed() = FileBasedIndex.getInstance().getContainingFiles(LatexExternalCommandIndex.id, cmd.commandWithSlash, GlobalSearchScope.everythingScope(project)).map { LatexPackage.create(it) }.contains(cmd.dependency)
+                fun alreadyIndexed() =
+                    FileBasedIndex.getInstance().getContainingFiles(LatexExternalCommandIndex.id, cmd.commandWithSlash, GlobalSearchScope.everythingScope(project))
+                        .map { LatexPackage.create(it) }.contains(cmd.dependency)
 
                 // Avoid adding duplicates
                 // Prefer the indexed command (if it really is the same one), as that one has documentation

--- a/src/nl/hannahsten/texifyidea/index/file/LatexExternalCommandDataIndexer.kt
+++ b/src/nl/hannahsten/texifyidea/index/file/LatexExternalCommandDataIndexer.kt
@@ -22,11 +22,12 @@ class LatexExternalCommandDataIndexer : DataIndexer<String, String, FileContent>
 
         /**
          * Documentation given by \DescribeMacro.
+         * Supports a definition with or without braces.
          */
         val describeMacroRegex =
             """(?=\\DescribeMacro(?:(?<key>\\[a-zA-Z_:]+\*?)|\{(?<key1>\\[a-zA-Z_:]+\*?)})\s*(?<value>[\s\S]{0,500}))""".toRegex()
 
-        val directCommandDefinitionRegex = """\\(DeclareRobustCommand|newcommand)\*?\{(?<key>\\[a-zA-Z_:]+\*?)}(?<value>)""".toRegex()
+        val directCommandDefinitionRegex = """\\(DeclareRobustCommand|newcommand|def)\*?(?:(?<key>\\[a-zA-Z_:]+\*?)|\{(?<key1>\\[a-zA-Z_:]+\*?)})(?<value>)""".toRegex()
 
         /**
          * See sourc2e.pdf:

--- a/src/nl/hannahsten/texifyidea/index/file/LatexExternalCommandDataIndexer.kt
+++ b/src/nl/hannahsten/texifyidea/index/file/LatexExternalCommandDataIndexer.kt
@@ -27,7 +27,8 @@ class LatexExternalCommandDataIndexer : DataIndexer<String, String, FileContent>
         val describeMacroRegex =
             """(?=\\DescribeMacro(?:(?<key>\\[a-zA-Z_:]+\*?)|\{(?<key1>\\[a-zA-Z_:]+\*?)})\s*(?<value>[\s\S]{0,500}))""".toRegex()
 
-        val directCommandDefinitionRegex = """\\(DeclareRobustCommand|newcommand|def)\*?(?:(?<key>\\[a-zA-Z_:]+\*?)|\{(?<key1>\\[a-zA-Z_:]+\*?)})(?<value>)""".toRegex()
+        // Avoid matching commands with @ in it by using an atomic group
+        val directCommandDefinitionRegex = """\\(DeclareRobustCommand|newcommand|def)\*?(?:(?<key>(?>\\[a-zA-Z_:]+\*?)(?!@))|\{(?<key1>\\[a-zA-Z_:]+\*?)})(?<value>)""".toRegex()
 
         /**
          * See sourc2e.pdf:

--- a/src/nl/hannahsten/texifyidea/index/file/LatexExternalCommandIndex.kt
+++ b/src/nl/hannahsten/texifyidea/index/file/LatexExternalCommandIndex.kt
@@ -43,7 +43,7 @@ class LatexExternalCommandIndex : FileBasedIndexExtension<String, String>() {
         return EnumeratorStringDescriptor.INSTANCE
     }
 
-    override fun getVersion() = 0
+    override fun getVersion() = 1
 
     override fun getInputFilter(): FileBasedIndex.InputFilter {
         return FileBasedIndex.InputFilter {

--- a/test/nl/hannahsten/texifyidea/index/file/LatexExternalCommandDataIndexerTest.kt
+++ b/test/nl/hannahsten/texifyidea/index/file/LatexExternalCommandDataIndexerTest.kt
@@ -227,6 +227,19 @@ class LatexExternalCommandDataIndexerTest : BasePlatformTestCase() {
         assertEquals("", map["\\textless"])
     }
 
+    fun testDef() {
+        val text = """
+            \blank@linefalse \def\par{\ifblank@line
+                             \leavevmode\fi
+                             \blank@linetrue\@@par
+                             \penalty\interlinepenalty}
+        """.trimIndent()
+        val file = myFixture.configureByText("doc.dtx", text)
+        val map = LatexExternalCommandDataIndexer().map(MockContent(file))
+        assertEquals(1, map.size)
+        assertEquals("", map["\\par"])
+    }
+
     class MockContent(val file: PsiFile) : FileContent {
 
         override fun <T : Any?> getUserData(key: Key<T>): T? { return null }


### PR DESCRIPTION

<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1760

#### Summary of additions and changes

* Add commands defined in packages with \def to autocompletion
* When the same command, both from LaTeX base, is already added to autocompletion, don't add it to avoid duplicates (you would get like 8 \par commands in the autocompletion otherwise)

I kept the commands from other packages:
![image](https://user-images.githubusercontent.com/15669080/106031212-4fe77e00-60cf-11eb-9ca3-96cdc1095a3f.png)
