### PR TITLE
Add SDK type for MiKTeX on Linux

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -437,8 +437,9 @@
         <projectService serviceImplementation="nl.hannahsten.texifyidea.run.latex.logtab.ui.LatexErrorTreeViewConfiguration"/>
         <sdkType implementation="nl.hannahsten.texifyidea.settings.sdk.TexliveSdk" />
         <sdkType implementation="nl.hannahsten.texifyidea.settings.sdk.DockerSdk" />
-        <sdkType implementation="nl.hannahsten.texifyidea.settings.sdk.MiktexSdk" />
+        <sdkType implementation="nl.hannahsten.texifyidea.settings.sdk.MiktexWindowsSdk" />
         <sdkType implementation="nl.hannahsten.texifyidea.settings.sdk.NativeTexliveSdk" />
+        <sdkType implementation="nl.hannahsten.texifyidea.settings.sdk.MiktexLinuxSdk" />
         <projectSdkSetupValidator implementation="nl.hannahsten.texifyidea.project.LatexProjectSdkSetupValidator" />
 
         <!-- Languages -->

--- a/src/nl/hannahsten/texifyidea/completion/handlers/LatexCommandArgumentInsertHandler.kt
+++ b/src/nl/hannahsten/texifyidea/completion/handlers/LatexCommandArgumentInsertHandler.kt
@@ -10,7 +10,6 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.util.TextRange
 import nl.hannahsten.texifyidea.lang.commands.Argument
 import nl.hannahsten.texifyidea.lang.commands.RequiredArgument
-import nl.hannahsten.texifyidea.lang.*
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.util.endOffset
 import nl.hannahsten.texifyidea.util.files.psiFile
@@ -22,7 +21,6 @@ import nl.hannahsten.texifyidea.util.parentOfType
 class LatexCommandArgumentInsertHandler(val arguments: List<Argument>? = null) : InsertHandler<LookupElement> {
 
     override fun handleInsert(insertionContext: InsertionContext, lookupElement: LookupElement) {
-        removeWhiteSpaces(insertionContext)
         insert(insertionContext, lookupElement)
     }
 
@@ -65,19 +63,5 @@ class LatexCommandArgumentInsertHandler(val arguments: List<Argument>? = null) :
         if (psiElement.text in setOf("{", "[")) {
             caret.moveToOffset((psiElement.parentOfType(LatexCommands::class)?.endOffset() ?: return) - extraSpaces)
         }
-    }
-
-    /**
-     * Remove whitespaces and everything after that that was inserted by the lookup text.
-     */
-    private fun removeWhiteSpaces(context: InsertionContext) {
-        val editor = context.editor
-        val document = editor.document
-        val offset = editor.caretModel.offset
-        // context.startOffset is the offset of the start of the just inserted text.
-        val insertedText = document.text.substring(context.startOffset, offset)
-        val indexFirstSpace = insertedText.indexOfFirst { it == ' ' }
-        if (indexFirstSpace == -1) return
-        document.deleteString(context.startOffset + indexFirstSpace, offset)
     }
 }

--- a/src/nl/hannahsten/texifyidea/completion/handlers/LatexNoMathInsertHandler.kt
+++ b/src/nl/hannahsten/texifyidea/completion/handlers/LatexNoMathInsertHandler.kt
@@ -24,6 +24,7 @@ import nl.hannahsten.texifyidea.util.magic.TypographyMagic
 class LatexNoMathInsertHandler(val arguments: List<Argument>? = null) : InsertHandler<LookupElement> {
 
     override fun handleInsert(context: InsertionContext, item: LookupElement) {
+        removeWhiteSpaces(context)
         val command = item.`object` as LatexCommand
 
         when (command.command) {
@@ -89,6 +90,20 @@ class LatexNoMathInsertHandler(val arguments: List<Argument>? = null) : InsertHa
 
         TemplateManager.getInstance(context.project)
             .startTemplate(context.editor, parameterTemplate)
+    }
+
+    /**
+     * Remove whitespaces and everything after that that was inserted by the lookup text.
+     */
+    private fun removeWhiteSpaces(context: InsertionContext) {
+        val editor = context.editor
+        val document = editor.document
+        val offset = editor.caretModel.offset
+        // context.startOffset is the offset of the start of the just inserted text.
+        val insertedText = document.text.substring(context.startOffset, offset)
+        val indexFirstSpace = insertedText.indexOfFirst { it == ' ' }
+        if (indexFirstSpace == -1) return
+        document.deleteString(context.startOffset + indexFirstSpace, offset)
     }
 
     /**

--- a/src/nl/hannahsten/texifyidea/index/file/LatexIndexableSetContributor.kt
+++ b/src/nl/hannahsten/texifyidea/index/file/LatexIndexableSetContributor.kt
@@ -26,7 +26,7 @@ class LatexIndexableSetContributor : IndexableSetContributor() {
                 // MiKTeX keeps the dtx files in tar.xz/tar.bz2 files, so we have to extract them ourselves.
                 // We could check if the target files exist and in that case not extract again, however then we would never update packages
                 // Because maintaining extraction dates seems a bit too much work for now, just extract again after reboot only
-                if (root.path.contains("MiKTeX") && !extractedFiles) {
+                if (root.path.contains("MiKTeX", ignoreCase = true) && !extractedFiles) {
                     val txArchiver = TarXZUnArchiver()
                     txArchiver.enableLogging(ConsoleLoggerManager().also { it.initialize() }.getLoggerForComponent("noop"))
                     File(root.path).list { _, name -> name.endsWith("tar.xz") }?.forEach { zipName ->

--- a/src/nl/hannahsten/texifyidea/settings/sdk/LatexSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/LatexSdk.kt
@@ -8,6 +8,11 @@ import org.jdom.Element
 /**
  * Represents the location of the LaTeX installation.
  *
+ * NOTES for subclasses:
+ * - suggestHomePath() will be the starting point when someone opens the file explorer dialog to select an SDK of this type
+ * - suggestHomePaths() appear under "Detected SDK's" when adding an SDK
+ * - HOWEVER they only do so, when getVersionString(sdkHome: String?) is implemented (implementing getVersionString(sdk: SDK?) is NOT enough)
+ *
  * @author Thomas
  */
 abstract class LatexSdk(name: String) : SdkType(name) {

--- a/src/nl/hannahsten/texifyidea/settings/sdk/LatexSdkUtil.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/LatexSdkUtil.kt
@@ -144,7 +144,7 @@ object LatexSdkUtil {
     private fun getPreferredSdkType(): Sdk? {
         val allSdks = ProjectJdkTable.getInstance().allJdks.filter { it.sdkType is LatexSdk }
         allSdks.firstOrNull { it.sdkType is TexliveSdk }?.let { return it }
-        allSdks.firstOrNull { it.sdkType is MiktexSdk }?.let { return it }
+        allSdks.firstOrNull { it.sdkType is MiktexWindowsSdk }?.let { return it }
         allSdks.firstOrNull { it.sdkType is DockerSdk }?.let { return it }
         return null
     }
@@ -177,7 +177,7 @@ object LatexSdkUtil {
             val default = if (sdk.homePath != null) setOf((sdk.sdkType as? LatexSdk)?.getDefaultSourcesPath(sdk.homePath!!)).filterNotNull() else emptySet()
             return userProvided + default
         }
-        for (sdkType in setOf(TexliveSdk(), NativeTexliveSdk(), MiktexSdk())) {
+        for (sdkType in setOf(TexliveSdk(), NativeTexliveSdk(), MiktexWindowsSdk())) {
             val roots = sdkType.suggestHomePaths().mapNotNull { homePath ->
                 sdkType.getDefaultSourcesPath(homePath)
             }.toSet()

--- a/src/nl/hannahsten/texifyidea/settings/sdk/MiktexLinuxSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/MiktexLinuxSdk.kt
@@ -47,7 +47,6 @@ class MiktexLinuxSdk : LatexSdk("MiKTeX Mac/Linux SDK") {
         return "$path${File.separator}pdflatex --version".runCommand()?.contains("pdfTeX") == true
     }
 
-
     override fun getVersionString(sdk: Sdk): String? {
         return getVersionString(sdk.homePath)
     }

--- a/src/nl/hannahsten/texifyidea/settings/sdk/MiktexLinuxSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/MiktexLinuxSdk.kt
@@ -1,6 +1,8 @@
 package nl.hannahsten.texifyidea.settings.sdk
 
 import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
 import nl.hannahsten.texifyidea.run.latex.LatexDistributionType
 import nl.hannahsten.texifyidea.util.runCommand
 import java.io.File
@@ -10,10 +12,10 @@ import java.nio.file.Paths
  * MiKTeX on Linux has a very different file structure than MiKTeX on Windows, so this warrants its own SDK type.
  * This has been tested on Arch Linux, and let's hope it's similar for other distros.
  * Based on user feedback, I'm guessing that it is very similar to MiKTeX for Mac.
- * todo change name on Mac?
  *
+ * On Arch (user install), the pdflatex binary was created in ~/bin and MiKTeX itself was installed to /opt/miktex, the texmf folder was in ~/.miktex.
  */
-class MiktexLinuxSdk : LatexSdk("MiKTeX Linux SDK") {
+class MiktexLinuxSdk : LatexSdk("MiKTeX Mac/Linux SDK") {
 
     companion object {
 
@@ -58,5 +60,11 @@ class MiktexLinuxSdk : LatexSdk("MiKTeX Linux SDK") {
         version = "\\(MiKTeX (\\d+.\\d+)\\)".toRegex().find(output)?.value
 
         return version
+    }
+
+    override fun getDefaultSourcesPath(homePath: String): VirtualFile? {
+        // This was the path on the tested Arch installation
+        // Note that also these files are zipped
+        return LocalFileSystem.getInstance().findFileByPath(Paths.get(System.getProperty("user.home"), ".miktex", "texmfs", "install", "source").toString())
     }
 }

--- a/src/nl/hannahsten/texifyidea/settings/sdk/MiktexLinuxSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/MiktexLinuxSdk.kt
@@ -1,0 +1,62 @@
+package nl.hannahsten.texifyidea.settings.sdk
+
+import com.intellij.openapi.projectRoots.Sdk
+import nl.hannahsten.texifyidea.run.latex.LatexDistributionType
+import nl.hannahsten.texifyidea.util.runCommand
+import java.io.File
+import java.nio.file.Paths
+
+/**
+ * MiKTeX on Linux has a very different file structure than MiKTeX on Windows, so this warrants its own SDK type.
+ * This has been tested on Arch Linux, and let's hope it's similar for other distros.
+ * Based on user feedback, I'm guessing that it is very similar to MiKTeX for Mac.
+ * todo change name on Mac?
+ *
+ */
+class MiktexLinuxSdk : LatexSdk("MiKTeX Linux SDK") {
+
+    companion object {
+
+        // Cache version
+        var version: String? = null
+    }
+
+    override fun getLatexDistributionType() = LatexDistributionType.MIKTEX
+
+    override fun getExecutableName(executable: String, homePath: String): String {
+        return "$homePath/$executable"
+    }
+
+    override fun suggestHomePath(): String {
+        // The user can by default install globally or for the user only (see below)
+        // Similar as with Windows we recommend installing for the user only.
+        return "~/bin/"
+    }
+
+    override fun suggestHomePaths(): MutableCollection<String> {
+        return listOf(
+            Paths.get(System.getProperty("user.home"), "bin").toString(),
+            "/usr/local/bin"
+        ).filter { isValidSdkHome(it) }.toMutableList()
+    }
+
+    override fun isValidSdkHome(path: String?): Boolean {
+        // We just want a path where pdflatex is present
+        return "$path${File.separator}pdflatex --version".runCommand()?.contains("pdfTeX") == true
+    }
+
+
+    override fun getVersionString(sdk: Sdk): String? {
+        return getVersionString(sdk.homePath)
+    }
+
+    override fun getVersionString(sdkHome: String?): String? {
+        version?.let { return version }
+
+        val executable = sdkHome?.let { getExecutableName("pdflatex", it) } ?: "pdflatex"
+        val output = "$executable --version".runCommand() ?: ""
+        version = "\\(MiKTeX (\\d+.\\d+)\\)".toRegex().find(output)?.value
+
+        return version
+    }
+}

--- a/src/nl/hannahsten/texifyidea/settings/sdk/MiktexWindowsSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/MiktexWindowsSdk.kt
@@ -8,7 +8,7 @@ import nl.hannahsten.texifyidea.util.runCommand
 import java.nio.file.Paths
 
 /**
- * todo only show on Windows?
+ * MiKTeX on Windows.
  */
 class MiktexWindowsSdk : LatexSdk("MiKTeX Windows SDK") {
 

--- a/src/nl/hannahsten/texifyidea/settings/sdk/MiktexWindowsSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/MiktexWindowsSdk.kt
@@ -7,10 +7,16 @@ import nl.hannahsten.texifyidea.run.latex.LatexDistributionType
 import nl.hannahsten.texifyidea.util.runCommand
 import java.nio.file.Paths
 
-class MiktexSdk : LatexSdk("MiKTeX SDK") {
+/**
+ * todo only show on Windows?
+ */
+class MiktexWindowsSdk : LatexSdk("MiKTeX Windows SDK") {
 
-    // Cache version
-    var version: String? = null
+    companion object {
+
+        // Cache version
+        var version: String? = null
+    }
 
     override fun getLatexDistributionType() = LatexDistributionType.MIKTEX
 
@@ -54,9 +60,13 @@ class MiktexSdk : LatexSdk("MiKTeX SDK") {
     }
 
     override fun getVersionString(sdk: Sdk): String? {
+        return getVersionString(sdk.homePath)
+    }
+
+    override fun getVersionString(sdkHome: String?): String? {
         version?.let { return version }
 
-        val executable = sdk.homePath?.let { getExecutableName("pdflatex", it) } ?: "pdflatex"
+        val executable = sdkHome?.let { getExecutableName("pdflatex", it) } ?: "pdflatex"
         val output = "$executable --version".runCommand() ?: ""
         version = "\\(MiKTeX (\\d+.\\d+)\\)".toRegex().find(output)?.value
 

--- a/src/nl/hannahsten/texifyidea/settings/sdk/NativeTexliveSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/NativeTexliveSdk.kt
@@ -60,10 +60,4 @@ class NativeTexliveSdk : TexliveSdk("Native TeX Live SDK") {
         return "$texmfDistPath/doc"
     }
 
-    override fun getExecutableName(executable: String, homePath: String): String {
-        // Even though pdflatex is in path, it may be not the pdflatex we want, so we prefix the path to be sure.
-        // Get base path of LaTeX distribution
-        val basePath = "/usr/bin"
-        return "$basePath/$executable"
-    }
 }

--- a/src/nl/hannahsten/texifyidea/settings/sdk/NativeTexliveSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/NativeTexliveSdk.kt
@@ -59,5 +59,4 @@ class NativeTexliveSdk : TexliveSdk("Native TeX Live SDK") {
     override fun getDefaultDocumentationUrl(sdk: Sdk): String? {
         return "$texmfDistPath/doc"
     }
-
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1761

#### Summary of additions and changes

* MiKTeX on Linux (and I think the one for Mac is similar) is very different from anything else I've seen so far.
* Interestingly, it seems to work pretty well so far, including indexing package sources (didn't find docs yet though)
* Fix MiKTeX SDK not being suggested 
* Fix autocomplete not removing package for pseudocode commands ([TEX-105](https://texify-idea.myjetbrains.com/youtrack/issue/TEX-105))

#### How to test this pull request

See wiki

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: