### PR TITLE
Fix Grazie LatexGrammarCheckingStrategy off by one error

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/LatexGrammarCheckingStrategy.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/LatexGrammarCheckingStrategy.kt
@@ -35,7 +35,12 @@ class LatexGrammarCheckingStrategy : GrammarCheckingStrategy {
             // Ranges that we need to keep
             // Note that textRangeInParent will not be correct because that's the text range in the direct parent, not in the root
             // Also note that ranges have to be valid in 'text' and not in 'root'
-            .flatMap { listOf(it.textRange.startOffset - root.startOffset, it.textRange.endOffset - root.startOffset) }
+            .flatMap {
+                listOf(
+                    it.textRange.startOffset - root.startOffset - 1,
+                    it.textRange.endOffset - root.startOffset + 1
+                )
+            }
             .sorted()
             .toMutableList()
             // Make sure that if the root does not start/end with normal text, that those parts are excluded

--- a/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
@@ -39,7 +39,6 @@ class GrazieInspectionTest : BasePlatformTestCase() {
         myFixture.checkHighlighting(true, false, false, true)
     }
 
-
     fun testInlineMath() {
         myFixture.configureByText(
             LatexFileType, """Does Grazie detect ${'$'}m$ as a sentence?

--- a/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
@@ -33,9 +33,18 @@ class GrazieInspectionTest : BasePlatformTestCase() {
         myFixture.checkHighlighting(true, false, false, true)
     }
 
+    fun testMultilineCheckGrammar() {
+        val testName = getTestName(false)
+        myFixture.configureByFile("$testName.tex")
+        myFixture.checkHighlighting(true, false, false, true)
+    }
+
+
     fun testInlineMath() {
-        myFixture.configureByText(LatexFileType, """Does Grazie detect ${'$'}m$ as a sentence?
-""")
+        myFixture.configureByText(
+            LatexFileType, """Does Grazie detect ${'$'}m$ as a sentence?
+"""
+        )
         myFixture.checkHighlighting()
     }
 }

--- a/test/resources/inspections/grazie/MultilineCheckGrammar.tex
+++ b/test/resources/inspections/grazie/MultilineCheckGrammar.tex
@@ -1,0 +1,4 @@
+\begin{document}
+    <warning descr="EN_A_VS_AN">A</warning> apple a day keeps the doctor away.
+    Some other sentence.
+\end{document}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1857 

#### Summary of additions and changes

* Fix an off by one error which caused Grazie to see a cut off version of the first/last sentence (without the first/last character)

#### How to test this pull request

See the included test case or the example in #1857 
