### PR TITLE
Auto fill error report

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 group = "nl.hannahsten"
-version = "0.7.6-alpha.1"
+version = "0.7.6-alpha.2"
 
 repositories {
     mavenCentral()

--- a/src/nl/hannahsten/texifyidea/LatexErrorReportSubmitter.kt
+++ b/src/nl/hannahsten/texifyidea/LatexErrorReportSubmitter.kt
@@ -5,6 +5,7 @@ import com.beust.klaxon.JsonObject
 import com.beust.klaxon.Parser
 import com.intellij.ide.BrowserUtil
 import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.diagnostic.ErrorReportSubmitter
 import com.intellij.openapi.diagnostic.IdeaLoggingEvent
 import com.intellij.openapi.diagnostic.SubmittedReportInfo
@@ -12,6 +13,7 @@ import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.openapi.ui.showOkCancelDialog
+import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.Consumer
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion
 import java.awt.Component
@@ -50,6 +52,10 @@ class LatexErrorReportSubmitter : ErrorReportSubmitter() {
                 return latestVersionCached
             }
         }
+
+        val currentVersion by lazy {
+            PluginManagerCore.getPlugin(PluginId.getId("nl.rubensten.texifyidea"))?.version
+        }
     }
 
     @Suppress("DialogTitleCapitalization")
@@ -57,7 +63,6 @@ class LatexErrorReportSubmitter : ErrorReportSubmitter() {
 
     override fun submit(events: Array<out IdeaLoggingEvent>?, additionalInfo: String?, parentComponent: Component, consumer: Consumer<in SubmittedReportInfo>): Boolean {
 
-        val currentVersion = PluginManagerCore.getPlugin(PluginId.getId("nl.rubensten.texifyidea"))?.version
         // Don't do the check when there's no internet connection
         val latestVersion = try {
             getLatestVersion()
@@ -97,15 +102,11 @@ class LatexErrorReportSubmitter : ErrorReportSubmitter() {
             builder.append(URLEncoder.encode(title, ENCODING))
             builder.append("&body=")
 
-            builder.append(URLEncoder.encode("### Type of JetBrains IDE (IntelliJ, PyCharm, etc.) and version\n\n", ENCODING))
-            builder.append(
-                URLEncoder.encode(
-                    "### Operating System \n" +
-                            "<!-- Windows, Ubuntu, Arch Linux, MacOS, etc. -->\n\n",
-                    ENCODING
-                )
-            )
-            builder.append(URLEncoder.encode("### TeXiFy IDEA version\n\n", ENCODING))
+            val applicationInfo = ApplicationInfo.getInstance().let { "${it.fullApplicationName} (build ${it.build})" }
+            builder.append(URLEncoder.encode("### Type of JetBrains IDE (IntelliJ, PyCharm, etc.) and version\n${applicationInfo}\n\n", ENCODING))
+            val systemInfo = "${SystemInfo.OS_NAME} ${SystemInfo.OS_VERSION} (${SystemInfo.OS_ARCH})"
+            builder.append(URLEncoder.encode("### Operating System \n$systemInfo\n\n", ENCODING))
+            builder.append(URLEncoder.encode("### TeXiFy IDEA version\n$currentVersion\n\n", ENCODING))
             builder.append(URLEncoder.encode("### Description\n", ENCODING))
             builder.append(URLEncoder.encode(additionalInfo ?: "\n", ENCODING))
             builder.append(URLEncoder.encode("\n\n### Stacktrace\n```\n${body.take(7000)}\n```", ENCODING))

--- a/src/nl/hannahsten/texifyidea/LatexParserDefinition.kt
+++ b/src/nl/hannahsten/texifyidea/LatexParserDefinition.kt
@@ -52,7 +52,7 @@ class LatexParserDefinition : ParserDefinition {
         val FILE: IStubFileElementType<*> = object : IStubFileElementType<LatexFileStub>(
             Language.findInstance(LatexLanguage::class.java)
         ) {
-            override fun getStubVersion(): Int = 22
+            override fun getStubVersion(): Int = 23
         }
     }
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix [TEX-122](https://texify-idea.myjetbrains.com/youtrack/issue/TEX-122)

#### Summary of additions and changes

When submitting an error report, automatically fill in:
- IntelliJ version and build number
- OS name, version, architecture
- TeXiFy version

#### How to test this pull request

![image](https://user-images.githubusercontent.com/15685876/114297891-92580e80-9ab3-11eb-8f91-513dcafa1fb5.png)

---
Note: this is based on the [`sectioning-indent`](https://github.com/Hannah-Sten/TeXiFy-IDEA/tree/sectioning-indent) branch, so ideally that should be merged first.