### PR TITLE
Replace tex formatting with html formatting in documentation popup

### DIFF
--- a/src/nl/hannahsten/texifyidea/index/file/LatexDocsRegexer.kt
+++ b/src/nl/hannahsten/texifyidea/index/file/LatexDocsRegexer.kt
@@ -14,20 +14,25 @@ object LatexDocsRegexer {
     /**
      * Regexes and replacements which clean up the documentation.
      *
+     * **test**
      * Arguments \[mop\]arg should be left in, because they are needed when adding to the autocomplete
      */
     private val formattingReplacers = listOf(
         // Commands to remove entirely,, making sure to capture in the argument nested braces
-        Pair("""\\(cite|footnote)\{(\{[^}]*}|[^}])+?}\s*""".toRegex(), { "" }),
+        Pair("""\\(cite|footnote)\{(\{[^}]*}|[^}])+?}\s*""".toRegex()) { "" },
         // \cs command from the doctools package
-        Pair("""(?<pre>[^|]|^)\\c[sn]\{(?<command>[^}]+?)}""".toRegex(), { result -> result.groups["pre"]?.value + "\\" + result.groups["command"]?.value }),
+        Pair("""(?<pre>[^|]|^)\\c[sn]\{(?<command>[^}]+?)}""".toRegex()) { result -> result.groups["pre"]?.value + "<tt>\\" + result.groups["command"]?.value + "</tt>" },
         // Other commands, except when in short verbatim
-        Pair<Regex, (MatchResult) -> String>("""(?<pre>[^|]|^)\\(?:textbf|emph|textsf|cmd|pkg|env)\{(?<argument>(\{[^}]*}|[^}])+?)}""".toRegex(), { result -> result.groups["pre"]?.value + result.groups["argument"]?.value }),
+        Pair("""(?<pre>[^|]|^)\\(?:textsf|textsc|cmd|pkg|env)\{(?<argument>(\{[^}]*}|[^}])+?)}""".toRegex()) { result -> result.groups["pre"]?.value + "<tt>" + result.groups["argument"]?.value + "</tt>" },
+        // Replace \textbf with <b> tags
+        Pair("""\\textbf\{(?<argument>(\{[^}]*}|[^}])+?)}""".toRegex()) { result -> "<b>${result.groups["argument"]?.value}</b>" },
+        // Replace \emph and \textit with <i> tags
+        Pair<Regex, (MatchResult) -> String>("""\\(textit|emph)\{(?<argument>(\{[^}]*}|[^}])+?)}""".toRegex()) { result -> "<i>${result.groups["argument"]?.value}</i>" },
         // Short verbatim, provided by ltxdoc
-        Pair("""\|""".toRegex(), { "" }),
+        Pair("""\|""".toRegex()) { "" },
         // While it is true that text reflows in the documentation popup, so we don't need linebreaks, often package authors include an environment or something else
         // which does depend on linebreaks to be readable, and therefore we keep linebreaks by default.
-        Pair("""\n""".toRegex(), { "<br>" }),
+        Pair("""\n""".toRegex()) { "<br>" },
     )
 
     /**

--- a/test/nl/hannahsten/texifyidea/index/file/LatexDocsRegexerTest.kt
+++ b/test/nl/hannahsten/texifyidea/index/file/LatexDocsRegexerTest.kt
@@ -11,7 +11,7 @@ class LatexDocsRegexerTest : BasePlatformTestCase() {
             The behaviour of the \pkg{siunitx} package is controlled by a number of key--value options. These can be given globally using the \cs{sisetup} function or locally as the optional argument to the user macros.
             \LaTeX{}
         """.trimIndent()
-        val expected = """The macro \bblastx will print the example number before last.<br>This is like \intertext but uses shorter skips between the math. <br>The behaviour of the siunitx package is controlled by a number of key--value options. These can be given globally using the \sisetup function or locally as the optional argument to the user macros.<br>\LaTeX{}"""
+        val expected = """The macro <tt>\bblastx</tt> will print the example number before last.<br>This is like <tt>\intertext</tt> but uses shorter skips between the math. <br>The behaviour of the <tt>siunitx</tt> package is controlled by a number of key--value options. These can be given globally using the <tt>\sisetup</tt> function or locally as the optional argument to the user macros.<br>\LaTeX{}"""
         assertEquals(expected, LatexDocsRegexer.format(input))
     }
 
@@ -32,6 +32,17 @@ class LatexDocsRegexerTest : BasePlatformTestCase() {
         """.trimIndent()
         val expected = """
             \circlearc\oarg{N}\marg{X}\marg{Y}\marg{RAD}\marg{ANGLE1}\marg{ANGLE2}\\
+        """.trimIndent()
+        assertEquals(expected, LatexDocsRegexer.format(input))
+    }
+
+    fun testMarkup() {
+        val input = """
+            Do \textbf{not} eat a banana before bedtime.
+            Bananas are \textit{evil}.
+        """.trimIndent()
+        val expected = """
+            Do <b>not</b> eat a banana before bedtime.<br>Bananas are <i>evil</i>.
         """.trimIndent()
         assertEquals(expected, LatexDocsRegexer.format(input))
     }

--- a/test/nl/hannahsten/texifyidea/index/file/LatexExternalCommandDataIndexerTest.kt
+++ b/test/nl/hannahsten/texifyidea/index/file/LatexExternalCommandDataIndexerTest.kt
@@ -107,7 +107,7 @@ class LatexExternalCommandDataIndexerTest : BasePlatformTestCase() {
         val file = myFixture.configureByText("doc.dtx", text)
         val map = LatexExternalCommandDataIndexer().map(MockContent(file))
         assertEquals(2, map.size)
-        assertEquals("Older releases of this environment omit the \\endgroup token,<br> when being nested. This was done to avoid unnecessary stack usage.<br> However it does not work if macro and<br> environment environments are mixed, therefore we now<br> use a simpler approach.", map["\\endenvironment"])
+        assertEquals("Older releases of this environment omit the \\endgroup token,<br> when being nested. This was done to avoid unnecessary stack usage.<br> However it does not work if <tt>macro</tt> and<br> <tt>environment</tt> environments are mixed, therefore we now<br> use a simpler approach.", map["\\endenvironment"])
         assertEquals(map["\\endenvironment"], map["\\endmacro"])
     }
 
@@ -148,7 +148,7 @@ class LatexExternalCommandDataIndexerTest : BasePlatformTestCase() {
         val file = myFixture.configureByText("doc.dtx", text)
         val map = LatexExternalCommandDataIndexer().map(MockContent(file))
         assertEquals(4, map.size)
-        assertEquals("The `module'<br> directives of the docstrip system are<br> normally recognised and invoke special formatting.", map["\\DontCheckModules"])
+        assertEquals("The `module'<br> directives of the <tt>docstrip</tt> system are<br> normally recognised and invoke special formatting.", map["\\DontCheckModules"])
         assertEquals(map["\\CheckModules"], map["\\DontCheckModules"])
         assertEquals(map["\\Module"], map["\\DontCheckModules"])
         assertEquals(map["\\AltMacroFont"], map["\\DontCheckModules"])
@@ -206,7 +206,7 @@ class LatexExternalCommandDataIndexerTest : BasePlatformTestCase() {
         """.trimIndent()
         val file = myFixture.configureByText("amsopn.dtx", text)
         val map = LatexExternalCommandDataIndexer().map(MockContent(file))
-        assertEquals("The command <tt>\\DeclareMathOperator</tt> defines the first argument to<br> be an operator name whose text is the second argument. The star<br> form means that the operator name should take limits (like <tt>\\max</tt><br> or \\lim).", map["\\DeclareMathOperator"])
+        assertEquals("The command <tt>\\DeclareMathOperator</tt> defines the first argument to<br> be an operator name whose text is the second argument. The star<br> form means that the operator name should take limits (like <tt>\\max</tt><br> or <tt>\\lim</tt>).", map["\\DeclareMathOperator"])
     }
 
     fun testDeclareTextSymbol() {

--- a/test/nl/hannahsten/texifyidea/index/file/LatexExternalCommandDataIndexerTest.kt
+++ b/test/nl/hannahsten/texifyidea/index/file/LatexExternalCommandDataIndexerTest.kt
@@ -206,7 +206,7 @@ class LatexExternalCommandDataIndexerTest : BasePlatformTestCase() {
         """.trimIndent()
         val file = myFixture.configureByText("amsopn.dtx", text)
         val map = LatexExternalCommandDataIndexer().map(MockContent(file))
-        assertEquals("The command \\DeclareMathOperator defines the first argument to<br> be an operator name whose text is the second argument. The star<br> form means that the operator name should take limits (like \\max<br> or \\lim).", map["\\DeclareMathOperator"])
+        assertEquals("The command <tt>\\DeclareMathOperator</tt> defines the first argument to<br> be an operator name whose text is the second argument. The star<br> form means that the operator name should take limits (like <tt>\\max</tt><br> or \\lim).", map["\\DeclareMathOperator"])
     }
 
     fun testDeclareTextSymbol() {

--- a/test/nl/hannahsten/texifyidea/index/file/LatexExternalEnvironmentDataIndexerTest.kt
+++ b/test/nl/hannahsten/texifyidea/index/file/LatexExternalEnvironmentDataIndexerTest.kt
@@ -26,7 +26,7 @@ class LatexExternalEnvironmentDataIndexerTest : BasePlatformTestCase() {
         """.trimIndent()
         val file = myFixture.configureByText("doc.dtx", text)
         val map = LatexExternalEnvironmentDataIndexer().map(MockContent(file))
-        assertEquals("It is often a good idea to include examples of the usage of new macros<br> in the text. Because of the % sign in the first column of every<br> row, the verbatim environment is slightly altered to suppress<br> those<br> characters.", map["verbatim"])
+        assertEquals("It is often a good idea to include examples of the usage of new macros<br> in the text. Because of the % sign in the first column of every<br> row, the <tt>verbatim</tt> environment is slightly altered to suppress<br> those<br> characters.", map["verbatim"])
     }
 
     fun testNewEnvironment() {
@@ -52,7 +52,7 @@ class LatexExternalEnvironmentDataIndexerTest : BasePlatformTestCase() {
         """.trimIndent()
         val file = myFixture.configureByText("doc.dtx", text)
         val map = LatexExternalEnvironmentDataIndexer().map(MockContent(file))
-        assertEquals("Parts of the macro definition will be surrounded by the<br> environment macrocode.  Put more precisely, they will be<br> enclosed by a macro whose argument (the text to be set<br> `verbatim') is terminated by the string<br> \\verb*+%    \\end{macrocode}+.  Carefully note the number of spaces.", map["macrocode"])
+        assertEquals("Parts of the macro definition will be surrounded by the<br> environment <tt>macrocode</tt>.  Put more precisely, they will be<br> enclosed by a macro whose argument (the text to be set<br> `verbatim') is terminated by the string<br> \\verb*+%    \\end{macrocode}+.  Carefully note the number of spaces.", map["macrocode"])
     }
 
     class MockContent(val file: PsiFile) : FileContent {


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix [TEX-91](https://texify-idea.myjetbrains.com/youtrack/issue/TEX-91)

#### Summary of additions and changes

* Use HTML formatting in documentation popups, instead of removing the latex markup.

#### How to test this pull request

Try the quick documentation popup on some commands that have bold, italics, or verbatim text:

```latex
\RubikRotation
\labelformat
```