### PR TITLE
Disable smart quotes and default live templates in verbatim.

### DIFF
--- a/resources/liveTemplates/LaTeX.xml
+++ b/resources/liveTemplates/LaTeX.xml
@@ -78,6 +78,23 @@
         </context>
     </template>
 
+    <template name="enq" value="\enquote{$QUOTE$} $END$" description="Enquote" toReformat="false" toShortenFQNames="true">
+        <variable name="QUOTE" expression="" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="LATEX" value="true"/>
+            <option name="LATEX_MATH" value="false"/>
+        </context>
+    </template>
+
+    <template name="fc" value="\footcite[$PAGE$]{$SOURCE$}$END$" description="footcite" toReformat="false" toShortenFQNames="true">
+        <variable name="PAGE" expression="" defaultValue="" alwaysStopAt="true" />
+        <variable name="SOURCE" expression="" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="LATEX" value="true"/>
+            <option name="LATEX_MATH" value="false"/>
+        </context>
+    </template>
+
     <!--  Mathematics  -->
     <template name="sum" value="\sum_{$FROM$}^{$TO$} $END$" description="Sum with sub- and superscript" toReformat="false" toShortenFQNames="true">
         <variable name="FROM" expression="" defaultValue="" alwaysStopAt="true"/>
@@ -92,23 +109,6 @@
         <variable name="TO" expression="" defaultValue="" alwaysStopAt="true"/>
         <context>
             <option name="LATEX_MATH" value="true"/>
-        </context>
-    </template>
-    
-    <template name="enq" value="\enquote{$QUOTE$} $END$" description="Enquote" toReformat="false" toShortenFQNames="true">
-        <variable name="QUOTE" expression="" defaultValue="" alwaysStopAt="true" />
-        <context>
-            <option name="LATEX" value="true"/>
-            <option name="LATEX_MATH" value="false"/>
-        </context>
-    </template>
-    
-    <template name="fc" value="\footcite[$PAGE$]{$SOURCE$}$END$" description="footcite" toReformat="false" toShortenFQNames="true">
-        <variable name="PAGE" expression="" defaultValue="" alwaysStopAt="true" />
-        <variable name="SOURCE" expression="" defaultValue="" alwaysStopAt="true" />
-        <context>
-            <option name="LATEX" value="true"/>
-            <option name="LATEX_MATH" value="false"/>
         </context>
     </template>
 </templateSet>

--- a/src/nl/hannahsten/texifyidea/editor/LatexQuoteInsertHandler.kt
+++ b/src/nl/hannahsten/texifyidea/editor/LatexQuoteInsertHandler.kt
@@ -11,6 +11,7 @@ import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
 import nl.hannahsten.texifyidea.settings.TexifySettings
 import nl.hannahsten.texifyidea.util.getOpenAndCloseQuotes
+import nl.hannahsten.texifyidea.util.inVerbatim
 import nl.hannahsten.texifyidea.util.insertUsepackage
 import kotlin.math.min
 
@@ -22,7 +23,6 @@ import kotlin.math.min
 open class LatexQuoteInsertHandler : TypedHandlerDelegate() {
 
     override fun charTyped(char: Char, project: Project, editor: Editor, file: PsiFile): Result {
-
         // Only do this for latex files and if the option is enabled
         if (file.fileType != LatexFileType || TexifySettings.getInstance().automaticQuoteReplacement == TexifySettings.QuoteReplacement.NONE) {
             return super.charTyped(char, project, editor, file)
@@ -31,6 +31,10 @@ open class LatexQuoteInsertHandler : TypedHandlerDelegate() {
         val document = editor.document
         val caret = editor.caretModel
         val offset = caret.offset
+
+        // Disable in verbatim context.
+        val psi = file.findElementAt(offset)
+        if (psi?.inVerbatim() == true) return super.charTyped(char, project, editor, file)
 
         // Only do smart things with double and single quotes
         if (char != '"' && char != '\'') {

--- a/src/nl/hannahsten/texifyidea/templates/LatexContext.kt
+++ b/src/nl/hannahsten/texifyidea/templates/LatexContext.kt
@@ -5,6 +5,7 @@ import com.intellij.codeInsight.template.TemplateActionContext
 import com.intellij.codeInsight.template.TemplateContextType
 import nl.hannahsten.texifyidea.file.LatexFile
 import nl.hannahsten.texifyidea.util.inMathContext
+import nl.hannahsten.texifyidea.util.inVerbatim
 
 /**
  * Defines a LaTeX template context, used to define in which context
@@ -18,10 +19,13 @@ open class LatexContext(
     baseContextType: Class<out TemplateContextType>
 ) : TemplateContextType(id, name, baseContextType) {
 
-    override fun isInContext(context: TemplateActionContext): Boolean =
-        context.file is LatexFile
+    override fun isInContext(context: TemplateActionContext): Boolean = context.file is LatexFile
 
-    class Generic : LatexContext("LATEX", "LaTeX", EverywhereContextType::class.java)
+    class Generic : LatexContext("LATEX", "LaTeX", EverywhereContextType::class.java) {
+
+        override fun isInContext(context: TemplateActionContext): Boolean =
+            context.file is LatexFile && context.file.findElementAt(context.startOffset)?.inVerbatim() == false
+    }
 
     open class LatexMathContext : LatexContext("LATEX_MATH", "Math", Generic::class.java) {
 

--- a/src/nl/hannahsten/texifyidea/util/Psi.kt
+++ b/src/nl/hannahsten/texifyidea/util/Psi.kt
@@ -10,6 +10,7 @@ import nl.hannahsten.texifyidea.lang.DefaultEnvironment
 import nl.hannahsten.texifyidea.lang.Environment
 import nl.hannahsten.texifyidea.lang.magic.TextBasedMagicCommentParser
 import nl.hannahsten.texifyidea.psi.*
+import nl.hannahsten.texifyidea.util.magic.EnvironmentMagic
 import kotlin.reflect.KClass
 
 /**
@@ -157,6 +158,11 @@ fun PsiElement.inComment() = inDirectEnvironmentContext(Environment.Context.COMM
     is PsiComment -> true
     else -> this is LeafPsiElement && elementType == LatexTypes.COMMAND_TOKEN
 }
+
+/**
+ * Checks if the element is inside a verbatim context.
+ */
+fun PsiElement.inVerbatim() = inDirectEnvironment(EnvironmentMagic.verbatim)
 
 /**
  * Finds the previous sibling of an element but skips over whitespace.

--- a/src/nl/hannahsten/texifyidea/util/magic/EnvironmentMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/EnvironmentMagic.kt
@@ -34,7 +34,9 @@ object EnvironmentMagic {
 
     // Note: used in the lexer
     @JvmField
-    val verbatim = hashSetOf(VERBATIM.env, VERBATIM_CAPITAL.env, LISTINGS.env, "plantuml", LUACODE.env, LUACODE_STAR.env, "sagesilent", "sageblock", "sagecommandline", "sageverbatim", "sageexample", "minted")
+    val verbatim = hashSetOf(VERBATIM.env, VERBATIM_CAPITAL.env, LISTINGS.env, "plantuml", LUACODE.env,
+        LUACODE_STAR.env, "sagesilent", "sageblock", "sagecommandline", "sageverbatim", "sageexample", "minted"
+    )
 
     /**
      * Environments that always contain a certain language.


### PR DESCRIPTION
Fixes [TEX-22](https://texify-idea.myjetbrains.com/youtrack/issue/TEX-22).

#### Summary of additions and changes

* Disabled smart quote substitution in verbatim environments.
* Disabled default intentions in verbatim environments (fig, tab, etc.)

#### Wiki

- Updated [Features](https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Features), fixed smart quotes link.
- Updated [Global settings](https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Global-settings#option-to-enable-smart-quote-substitution)
- Updated [Live templates](https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Live-templates)