### PR TITLE
Add *.cbx files and biblatex-dm.cfg as LaTeX style files.

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -384,8 +384,8 @@
         <!-- Files and project -->
         <moduleType id="LATEX_MODULE_TYPE" implementationClass="nl.hannahsten.texifyidea.modules.LatexModuleType"/>
         <fileType implementationClass="nl.hannahsten.texifyidea.file.LatexFileType" name="LaTeX source file" language="Latex" extensions="tex;glstex" />
-        <fileType implementationClass="nl.hannahsten.texifyidea.file.StyleFileType" name="LaTeX style file" language="Latex" extensions="sty;dbx;bbx" /> <!-- dbx is a Biblatex Data Model, bbx a Biblatex Style -->
-        <fileType name="LaTeX style file" fileNames="biblatex.cfg" /> <!-- Biblatex configuration -->
+        <fileType implementationClass="nl.hannahsten.texifyidea.file.StyleFileType" name="LaTeX style file" language="Latex" extensions="sty;dbx;bbx;cbx" /> <!-- dbx is a Biblatex Data Model, bbx a Biblatex Style -->
+        <fileType name="LaTeX style file" fileNames="biblatex.cfg;biblatex-dm.cfg" /> <!-- Biblatex configuration -->
         <fileType implementationClass="nl.hannahsten.texifyidea.file.ClassFileType" name="LaTeX class file" language="Latex" extensions="cls" />
         <fileType implementationClass="nl.hannahsten.texifyidea.file.BibtexFileType" name="BibTeX bibliography file" language="Bibtex" extensions="bib" />
         <fileType implementationClass="nl.hannahsten.texifyidea.file.TikzFileType" name="TikZ picture file" language="Latex" extensions="tikz" />


### PR DESCRIPTION
Fix for Hannah-Sten/TeXiFy-IDEA#1804.

#### Summary of additions and changes

* Added `*.cbx` files to the LaTeX style filetype.
* Added `biblatex-dm.cfg` file to the LaTeX style filetype.

#### How to test this pull request
Just make a `.cbx` file and open it lol. Same thing for `biblatex-dm.cfg`.

#### Wiki
There was nothing in the docs mentioning `.bbx` files or `.dbx` files, so I didn't feel like I needed to document this change. This is a really small, super technical thing anyways.

<!-- Add link to updated wiki page -->
- [ ] Updated the wiki: