### PR TITLE
Change color in color definition via gutter

### DIFF
--- a/src/nl/hannahsten/texifyidea/gutter/LatexElementColorProvider.kt
+++ b/src/nl/hannahsten/texifyidea/gutter/LatexElementColorProvider.kt
@@ -206,7 +206,7 @@ object LatexElementColorProvider : ElementColorProvider {
      */
     private fun Color.toRgbString(integer: Boolean = true): String =
         if (integer) "$red, $green, $blue"
-        else listOf(red, green, blue).map { it / 255.0 }.joinToString(", ")
+        else listOf(red, green, blue).map { it / 255.0 }.joinToString(", ") { it.format() }
 
     /**
      * Get the [Color] from an HSB string, assuming that the values are in the range [0, 1].
@@ -220,7 +220,8 @@ object LatexElementColorProvider : ElementColorProvider {
     /**
      * Convert a color to an HSB string "hue, saturation, brightness" where each value is a float in the range [0, 1].
      */
-    private fun Color.toHsbString(): String = Color.RGBtoHSB(red, green, blue, null).joinToString(", ")
+    private fun Color.toHsbString(): String = Color.RGBtoHSB(red, green, blue, null)
+        .joinToString(", ") { it.toDouble().format() }
 
     /**
      * Get a [Color] object from a cmyk (cyan, magenta, blue, black) string.
@@ -240,7 +241,7 @@ object LatexElementColorProvider : ElementColorProvider {
     private fun Color.toCmykString(): String? {
         val rgb = listOf(red, green, blue).map { it / 255.0 }
         val k: Double = 1.0 - (rgb.maxOrNull() ?: return null)
-        return rgb.map { (1.0 - it - k) / (1.0 - k) }.joinToString(", ") + ", $k"
+        return rgb.map { (1.0 - it - k) / (1.0 - k) }.joinToString(", ") { it.format() } + ", $k"
     }
 
     /**
@@ -255,8 +256,7 @@ object LatexElementColorProvider : ElementColorProvider {
      * Convert a [Color] to a cmy string.
      */
     private fun Color.toCmyString() = listOf(red, green, blue)
-        .map { 1.0 - (it / 255.0) }
-        .joinToString(", ")
+        .map { 1.0 - (it / 255.0) }.joinToString(", ") { it.format() }
 
     /**
      * Convert a gray string (i.e., one number taken from the interval [0, 1]) to a [Color].
@@ -277,7 +277,7 @@ object LatexElementColorProvider : ElementColorProvider {
     private fun Color.toGrayString() = listOf(0.2126, 0.7152, 0.0722)
         .zip(listOf(red, green, blue))
         .sumByDouble { (weight, rgb) -> weight * (rgb / 255.0) }
-        .toString()
+        .format()
 
     /**
      * Get a [Color] from a hex color string.
@@ -299,4 +299,6 @@ object LatexElementColorProvider : ElementColorProvider {
      */
     private fun Int.projectOnto(range: IntRange) = max(range.first, min(range.last, this))
     private fun Float.projectOnto(range: IntRange) = max(range.first.toFloat(), min(range.last.toFloat(), this))
+
+    private fun Double.format(digits: Int = 3) = String.format("%.${digits}f", this)
 }

--- a/src/nl/hannahsten/texifyidea/gutter/LatexElementColorProvider.kt
+++ b/src/nl/hannahsten/texifyidea/gutter/LatexElementColorProvider.kt
@@ -196,7 +196,7 @@ object LatexElementColorProvider : ElementColorProvider {
             rgb.map { it.toInt().projectOnto(0..255) }.let { Color(it[0], it[1], it[2]) }
         }
         catch (e: NumberFormatException) {
-            rgb.map { it.toFloat() }.let { Color(it[0], it[1], it[2]) }
+            rgb.map { it.toFloat().projectOnto(0..1) }.let { Color(it[0], it[1], it[2]) }
         }
     }
 
@@ -213,8 +213,9 @@ object LatexElementColorProvider : ElementColorProvider {
      */
     private fun fromHsbString(hsbText: String): Color {
         val hsb = hsbText.split(",").map { it.trim() }
-        return hsb.map { it.toFloat() }
-            .let { Color.getHSBColor(it[0], it[1], it[2]) }
+        return hsb.map { it.toFloat().projectOnto(0..1) }
+            .let { Color.getHSBColor(
+                it[0], it[1], it[2]) }
     }
 
     /**
@@ -248,7 +249,9 @@ object LatexElementColorProvider : ElementColorProvider {
      * Get a [Color] from a cmy string.
      */
     private fun fromCmyString(cmyText: String): Color {
-        val cmy = cmyText.split(",").map { it.trim() }.map { it.toFloat() }
+        val cmy = cmyText.split(",")
+            .map { it.trim() }
+            .map { it.toFloat().projectOnto(0..1) }
         return Color(1 - cmy[0], 1 - cmy[1], 1 - cmy[2])
     }
 
@@ -298,6 +301,10 @@ object LatexElementColorProvider : ElementColorProvider {
      * - the maximum of the [range] if [this] is larger than every element in the [range].
      */
     private fun Int.projectOnto(range: IntRange) = max(range.first, min(range.last, this))
+
+    /**
+     * @see [projectOnto]
+     */
     private fun Float.projectOnto(range: IntRange) = max(range.first.toFloat(), min(range.last.toFloat(), this))
 
     private fun Double.format(digits: Int = 3) = String.format("%.${digits}f", this)

--- a/src/nl/hannahsten/texifyidea/gutter/LatexElementColorProvider.kt
+++ b/src/nl/hannahsten/texifyidea/gutter/LatexElementColorProvider.kt
@@ -6,11 +6,11 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import nl.hannahsten.texifyidea.index.LatexCommandsIndex
 import nl.hannahsten.texifyidea.lang.commands.LatexXcolorCommand
+import nl.hannahsten.texifyidea.lang.commands.RequiredArgument
 import nl.hannahsten.texifyidea.psi.LatexCommands
-import nl.hannahsten.texifyidea.util.firstParentOfType
-import nl.hannahsten.texifyidea.util.getRequiredArgumentValueByName
+import nl.hannahsten.texifyidea.psi.LatexPsiHelper
+import nl.hannahsten.texifyidea.util.*
 import nl.hannahsten.texifyidea.util.magic.ColorMagic
-import nl.hannahsten.texifyidea.util.usesColor
 import java.awt.Color
 import kotlin.math.max
 import kotlin.math.min
@@ -22,8 +22,43 @@ import kotlin.math.min
  */
 object LatexElementColorProvider : ElementColorProvider {
 
-    override fun setColorTo(element: PsiElement, color: Color) {}
+    /**
+     * Set the color in the document based on changes in the color picker from the gutter.
+     *
+     * Only changes the color when we are in the gutter of a color definition. Do nothing when we are in the gutter
+     * of a color usage.
+     */
+    override fun setColorTo(element: PsiElement, color: Color) {
+        if (element is LeafPsiElement) {
+            val command = element.firstParentOfType(LatexCommands::class)
+            val commandTemplate = LatexXcolorCommand.values().firstOrNull {
+                it.commandWithSlash == command?.name
+            } ?: return
+            val colorModel = command?.getRequiredArgumentValueByName("model-list") ?: return
+            val oldColor = command.getRequiredArgumentValueByName("spec-list") ?: return
+            val newColorString = when (colorModel.toLowerCase()) {
+                "rgb" -> color.toRgbString(integer = oldColor.split(",").firstOrNull()?.contains('.') == false)
+                "hsb" -> color.toHsbString()
+                "html" -> color.toHtmlStsring()
+                "gray" -> color.toGrayString()
+                "cmyk" -> color.toCmykString()
+                "cmy" -> color.toCmyString()
+                else -> null
+            } ?: return
 
+            val colorArgumentIndex =
+                commandTemplate.arguments.filterIsInstance<RequiredArgument>().indexOfFirst { it.name == "spec-list" }
+            if (colorArgumentIndex == -1) return
+
+            val newColorParameter = LatexPsiHelper(element.project).createRequiredParameter(newColorString)
+            val oldColorParameter = command.requiredParameters()[colorArgumentIndex]
+            oldColorParameter.parent.node.replaceChild(oldColorParameter.node, newColorParameter.node)
+        }
+    }
+
+    /**
+     * Get the color that is used in a command that uses color. This color will be shown in the gutter.
+     */
     override fun getColorFrom(element: PsiElement): Color? {
         if (element is LeafPsiElement) {
             val command = element.firstParentOfType(LatexCommands::class)
@@ -62,9 +97,11 @@ object LatexElementColorProvider : ElementColorProvider {
             // and we did not find it in the default colors (above), it should be in the
             // first parameter of a color definition command. If not, we can not find the
             // color (and return null in the end).
-            if (colorName.contains('!') || colorDefiningCommands.map { it.getRequiredArgumentValueByName("name") }.contains(colorName)) {
+            if (colorName.contains('!') || colorDefiningCommands.map { it.getRequiredArgumentValueByName("name") }
+                    .contains(colorName)) {
 
-                val colorDefinitionCommand = colorDefiningCommands.find { it.getRequiredArgumentValueByName("name") == colorName }
+                val colorDefinitionCommand =
+                    colorDefiningCommands.find { it.getRequiredArgumentValueByName("name") == colorName }
                 when (colorDefinitionCommand?.name?.substring(1)) {
                     LatexXcolorCommand.COLORLET.command -> {
                         getColorFromColorParameter(file, colorDefinitionCommand.getRequiredArgumentValueByName("color"))
@@ -83,7 +120,7 @@ object LatexElementColorProvider : ElementColorProvider {
     }
 
     /**
-     * Given the [color] parameter of a command, compute the defined color.
+     * Given the color parameter [definitionText] of a command, compute the defined color.
      */
     private fun getColorFromColorParameter(file: PsiFile, definitionText: String?): Color? {
         definitionText ?: return null
@@ -148,26 +185,46 @@ object LatexElementColorProvider : ElementColorProvider {
         }
     }
 
+    /**
+     * Get the [Color] from an RGB string, where the RGB values are either
+     * - integers in the range [0, 255],
+     * - or floats in the range [0, 1].
+     */
     private fun fromRgbString(rgbText: String): Color {
         val rgb = rgbText.split(",").map { it.trim() }
         return try {
             rgb.map { it.toInt().projectOnto(0..255) }.let { Color(it[0], it[1], it[2]) }
         }
         catch (e: NumberFormatException) {
-            rgb.map { it.toFloat().projectOnto(0..255) }.let { Color(it[0], it[1], it[2]) }
+            rgb.map { it.toFloat() }.let { Color(it[0], it[1], it[2]) }
         }
     }
 
+    /**
+     * Convert a [Color] object to an RGB string "R, G, B" with R, G, and B integers in the range [0, 255] if [integer]
+     * is true, and R, G, and B floats in the range [0, 1] otherwise.
+     */
+    private fun Color.toRgbString(integer: Boolean = true): String =
+        if (integer) "$red, $green, $blue"
+        else listOf(red, green, blue).map { it / 255.0 }.joinToString(", ")
+
+    /**
+     * Get the [Color] from an HSB string, assuming that the values are in the range [0, 1].
+     */
     private fun fromHsbString(hsbText: String): Color {
         val hsb = hsbText.split(",").map { it.trim() }
         return hsb.map { it.toFloat() }
-            .let { Color.getHSBColor(
-                it[0].projectOnto(0..360),
-                it[1].projectOnto(0..100),
-                it[2].projectOnto(0..100)
-            ) }
+            .let { Color.getHSBColor(it[0], it[1], it[2]) }
     }
 
+    /**
+     * Convert a color to an HSB string "hue, saturation, brightness" where each value is a float in the range [0, 1].
+     */
+    private fun Color.toHsbString(): String = Color.RGBtoHSB(red, green, blue, null).joinToString(", ")
+
+    /**
+     * Get a [Color] object from a cmyk (cyan, magenta, blue, black) string.
+     */
     private fun fromCmykString(cmykText: String): Color {
         val cmyk = cmykText.split(",").map { it.trim() }
             .map { it.toFloat() }
@@ -177,20 +234,62 @@ object LatexElementColorProvider : ElementColorProvider {
             .let { Color(it[0], it[1], it[2]) }
     }
 
+    /**
+     * Convert a [Color] object to a cmyk string.
+     */
+    private fun Color.toCmykString(): String? {
+        val rgb = listOf(red, green, blue).map { it / 255.0 }
+        val k: Double = 1.0 - (rgb.maxOrNull() ?: return null)
+        return rgb.map { (1.0 - it - k) / (1.0 - k) }.joinToString(", ") + ", $k"
+    }
+
+    /**
+     * Get a [Color] from a cmy string.
+     */
     private fun fromCmyString(cmyText: String): Color {
         val cmy = cmyText.split(",").map { it.trim() }.map { it.toFloat() }
         return Color(1 - cmy[0], 1 - cmy[1], 1 - cmy[2])
     }
 
+    /**
+     * Convert a [Color] to a cmy string.
+     */
+    private fun Color.toCmyString() = listOf(red, green, blue)
+        .map { 1.0 - (it / 255.0) }
+        .joinToString(", ")
+
+    /**
+     * Convert a gray string (i.e., one number taken from the interval [0, 1]) to a [Color].
+     */
     private fun fromGrayString(grayText: String): Color {
         fun Float.toRgb() = (this * 255).toInt()
         val gray = grayText.toFloat().projectOnto(0..255)
         return Color(gray.toRgb(), gray.toRgb(), gray.toRgb())
     }
 
+    /**
+     * Get a grayscale number from a [Color] object.
+     *
+     * When the color itself is not gray, it is converted to grayscale by using weights for each color vector [`[1]`](https://en.wikipedia.org/wiki/Grayscale#Converting_color_to_grayscale).
+     *
+     * 1. [https://en.wikipedia.org/wiki/Grayscale#Converting_color_to_grayscale](https://en.wikipedia.org/wiki/Grayscale#Converting_color_to_grayscale)
+     */
+    private fun Color.toGrayString() = listOf(0.2126, 0.7152, 0.0722)
+        .zip(listOf(red, green, blue))
+        .sumByDouble { (weight, rgb) -> weight * (rgb / 255.0) }
+        .toString()
+
+    /**
+     * Get a [Color] from a hex color string.
+     */
     private fun fromHtmlString(htmlText: String): Color {
         return Color.decode("#$htmlText")
     }
+
+    /**
+     * Get the hex string of a [Color], without leading #.
+     */
+    private fun Color.toHtmlStsring() = "${red.toHexString()}${green.toHexString()}${blue.toHexString()}"
 
     /**
      * Project [this] onto [range] by taking


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1858 

#### Summary of additions and changes

* Fix index out of bounds exception when color values are out of the range that their color model supports.
* Add support for setting a color definition by using the color picker from the color icon in the gutter.

#### How to test this pull request

```latex
\definecolor{jkl}{RGB}{300, 7, 7}
\definecolor{crashycrash}{RGB}{0.918, 0.439, 0.020}
\definecolor{blueish}{RGB}{229, 225, 15}
\definecolor{bloop}{HTML}{4cbb23}
\definecolor{whaaa}{cmy}{0.537, 0.063, 0.133}
\definecolor{help}{hsb}{0.800, 0.425, 0.655}
\definecolor{moon}{gray}{0.188}
```

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Color-preview