### PR TITLE
Executing commands on Mac

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 group = "nl.hannahsten"
-version = "0.7.6"
+version = "0.7.7-alpha-cl445-2"
 
 repositories {
     mavenCentral()

--- a/src/nl/hannahsten/texifyidea/ui/PreviewFormUpdater.kt
+++ b/src/nl/hannahsten/texifyidea/ui/PreviewFormUpdater.kt
@@ -7,11 +7,11 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import nl.hannahsten.texifyidea.settings.sdk.LatexSdkUtil
 import nl.hannahsten.texifyidea.util.SystemEnvironment
+import nl.hannahsten.texifyidea.util.runCommandWithExitCode
 import java.io.File
 import java.io.IOException
 import java.io.PrintWriter
 import java.nio.file.Paths
-import java.util.concurrent.TimeUnit
 import javax.imageio.ImageIO
 import javax.swing.SwingUtilities.invokeLater
 
@@ -78,7 +78,7 @@ $previewCode
                 writer.println(tmpContent)
                 writer.close()
 
-                val latexStdoutText = runCommand(
+                val latexStdoutText = runPreviewFormCommand(
                     LatexSdkUtil.getExecutableName("pdflatex", project),
                     arrayOf(
                         "-interaction=nonstopmode",
@@ -128,7 +128,7 @@ $previewCode
     private fun runInkscape(tempBasename: String, tempDirectory: File) {
         // If 1.0 or higher
         if (SystemEnvironment.inkscapeMajorVersion >= 1) {
-            runCommand(
+            runPreviewFormCommand(
                 inkscapeExecutable(),
                 arrayOf(
                     "$tempBasename.pdf",
@@ -142,7 +142,7 @@ $previewCode
             ) ?: throw AccessDeniedException(tempDirectory)
         }
         else {
-            runCommand(
+            runPreviewFormCommand(
                 pdf2svgExecutable(),
                 arrayOf(
                     "$tempBasename.pdf",
@@ -151,7 +151,7 @@ $previewCode
                 tempDirectory
             ) ?: return
 
-            runCommand(
+            runPreviewFormCommand(
                 inkscapeExecutable(),
                 arrayOf(
                     "$tempBasename.svg",
@@ -165,28 +165,16 @@ $previewCode
         }
     }
 
-    private fun runCommand(command: String, args: Array<String>, workDirectory: File): String? {
+    private fun runPreviewFormCommand(command: String, args: Array<String>, workDirectory: File): String? {
 
-        val executable = Runtime.getRuntime().exec(
-            arrayOf(command) + args,
-            null,
-            workDirectory
-        )
+        val result = runCommandWithExitCode(command, *args, workingDirectory = workDirectory, timeout = waitTime)
 
-        val (stdout, stderr) = executable.inputStream.bufferedReader().use { stdout ->
-            executable.errorStream.bufferedReader().use { stderr ->
-                Pair(stdout.readText(), stderr.readText())
-            }
-        }
-
-        executable.waitFor(waitTime, TimeUnit.SECONDS)
-
-        if (executable.exitValue() != 0) {
-            previewForm.setLatexErrorMessage("$command exited with ${executable.exitValue()}\n$stdout\n$stderr")
+        if (result.second != 0) {
+            previewForm.setLatexErrorMessage("$command exited with ${result.second}\n${result.first}")
             return null
         }
 
-        return stdout
+        return result.first
     }
 
     private fun inkscapeExecutable(): String {

--- a/src/nl/hannahsten/texifyidea/util/SystemEnvironment.kt
+++ b/src/nl/hannahsten/texifyidea/util/SystemEnvironment.kt
@@ -1,6 +1,7 @@
 package nl.hannahsten.texifyidea.util
 
 import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.ProcessNotCreatedException
 import java.io.File
 import java.io.IOException
 import java.util.concurrent.TimeUnit
@@ -39,22 +40,34 @@ class SystemEnvironment {
  * @return The output of the command or null if an exception was thrown.
  */
 fun runCommand(vararg commands: String, workingDirectory: File? = null): String? {
+    return runCommandWithExitCode(*commands, workingDirectory = workingDirectory).first
+}
+
+/**
+ * See [runCommand], but also returns exit code.
+ */
+fun runCommandWithExitCode(vararg commands: String, workingDirectory: File? = null, timeout: Long = 3): Pair<String?, Int> {
     return try {
         val proc = GeneralCommandLine(*commands)
             .withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE)
             .withWorkDirectory(workingDirectory)
             .createProcess()
 
-        if (proc.waitFor(3, TimeUnit.SECONDS)) {
-            proc.inputStream.bufferedReader().readText().trim() + proc.errorStream.bufferedReader().readText().trim()
+        if (proc.waitFor(timeout, TimeUnit.SECONDS)) {
+            val output = proc.inputStream.bufferedReader().readText().trim() + proc.errorStream.bufferedReader().readText().trim()
+            return Pair(output, proc.exitValue())
         }
         else {
             proc.destroy()
             proc.waitFor()
-            null
+            Pair(null, proc.exitValue())
         }
     }
     catch (e: IOException) {
-        null // Don't print the stacktrace because that is confusing.
+        Pair(null, -1) // Don't print the stacktrace because that is confusing.
+    }
+    catch (e: ProcessNotCreatedException) {
+        // e.g. if the command is just trying if a program can be run or not, and it's not the case
+        Pair(null, -1)
     }
 }

--- a/src/nl/hannahsten/texifyidea/util/SystemEnvironment.kt
+++ b/src/nl/hannahsten/texifyidea/util/SystemEnvironment.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.util
 
+import com.intellij.execution.configurations.GeneralCommandLine
 import java.io.File
 import java.io.IOException
 import java.util.concurrent.TimeUnit
@@ -39,12 +40,10 @@ class SystemEnvironment {
  */
 fun runCommand(vararg commands: String, workingDirectory: File? = null): String? {
     return try {
-        val command = arrayListOf(*commands)
-        val proc = ProcessBuilder(command)
-            .redirectOutput(ProcessBuilder.Redirect.PIPE)
-            .redirectError(ProcessBuilder.Redirect.PIPE)
-            .directory(workingDirectory)
-            .start()
+        val proc = GeneralCommandLine(*commands)
+            .withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE)
+            .withWorkDirectory(workingDirectory)
+            .createProcess()
 
         if (proc.waitFor(3, TimeUnit.SECONDS)) {
             proc.inputStream.bufferedReader().readText().trim() + proc.errorStream.bufferedReader().readText().trim()

--- a/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
@@ -2,9 +2,8 @@ package nl.hannahsten.texifyidea.util.files
 
 import com.intellij.openapi.project.Project
 import nl.hannahsten.texifyidea.settings.sdk.LatexSdkUtil
-import java.io.BufferedReader
+import nl.hannahsten.texifyidea.util.runCommand
 import java.io.IOException
-import java.io.InputStreamReader
 
 /**
  * Cache locations of LaTeX packages in memory, because especially on Windows they can be expensive to retrieve
@@ -41,9 +40,7 @@ object LatexPackageLocationCache {
         else {
             "${LatexSdkUtil.getExecutableName("kpsewhich", project)} $arg"
         }
-        BufferedReader(
-                InputStreamReader(Runtime.getRuntime().exec(command).inputStream)
-        ).readLine() // Returns null if no line read.
+        command.runCommand()
     }
     catch (e: IOException) {
         null


### PR DESCRIPTION
Fix #1874, now for real.
Fix #962 (same cause)
Fix #1407 (same cause)

I found something to resolve the issue that we cannot run any latex executables on Mac because PATH is not known to us, see `EnvironmentUtil.getEnvironmentMap()`, but it seems to break all the tests.