### PR TITLE
Add quick fix for normal space to line break inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/Hannah-Sten/TeXiFy-IDEA.svg)](http://isitmaintained.com/project/Hannah-Sten/TeXiFy-IDEA "Percentage of issues still open")
 
 # TeXiFy-IDEA
+<sup><sub>(Pronounced as `/ˈtɛxɪfaɪ aɪˈdɪə/` with a greek letter Chi (χ), just as in LaTeX)</sub></sup>
+
 LaTeX support for the IntelliJ Platform by [JetBrains](https://www.jetbrains.com/).
 
 No idea where to start? Have a look at the [installation instructions](https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Installation). Otherwise, take a look at the [tips](https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Installation) instead, or browse through the documentation in the [Wiki](https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Features)

--- a/gen/nl/hannahsten/texifyidea/grammar/BibtexLexer.java
+++ b/gen/nl/hannahsten/texifyidea/grammar/BibtexLexer.java
@@ -42,7 +42,7 @@ public class BibtexLexer implements FlexLexer {
    *                  at the beginning of a line
    * l is of the form l = 2*k, k a non negative integer
    */
-  private static final int[] ZZ_LEXSTATE = {
+  private static final int ZZ_LEXSTATE[] = { 
      0,  0,  1,  1,  2,  2,  3,  3,  4,  4,  5,  5,  6,  6,  7,  7, 
      8,  8,  9,  9, 10, 10
   };
@@ -57,19 +57,19 @@ public class BibtexLexer implements FlexLexer {
   }
 
   /* The ZZ_CMAP_Z table has 68 entries */
-  static final char[] ZZ_CMAP_Z = zzUnpackCMap(
+  static final char ZZ_CMAP_Z[] = zzUnpackCMap(
     "\1\0\103\200");
 
   /* The ZZ_CMAP_Y table has 256 entries */
-  static final char[] ZZ_CMAP_Y = zzUnpackCMap(
+  static final char ZZ_CMAP_Y[] = zzUnpackCMap(
     "\1\0\1\1\53\2\1\3\22\2\1\4\37\2\1\3\237\2");
 
   /* The ZZ_CMAP_A table has 640 entries */
-  static final char[] ZZ_CMAP_A = zzUnpackCMap(
+  static final char ZZ_CMAP_A[] = zzUnpackCMap(
     "\11\0\1\1\1\3\2\1\1\2\22\0\1\20\1\0\1\13\1\12\1\0\1\16\1\0\1\17\1\6\1\7\2"+
-    "\0\1\10\1\21\2\0\12\21\3\0\1\11\2\0\1\14\32\15\1\0\1\22\4\0\32\15\1\4\1\0"+
-    "\1\5\1\17\6\0\1\23\32\0\1\23\337\0\1\23\177\0\13\23\35\0\2\23\5\0\1\23\57"+
-    "\0\1\23\40\0");
+    "\0\1\10\1\21\2\0\12\21\3\0\1\11\2\0\1\14\32\15\1\0\1\22\2\0\1\15\1\0\32\15"+
+    "\1\4\1\0\1\5\1\17\6\0\1\23\32\0\1\23\337\0\1\23\177\0\13\23\35\0\2\23\5\0"+
+    "\1\23\57\0\1\23\40\0");
 
   /** 
    * Translates DFA states to action switch labels.

--- a/src/nl/hannahsten/texifyidea/BibtexParserDefinition.kt
+++ b/src/nl/hannahsten/texifyidea/BibtexParserDefinition.kt
@@ -50,7 +50,7 @@ class BibtexParserDefinition : ParserDefinition {
         val FILE = object : IStubFileElementType<BibtexFileStub>(
             Language.findInstance(BibtexLanguage::class.java)
         ) {
-            override fun getStubVersion(): Int = 6
+            override fun getStubVersion(): Int = 7
         }
     }
 

--- a/src/nl/hannahsten/texifyidea/action/ClearGeneratedFiles.kt
+++ b/src/nl/hannahsten/texifyidea/action/ClearGeneratedFiles.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.ui.showOkCancelDialog
 import com.intellij.openapi.vfs.LocalFileSystem
-import nl.hannahsten.texifyidea.util.allRunConfigurations
+import nl.hannahsten.texifyidea.util.getLatexRunConfigurations
 import nl.hannahsten.texifyidea.util.magic.FileMagic
 import nl.hannahsten.texifyidea.util.runWriteAction
 import java.io.File
@@ -48,7 +48,7 @@ class ClearGeneratedFiles : AnAction() {
         }
 
         // Custom out/aux dirs
-        val customOutput = project.allRunConfigurations().flatMap { listOf(it.outputPath.getAndCreatePath(), it.auxilPath.getAndCreatePath()) }
+        val customOutput = project.getLatexRunConfigurations().flatMap { listOf(it.outputPath.getAndCreatePath(), it.auxilPath.getAndCreatePath()) }
         runWriteAction {
             for (path in customOutput) {
                 path?.children?.forEach { it.delete(this) }

--- a/src/nl/hannahsten/texifyidea/grammar/BibtexLexer.flex
+++ b/src/nl/hannahsten/texifyidea/grammar/BibtexLexer.flex
@@ -33,7 +33,7 @@ CONCATENATE="#"
 QUOTES="\""
 
 WHITE_SPACE=[ \t\n\x0B\f\r]+
-TYPE_TOKEN=@[a-zA-Z]+
+TYPE_TOKEN=@[a-zA-Z_]+
 COMMENT_TOKEN=%[^\r\n]*
 // Characters disallowed by bibtex or biber (non-ascii or not depends on LaTeX compiler)
 IDENTIFIER=[^,{}\(\)\"#%'=~\\ \n]+

--- a/src/nl/hannahsten/texifyidea/inspections/latex/LatexSpaceAfterAbbreviationInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/LatexSpaceAfterAbbreviationInspection.kt
@@ -91,9 +91,9 @@ open class LatexSpaceAfterAbbreviationInspection : TexifyInspectionBase() {
     /**
      * @author Hannah Schellekens
      */
-    private open class NormalSpaceFix(val whitespaceRange: IntRange) : LocalQuickFix {
+    open class NormalSpaceFix(private val whitespaceRange: IntRange) : LocalQuickFix {
 
-        override fun getFamilyName() = "Insert normal space"
+        override fun getFamilyName() = "Insert normal space after abbreviation"
 
         override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
             val element = descriptor.psiElement as LatexNormalText

--- a/src/nl/hannahsten/texifyidea/settings/sdk/MiktexWindowsSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/MiktexWindowsSdk.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import nl.hannahsten.texifyidea.run.latex.LatexDistributionType
 import nl.hannahsten.texifyidea.util.runCommand
+import java.nio.file.InvalidPathException
 import java.nio.file.Paths
 
 /**
@@ -45,8 +46,12 @@ class MiktexWindowsSdk : LatexSdk("MiKTeX Windows SDK") {
     }
 
     override fun getDefaultSourcesPath(homePath: String): VirtualFile? {
-        // To save space, MiKTeX leaves source/latex empty by default, but does leave the zipped files in source/
-        return LocalFileSystem.getInstance().findFileByPath(Paths.get(homePath, "source").toString())
+        return try {
+            // To save space, MiKTeX leaves source/latex empty by default, but does leave the zipped files in source/
+            LocalFileSystem.getInstance().findFileByPath(Paths.get(homePath, "source").toString())
+        } catch (ignored: InvalidPathException) {
+            null
+        }
     }
 
     override fun isValidSdkHome(path: String?): Boolean {

--- a/src/nl/hannahsten/texifyidea/settings/sdk/MiktexWindowsSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/MiktexWindowsSdk.kt
@@ -49,7 +49,8 @@ class MiktexWindowsSdk : LatexSdk("MiKTeX Windows SDK") {
         return try {
             // To save space, MiKTeX leaves source/latex empty by default, but does leave the zipped files in source/
             LocalFileSystem.getInstance().findFileByPath(Paths.get(homePath, "source").toString())
-        } catch (ignored: InvalidPathException) {
+        }
+        catch (ignored: InvalidPathException) {
             null
         }
     }

--- a/src/nl/hannahsten/texifyidea/settings/sdk/NativeTexliveSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/NativeTexliveSdk.kt
@@ -33,7 +33,9 @@ class NativeTexliveSdk : TexliveSdk("Native TeX Live SDK") {
         // Note that suggested paths appear under "Detected SDK's" when adding an SDK
         val results = mutableSetOf<String>()
         val path = "which pdflatex".runCommand()
-        if (!path.isNullOrEmpty()) {
+
+        // Avoid duplicates of TexliveSdks, which probably have x86_64-linux in the path
+        if (!path.isNullOrEmpty() && !path.contains("x86_64-linux")) {
             results.add(path.substringBefore("/pdflatex"))
         }
         results.add(suggestHomePath())

--- a/src/nl/hannahsten/texifyidea/util/General.kt
+++ b/src/nl/hannahsten/texifyidea/util/General.kt
@@ -60,6 +60,13 @@ val IntRange.length: Int
 fun IntRange.toRangeString(separator: String = "-") = if (start == endInclusive) start else "$start-$endInclusive"
 
 /**
+ * Shift the range to the right by the number of places given.
+ */
+fun IntRange.shiftRight(displacement: Int): IntRange {
+    return (this.first + displacement)..(this.last + displacement)
+}
+
+/**
  * Converts a [TextRange] to [IntRange].
  */
 fun TextRange.toIntRange() = startOffset..endOffset

--- a/src/nl/hannahsten/texifyidea/util/Projects.kt
+++ b/src/nl/hannahsten/texifyidea/util/Projects.kt
@@ -57,7 +57,7 @@ fun Project.allFiles(type: FileType): Collection<VirtualFile> {
 /**
  * Get all LaTeX run configurations in the project.
  */
-fun Project.allRunConfigurations(): Collection<LatexRunConfiguration> {
+fun Project.getLatexRunConfigurations(): Collection<LatexRunConfiguration> {
     return (RunManagerImpl.getInstanceImpl(this) as RunManager).allConfigurationsList.filterIsInstance<LatexRunConfiguration>()
 }
 

--- a/src/nl/hannahsten/texifyidea/util/files/RootFile.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/RootFile.kt
@@ -6,7 +6,7 @@ import nl.hannahsten.texifyidea.lang.magic.DefaultMagicKeys
 import nl.hannahsten.texifyidea.lang.magic.magicComment
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexEnvironment
-import nl.hannahsten.texifyidea.util.allRunConfigurations
+import nl.hannahsten.texifyidea.util.getLatexRunConfigurations
 import nl.hannahsten.texifyidea.util.childrenOfType
 
 /**
@@ -80,7 +80,7 @@ fun PsiFile.isRoot(): Boolean {
 
     // Go through all run configurations, to check if there is one which contains the current file.
     // If so, then we assume that the file is compilable and must be a root file.
-    val isMainFileInAnyConfiguration = project.allRunConfigurations().any { it.mainFile == this.virtualFile }
+    val isMainFileInAnyConfiguration = project.getLatexRunConfigurations().any { it.mainFile == this.virtualFile }
 
     return (isMainFileInAnyConfiguration || documentEnvironment()) && !usesSubFiles()
 }

--- a/src/nl/hannahsten/texifyidea/util/magic/PatternMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/PatternMagic.kt
@@ -27,7 +27,8 @@ object PatternMagic {
      *
      * Includes `[^.][^.]` because of abbreviations (at least in Dutch) like `s.v.p.`
      */
-    val sentenceEnd = RegexPattern.compile("([^.A-Z][^.A-Z][.?!;;] +[^%\\s])|(^\\. )")!!
+    const val sentenceEndPrefix = "[^.A-Z][^.A-Z]"
+    val sentenceEnd = RegexPattern.compile("($sentenceEndPrefix[.?!;;] +[^%\\s])|(^\\. )")!!
 
     /**
      * Matches all interpunction that marks the end of a sentence.

--- a/test/nl/hannahsten/texifyidea/inspections/latex/LatexLineBreakInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/LatexLineBreakInspectionTest.kt
@@ -4,21 +4,27 @@ import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
 
 class LatexLineBreakInspectionTest : TexifyInspectionTestBase(LatexLineBreakInspection()) {
 
-    fun testWarning() = testHighlighting("""
+    fun testWarning() = testHighlighting(
+        """
             Not this, b<weak_warning descr="Sentence does not start on a new line">ut. This starts a new line.</weak_warning>
 This e<weak_warning descr="Sentence does not start on a new line">tc. is missing a normal space, but i.e. this etc.</weak_warning>\ is not.
             % not. in. comments
-        """.trimIndent())
+        """.trimIndent()
+    )
 
-    fun testNoWarning() = testHighlighting("""
+    fun testNoWarning() = testHighlighting(
+        """
             First sentence.
             Second sentence.
-        """.trimIndent())
+        """.trimIndent()
+    )
 
-    fun `test no warning in comment`() = testHighlighting("""
+    fun `test no warning in comment`() = testHighlighting(
+        """
             This is an abbreviation (ABC). % commemt
             More text here.
-        """.trimIndent())
+        """.trimIndent()
+    )
 
     fun `test no warning in math mode`() = testHighlighting("""\[ Why. would. you. do. this. \]""")
 
@@ -27,10 +33,28 @@ This e<weak_warning descr="Sentence does not start on a new line">tc. is missing
     fun `test no warning in magic comment on line with text`() = testHighlighting("""This is a sentence. %! suppress = CiteBeforePeriod""")
 
     fun `test quick fix`() = testQuickFix(
-            before = """I end. a sentence.""",
-            after = """
+        before = """I end. a sentence.""",
+        after = """
                 I end.
                 a sentence.
-            """.trimIndent()
+            """.trimIndent(),
+        numberOfFixes = 2,
+        selectedFix = 1
+    )
+
+    fun `test quick fix abbreviation`() = testQuickFix(
+        before = """Ich sehe ihn bzw. seinen Schatten.""",
+        after = """Ich sehe ihn bzw.\ seinen Schatten.""",
+        numberOfFixes = 2,
+        selectedFix = 2
+    )
+
+    fun `test quick fix non-abbreviation`() = testQuickFix(
+        before = """This! cannot have been an abbreviation.""",
+        after = """
+            This!
+            cannot have been an abbreviation.
+        """.trimIndent(),
+        numberOfFixes = 1,
     )
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1783
Fix [TEX-31](https://texify-idea.myjetbrains.com/youtrack/issue/TEX-31)
Fix #1785
Fix #1786
Fix #1789

#### Summary of additions and changes

* Add quick fix for normal space to line break inspection
* Look in run configurations for possible paths to latex executables when using pycharm on a mac
* Fix #1786 (underscore in bibtex type)

#### How to test this pull request

* First sentence now has two quickfixes, second one still has only one.
```latex
 In the uneven section, nondescript agencies of the note is found. Applications can also be appended by Sophie on Friday.
    On average 77 quietly abject persons are objecting markets during these basements! However, it is various that, after the waiting time has been dealt, the vengeful lorem ipsum of the following need expect to insult it.

```

* Buy a mac, install pycharm, check kpsewhich is actually working

