### PR TITLE
Fix invalid windows path, NPE and wrong executable path for native tex live

### DIFF
--- a/src/nl/hannahsten/texifyidea/completion/LatexCommandProvider.kt
+++ b/src/nl/hannahsten/texifyidea/completion/LatexCommandProvider.kt
@@ -39,6 +39,7 @@ class LatexCommandProvider internal constructor(private val mode: LatexMode) :
     CompletionProvider<CompletionParameters>() {
 
     companion object {
+
         /** Cache for commands which are indexed and which should be added to the autocompletion. */
         val indexedCommands = mutableSetOf<LookupElementBuilder>()
     }

--- a/src/nl/hannahsten/texifyidea/completion/LatexCommandProvider.kt
+++ b/src/nl/hannahsten/texifyidea/completion/LatexCommandProvider.kt
@@ -38,6 +38,11 @@ import java.util.stream.Collectors
 class LatexCommandProvider internal constructor(private val mode: LatexMode) :
     CompletionProvider<CompletionParameters>() {
 
+    companion object {
+        /** Cache for commands which are indexed and which should be added to the autocompletion. */
+        val indexedCommands = mutableSetOf<LookupElementBuilder>()
+    }
+
     override fun addCompletions(
         parameters: CompletionParameters,
         context: ProcessingContext,
@@ -77,7 +82,16 @@ class LatexCommandProvider internal constructor(private val mode: LatexMode) :
         }
     }
 
+    /**
+     * Add all indexed commands to the autocompletion.
+     */
     private fun addIndexedCommands(result: CompletionResultSet, parameters: CompletionParameters) {
+        // Use cache if available
+        if (indexedCommands.isNotEmpty()) {
+            result.addAllElements(indexedCommands)
+            return
+        }
+
         val commands = mutableSetOf<LookupElementBuilder>()
         FileBasedIndex.getInstance().getAllKeys(LatexExternalCommandIndex.id, parameters.editor.project ?: return)
             .forEach { cmdWithSlash ->
@@ -98,6 +112,7 @@ class LatexCommandProvider internal constructor(private val mode: LatexMode) :
                         .forEach { commands.add(it) }
                 }
             }
+        indexedCommands.addAll(commands)
         result.addAllElements(commands)
     }
 

--- a/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
@@ -67,7 +67,7 @@ class InputFileReference(
         // Find the sources root of the current file.
         // findRootFile will also call getImportPaths, so that will be executed twice
         val rootFile = givenRootFile ?: element.containingFile.findRootFile().virtualFile
-        val rootDirectory = rootFile.parent ?: return null
+        val rootDirectory = rootFile?.parent ?: return null
 
         var targetFile: VirtualFile? = null
 

--- a/src/nl/hannahsten/texifyidea/settings/sdk/MiktexWindowsSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/MiktexWindowsSdk.kt
@@ -33,7 +33,7 @@ class MiktexWindowsSdk : LatexSdk("MiKTeX Windows SDK") {
     override fun suggestHomePaths(): MutableCollection<String> {
         val results = mutableSetOf<String>()
         val paths = "where pdflatex".runCommand()
-        if (paths != null) {
+        if (paths != null && !paths.contains("Could not find")) { // Full output is INFO: Could not find files for the given pattern(s).
             paths.split("\r\n").forEach { path ->
                 val index = path.findLastAnyOf(setOf("miktex\\bin"))?.first ?: path.length - 1
                 results.add(path.substring(0, index))

--- a/src/nl/hannahsten/texifyidea/settings/sdk/NativeTexliveSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/NativeTexliveSdk.kt
@@ -58,7 +58,11 @@ class NativeTexliveSdk : TexliveSdk("Native TeX Live SDK") {
         return """TeX Live (\d\d\d\d\/.+)""".toRegex().find(LatexSdkUtil.pdflatexVersionText)?.value ?: "Unknown version"
     }
 
-    override fun getDefaultDocumentationUrl(sdk: Sdk): String? {
+    override fun getDefaultDocumentationUrl(sdk: Sdk): String {
         return "$texmfDistPath/doc"
+    }
+
+    override fun getExecutableName(executable: String, homePath: String): String {
+        return "$homePath/$executable"
     }
 }

--- a/src/nl/hannahsten/texifyidea/settings/sdk/TexliveSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/TexliveSdk.kt
@@ -93,6 +93,6 @@ open class TexliveSdk(name: String = "TeX Live SDK") : LatexSdk(name) {
     override fun getExecutableName(executable: String, homePath: String): String {
         // Get base path of LaTeX distribution
         val basePath = LatexSdkUtil.getPdflatexParentPath(homePath)
-        return "$basePath/$executable"
+        return if (basePath != null) "$basePath/$executable" else executable
     }
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1793 (invalid windows path)
Fix #1795 (NPE rootFile)
Fix #1796 (executable path for native tex live)

#### Summary of additions and changes

* Improve autocompletion speed especially for texlive-full installations by caching lookupbuilders in memory (not sure if this is the way to go for performance improvements, but it works)

