### PR TITLE
Fix bug in updating psi tree when inserting an optional label parameter for an environment

### DIFF
--- a/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMissingLabelInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMissingLabelInspectionTest.kt
@@ -3,6 +3,8 @@ package nl.hannahsten.texifyidea.inspections.latex.codestyle
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
 import nl.hannahsten.texifyidea.lang.CommandManager
+import nl.hannahsten.texifyidea.psi.LatexKeyvalPair
+import nl.hannahsten.texifyidea.util.childrenOfType
 
 class LatexMissingLabelInspectionTest : TexifyInspectionTestBase(LatexMissingLabelInspection()) {
 
@@ -160,20 +162,24 @@ class LatexMissingLabelInspectionTest : TexifyInspectionTestBase(LatexMissingLab
         """.trimIndent()
     )
 
-    fun `test quick fix in listings with other parameters`() = testQuickFix(
-        before = """
-        \begin{document}
-            \begin{lstlisting}[someoption,otheroption={with value}]
-            \end{lstlisting}
-        \end{document}
-        """.trimIndent(),
-        after = """
-        \begin{document}
-            \begin{lstlisting}[someoption,otheroption={with value},label={lst:lstlisting}]
-            \end{lstlisting}
-        \end{document}
-        """.trimIndent()
-    )
+    fun `test quick fix in listings with other parameters`() {
+        testQuickFix(
+            before = """
+                \begin{document}
+                    \begin{lstlisting}[someoption,otheroption={with value}]
+                    \end{lstlisting}
+                \end{document}
+            """.trimIndent(),
+            after = """
+                \begin{document}
+                    \begin{lstlisting}[someoption,otheroption={with value},label={lst:lstlisting}]
+                    \end{lstlisting}
+                \end{document}
+            """.trimIndent()
+        )
+        // Sometimes, errors in psi structure only show when initiating a WalkingState
+        myFixture.file.children.first().childrenOfType(LatexKeyvalPair::class)
+    }
 
     fun `test fix all missing label problems in this file`() = testQuickFixAll(
             before = """


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1947

#### Summary of additions and changes


* `LatexPsiHelper#createFromText` returns a PsiFile, but when creating a psi element for a comma this PsiFile was actually inserted in the psi tree which was then automatically replaced by a DummyHolder, which then caused the WalkingState to fail because DummyHolder's `prevSibling` is not correct. So the error would actually only show when you walk the psi tree, which is why the test originally passed. Fixed it by inserting the actual element of the comma token.

@fberlakovich This was a quite hard to find bug, so maybe good to take note.

#### How to test this pull request

See `LatexMissingLabelInspectionTest#test quick fix in listings with other parameters`
