### PR TITLE
Support multiple MiKTeX installations in MiktexSDK, bstinputs, texcount and command redefinitions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 group = "nl.hannahsten"
-version = "0.7.3-alpha.6"
+version = "0.7.4-alpha.1"
 
 repositories {
     mavenCentral()

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -343,13 +343,14 @@
         </group>
 
         <!-- Debug/development -->
-        <group id="texify.LatexMenu.Debug" class="nl.hannahsten.texifyidea.action.group.DebugActionGroup" text="TeXiFy IDEA"
-               description="Contains debug- and development actions for TeXiFy developers." popup="true">
-            <add-to-group group-id="Internal" anchor="last"/>
+        <!-- Currently disabled because the Internal menu group does not exist by default. -->
+<!--        <group id="texify.LatexMenu.Debug" class="nl.hannahsten.texifyidea.action.group.DebugActionGroup" text="TeXiFy IDEA"-->
+<!--               description="Contains debug- and development actions for TeXiFy developers." popup="true">-->
+<!--            <add-to-group group-id="Internal" anchor="last"/>-->
 
-            <action class="nl.hannahsten.texifyidea.action.debug.GenerateSymbolImagesAction" id="texify.debug.GenerateSymbolImages"
-                    text="Generate Symbol Images" description="Generate symbol images"/>
-        </group>
+<!--            <action class="nl.hannahsten.texifyidea.action.debug.GenerateSymbolImagesAction" id="texify.debug.GenerateSymbolImages"-->
+<!--                    text="Generate Symbol Images" description="Generate symbol images"/>-->
+<!--        </group>-->
 
     </actions>
 

--- a/src/nl/hannahsten/texifyidea/action/analysis/WordCountAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/analysis/WordCountAction.kt
@@ -70,7 +70,6 @@ open class WordCountAction : AnAction(
         val project = event.getData(PlatformDataKeys.PROJECT) ?: return
         val psiFile = virtualFile.psiFile(project) ?: return
 
-
         val dialog = if (SystemEnvironment.isTexcountAvailable) {
             val root = psiFile.findRootFile().virtualFile
             val words = "texcount -1 -inc -sum ${root.path}".runCommand(workingDirectory = File(root.parent.path))?.toIntOrNull()

--- a/src/nl/hannahsten/texifyidea/action/analysis/WordCountAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/analysis/WordCountAction.kt
@@ -11,8 +11,10 @@ import com.intellij.psi.PsiWhiteSpace
 import nl.hannahsten.texifyidea.TexifyIcons
 import nl.hannahsten.texifyidea.psi.*
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.findRootFile
 import nl.hannahsten.texifyidea.util.files.psiFile
 import nl.hannahsten.texifyidea.util.files.referencedFileSet
+import java.io.File
 import java.util.regex.Pattern
 import javax.swing.JLabel
 import javax.swing.SwingConstants
@@ -68,8 +70,16 @@ open class WordCountAction : AnAction(
         val project = event.getData(PlatformDataKeys.PROJECT) ?: return
         val psiFile = virtualFile.psiFile(project) ?: return
 
-        val (words, chars) = countWords(psiFile)
-        val dialog = makeDialog(psiFile, words, chars)
+
+        val dialog = if (SystemEnvironment.isTexcountAvailable) {
+            val root = psiFile.findRootFile().virtualFile
+            val words = "texcount -1 -inc -sum ${root.path}".runCommand(workingDirectory = File(root.parent.path))?.toIntOrNull()
+            makeDialog(psiFile, words)
+        }
+        else {
+            val (words, chars) = countWords(psiFile)
+            makeDialog(psiFile, words, chars)
+        }
 
         dialog.show()
     }
@@ -77,17 +87,23 @@ open class WordCountAction : AnAction(
     /**
      * Builds the dialog that must show the word count.
      */
-    private fun makeDialog(baseFile: PsiFile, wordCount: Int, characters: Int): DialogBuilder {
+    private fun makeDialog(baseFile: PsiFile, wordCount: Int?, characters: Int? = null): DialogBuilder {
         return DialogBuilder().apply {
-            setTitle("Word count")
+            setTitle("Word Count")
 
+            val characterString = if (characters == null) {
+                ""
+            }
+            else {
+                "|   <tr><td style='text-align:right'>Character count:</td><td><b>$characters</b></td>"
+            }
             setCenterPanel(
                 JLabel(
                     """|<html>
                         |<p>Analysis of <i>${baseFile.name}</i> (and inclusions):</p>
                         |<table cellpadding=1 style='margin-top:4px'>
                         |   <tr><td style='text-align:right'>Word count:</td><td><b>$wordCount</b></td></tr>
-                        |   <tr><td style='text-align:right'>Character count:</td><td><b>$characters</b></td>
+                        $characterString
                         |</table>
                         |</html>""".trimMargin(),
                     AllIcons.General.InformationDialog,

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexCollapseCiteInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexCollapseCiteInspection.kt
@@ -104,19 +104,20 @@ open class LatexCollapseCiteInspection : TexifyInspectionBase() {
         val content = firstParentOfType(LatexNoMathContent::class) ?: return null
         val nextContent = nextThing(content) ?: return null
 
-        var cite = nextContent.firstChildOfType(LatexCommands::class)
+        var cite = nextContent.firstChild
         // If there is no command inside the sibling grandparent, it can still be a non-breaking space.
-        if (cite == null) {
+        if (cite !is LatexCommands) {
             // If it is a non-breaking space, we want to check if the next grandparent sibling contains a cite.
             if (nextContent.isNonBreakingSpace()) {
                 val secondNextContent = nextThing(nextContent) ?: return null
-                cite = secondNextContent.firstChildOfType(LatexCommands::class) ?: return null
+                cite = secondNextContent.firstChild ?: return null
             }
             // If it is not a non-breaking space it is some other text and we won't find another cite in this direction.
             else return null
         }
 
         // Check if the found command is a similar cite command as the one we started at.
+        if (cite !is LatexCommands) return null
         val name = cite.name ?: return null
         val nextCommandIsACitation = name in CommandMagic.bibliographyReference
         val previousCommandIsOfTheSameType = this.name == name

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexCommandAlreadyDefinedInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexCommandAlreadyDefinedInspection.kt
@@ -18,6 +18,8 @@ import nl.hannahsten.texifyidea.util.replaceString
 import java.util.*
 
 /**
+ * Warns for commands that (maybe by mistake) redefine commands that are defined by LaTeX (packages).
+ *
  * @author Sten Wessel
  */
 class LatexCommandAlreadyDefinedInspection : TexifyInspectionBase() {
@@ -49,9 +51,10 @@ class LatexCommandAlreadyDefinedInspection : TexifyInspectionBase() {
                     descriptors.add(
                         manager.createProblemDescriptor(
                             command,
-                            "Command is already defined",
+                            "Command may already be defined in a LaTeX package",
                             true,
-                            ProblemHighlightType.GENERIC_ERROR,
+                            // Warning because may not be true: command may be defined in a LaTeX package which is not actually imported
+                            ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
                             isOntheFly, RenewCommandFix
                         )
                     )
@@ -65,7 +68,7 @@ class LatexCommandAlreadyDefinedInspection : TexifyInspectionBase() {
                     descriptors.add(
                         manager.createProblemDescriptor(
                             command,
-                            "Command is already defined",
+                            "Command may already be defined in a LaTeX package",
                             true,
                             ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
                             isOntheFly

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexDuplicateDefinitionInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexDuplicateDefinitionInspection.kt
@@ -13,6 +13,8 @@ import nl.hannahsten.texifyidea.util.files.definitionsInFileSet
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 
 /**
+ * Warns for commands that are defined twice in the same fileset.
+ *
  * @author Hannah Schellekens
  */
 open class LatexDuplicateDefinitionInspection : TexifyInspectionBase() {

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingImportInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexMissingImportInspection.kt
@@ -13,11 +13,7 @@ import nl.hannahsten.texifyidea.insight.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.lang.DefaultEnvironment
 import nl.hannahsten.texifyidea.lang.LatexPackage
-import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.AMSFONTS
-import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.AMSMATH
-import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.AMSSYMB
 import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.DEFAULT
-import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.MATHTOOLS
 import nl.hannahsten.texifyidea.lang.commands.LatexCommand
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexCommands
@@ -70,7 +66,7 @@ open class LatexMissingImportInspection : TexifyInspectionBase() {
             .mapNotNull { it.requiredParameter(0) }
             .toSet()
 
-        for (env in environments) {
+        outerLoop@ for (env in environments) {
             // Don't consider environments that have been defined.
             if (env.name()?.text in defined) {
                 continue
@@ -84,14 +80,11 @@ open class LatexMissingImportInspection : TexifyInspectionBase() {
                 continue
             }
 
-            // amsfonts is included in amssymb
-            if (pack == AMSFONTS && includedPackages.contains(AMSSYMB.name)) {
-                continue
-            }
-
-            // amsmath is included in mathtools
-            if (pack == AMSMATH && includedPackages.contains(MATHTOOLS.name)) {
-                continue
+            // Packages included in other packages
+            for (packageInclusion in PackageMagic.packagesLoadingOtherPackages) {
+                if (packageInclusion == pack && includedPackages.contains(packageInclusion.key.name)) {
+                    continue@outerLoop
+                }
             }
 
             descriptors.add(
@@ -114,6 +107,17 @@ open class LatexMissingImportInspection : TexifyInspectionBase() {
     ) {
         val commands = file.commandsInFile()
         commandLoop@ for (command in commands) {
+
+            // If we are actually defining the command, then it doesn't need any dependency
+            if (command.parent.firstParentOfType(LatexCommands::class).isCommandDefinition()) {
+                continue
+            }
+
+            // If defined within the project, also fine
+            if (command.project.findCommandDefinitions().map { it.definedCommandName() }.contains(command.name)) {
+                continue
+            }
+
             val name = command.commandToken.text.substring(1)
             val latexCommands = LatexCommand.lookup(name) ?: continue
 

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
@@ -32,8 +32,8 @@ import nl.hannahsten.texifyidea.run.latex.ui.LatexSettingsEditor
 import nl.hannahsten.texifyidea.run.linuxpdfviewer.InternalPdfViewer
 import nl.hannahsten.texifyidea.run.pdfviewer.ExternalPdfViewers
 import nl.hannahsten.texifyidea.run.pdfviewer.PdfViewer
-import nl.hannahsten.texifyidea.settings.sdk.LatexSdkUtil
 import nl.hannahsten.texifyidea.settings.TexifySettings
+import nl.hannahsten.texifyidea.settings.sdk.LatexSdkUtil
 import nl.hannahsten.texifyidea.util.allCommands
 import nl.hannahsten.texifyidea.util.files.commandsInFileSet
 import nl.hannahsten.texifyidea.util.files.findFile
@@ -388,7 +388,7 @@ class LatexRunConfiguration constructor(
         if (!latexDistribution.isMiktex()) {
             // Only if default, because the user could have changed it after creating the run config but before running
             if (mainFile != null && outputPath.virtualFile != mainFile.parent) {
-                bibtexRunConfiguration.environmentVariables = bibtexRunConfiguration.environmentVariables.with(mapOf("BIBINPUTS" to mainFile.parent.path))
+                bibtexRunConfiguration.environmentVariables = bibtexRunConfiguration.environmentVariables.with(mapOf("BIBINPUTS" to mainFile.parent.path, "BSTINPUTS" to mainFile.parent.path + ":"))
             }
         }
 

--- a/src/nl/hannahsten/texifyidea/settings/sdk/MiktexSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/MiktexSdk.kt
@@ -25,10 +25,12 @@ class MiktexSdk : LatexSdk("MiKTeX SDK") {
 
     override fun suggestHomePaths(): MutableCollection<String> {
         val results = mutableSetOf<String>()
-        val path = "where pdflatex".runCommand()
-        if (path != null) {
-            val index = path.findLastAnyOf(setOf("miktex\\bin"))?.first ?: path.length - 1
-            results.add(path.substring(0, index))
+        val paths = "where pdflatex".runCommand()
+        if (paths != null) {
+            paths.split("\r\n").forEach { path ->
+                val index = path.findLastAnyOf(setOf("miktex\\bin"))?.first ?: path.length - 1
+                results.add(path.substring(0, index))
+            }
         }
         else {
             results.add(suggestHomePath())

--- a/src/nl/hannahsten/texifyidea/util/Strings.kt
+++ b/src/nl/hannahsten/texifyidea/util/Strings.kt
@@ -197,7 +197,7 @@ fun String.removeHtmlTags() = this.replace(PatternMagic.htmlTag.toRegex(), "")
  *
  * @return The output of the command or null if an exception was thrown.
  */
-fun String.runCommand(workingDirectory: File? = null) = runCommand(*(this.split("\\s".toRegex())).toTypedArray(), workingDirectory=workingDirectory)
+fun String.runCommand(workingDirectory: File? = null) = runCommand(*(this.split("\\s".toRegex())).toTypedArray(), workingDirectory = workingDirectory)
 
 /**
  * Index of first occurrence of any of the given chars. Return last index if chars do not appear in the string.

--- a/src/nl/hannahsten/texifyidea/util/Strings.kt
+++ b/src/nl/hannahsten/texifyidea/util/Strings.kt
@@ -3,6 +3,7 @@ package nl.hannahsten.texifyidea.util
 import com.intellij.openapi.util.TextRange
 import nl.hannahsten.texifyidea.util.magic.PatternMagic
 import org.intellij.lang.annotations.Language
+import java.io.File
 import kotlin.math.max
 import kotlin.math.min
 
@@ -196,7 +197,7 @@ fun String.removeHtmlTags() = this.replace(PatternMagic.htmlTag.toRegex(), "")
  *
  * @return The output of the command or null if an exception was thrown.
  */
-fun String.runCommand() = runCommand(*(this.split("\\s".toRegex())).toTypedArray())
+fun String.runCommand(workingDirectory: File? = null) = runCommand(*(this.split("\\s".toRegex())).toTypedArray(), workingDirectory=workingDirectory)
 
 /**
  * Index of first occurrence of any of the given chars. Return last index if chars do not appear in the string.

--- a/src/nl/hannahsten/texifyidea/util/SystemEnvironment.kt
+++ b/src/nl/hannahsten/texifyidea/util/SystemEnvironment.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.util
 
+import java.io.File
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 
@@ -24,6 +25,10 @@ class SystemEnvironment {
         val isPerlInstalled: Boolean by lazy {
             "perl -v".runCommand()?.contains("This is perl") == true
         }
+
+        val isTexcountAvailable: Boolean by lazy {
+            "texcount".runCommand()?.contains("TeXcount") == true
+        }
     }
 }
 
@@ -32,12 +37,13 @@ class SystemEnvironment {
  *
  * @return The output of the command or null if an exception was thrown.
  */
-fun runCommand(vararg commands: String): String? {
+fun runCommand(vararg commands: String, workingDirectory: File? = null): String? {
     return try {
         val command = arrayListOf(*commands)
         val proc = ProcessBuilder(command)
             .redirectOutput(ProcessBuilder.Redirect.PIPE)
             .redirectError(ProcessBuilder.Redirect.PIPE)
+            .directory(workingDirectory)
             .start()
 
         if (proc.waitFor(3, TimeUnit.SECONDS)) {

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LatexCollapseCiteInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LatexCollapseCiteInspectionTest.kt
@@ -16,6 +16,19 @@ class LatexCollapseCiteInspectionTest : TexifyInspectionTestBase(LatexCollapseCi
         myFixture.checkHighlighting()
     }
 
+    fun testNoWarning() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \newcommand{\citet}[1]{\citeauthor{#1} \shortcite{#1}}
+            \begin{document}
+                \citet{X}
+            \end{document}
+            """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
     fun `test warning non breaking space`() {
         testHighlighting("<warning>\\cite{a}</warning>~<warning>\\cite{b}</warning>")
     }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LatexCommandAlreadyDefinedInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LatexCommandAlreadyDefinedInspectionTest.kt
@@ -9,9 +9,9 @@ class LatexCommandAlreadyDefinedInspectionTest : TexifyInspectionTestBase(LatexC
         myFixture.configureByText(
             LatexFileType,
             """
-            <error descr="Command is already defined">\newcommand{\cite}{\citeauthor}</error>
+            <warning descr="Command may already be defined in a LaTeX package">\newcommand{\cite}{\citeauthor}</warning>
             
-            <warning descr="Command is already defined">\def</warning>\citeauthor\cite
+            <warning descr="Command may already be defined in a LaTeX package">\def</warning>\citeauthor\cite
             
             \newcommand{\notexists}{}
             """.trimIndent()


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix  [TEX-93](https://texify-idea.myjetbrains.com/youtrack/issue/TEX-93)
Fix #1757
Fix #1723 
Fix #1753 
Fix #1765 (well, workaround)

#### Summary of additions and changes

* Apparently the 'where' command on Windows can return multiple paths
I think the bug is already in 0.7.3, but I assume it can only happen if you have multiple MiKTeX installs.
* Add BSTINPUTS by default to bibtex run config, similar to BIBINPUTS
* Use texcount for word count if available. Not perfect, but good enough for now.
* Fix false positive for missing import inspection: when command is being defined
* Make 'command already defined' a warning, because the original command may not be imported (maybe we should check for this)