### PR TITLE
Re-enable forward search action for sumatra

### DIFF
--- a/src/nl/hannahsten/texifyidea/action/ForwardSearchAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/ForwardSearchAction.kt
@@ -27,7 +27,7 @@ open class ForwardSearchAction(var viewer: PdfViewer? = null) : EditorAction(
 
         when (viewer) {
             is ExternalPdfViewer -> (viewer as ExternalPdfViewer).forwardSearch(null, file.path, line, project, focusAllowed = true)
-            is InternalPdfViewer -> (viewer as InternalPdfViewer).conversation!!.forwardSearch(null, file.path, line, project, focusAllowed = true)
+            is InternalPdfViewer -> (viewer as InternalPdfViewer).conversation?.forwardSearch(null, file.path, line, project, focusAllowed = true)
             else -> return
         }
     }

--- a/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/InternalPdfViewer.kt
+++ b/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/InternalPdfViewer.kt
@@ -6,6 +6,7 @@ import nl.hannahsten.texifyidea.run.linuxpdfviewer.okular.OkularConversation
 import nl.hannahsten.texifyidea.run.linuxpdfviewer.skim.SkimConversation
 import nl.hannahsten.texifyidea.run.linuxpdfviewer.zathura.ZathuraConversation
 import nl.hannahsten.texifyidea.run.pdfviewer.PdfViewer
+import nl.hannahsten.texifyidea.run.sumatra.SumatraConversation
 import nl.hannahsten.texifyidea.run.sumatra.isSumatraAvailable
 import nl.hannahsten.texifyidea.util.runCommand
 
@@ -26,7 +27,7 @@ enum class InternalPdfViewer(
     OKULAR("okular", "Okular", OkularConversation),
     ZATHURA("zathura", "Zathura", ZathuraConversation),
     SKIM("skim", "Skim", SkimConversation),
-    SUMATRA("sumatra", "Sumatra", null), // Dummy options to support Windows
+    SUMATRA("sumatra", "Sumatra", SumatraConversation()),
     NONE("", "No PDF viewer", null);
 
     override fun isAvailable(): Boolean = availability[this] ?: false

--- a/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/OpenViewerListener.kt
+++ b/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/OpenViewerListener.kt
@@ -30,7 +30,7 @@ class OpenViewerListener(
             runAsync {
                 try {
                     when (viewer) {
-                        is InternalPdfViewer -> viewer.conversation!!.forwardSearch(pdfPath = runConfig.outputFilePath, sourceFilePath = sourceFilePath, line = line, project = project, focusAllowed = focusAllowed)
+                        is InternalPdfViewer -> viewer.conversation?.forwardSearch(pdfPath = runConfig.outputFilePath, sourceFilePath = sourceFilePath, line = line, project = project, focusAllowed = focusAllowed)
                         is ExternalPdfViewer -> viewer.forwardSearch(pdfPath = runConfig.outputFilePath, sourceFilePath = sourceFilePath, line = line, project = project, focusAllowed = focusAllowed)
                         else -> {}
                     }

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraConversation.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraConversation.kt
@@ -71,14 +71,16 @@ class SumatraConversation : ViewerConversation() {
 
     private val server = "SUMATRA"
     private val topic = "control"
-    private val conversation: DDEClientConversation?
+    private var conversation: DDEClientConversation? = null
 
     init {
-        try {
-            conversation = DDEClientConversation()
-        }
-        catch (e: NoClassDefFoundError) {
-            throw TeXception("Native library DLLs could not be found.", e)
+        if (isSumatraAvailable) {
+            try {
+                conversation = DDEClientConversation()
+            }
+            catch (e: NoClassDefFoundError) {
+                throw TeXception("Native library DLLs could not be found.", e)
+            }
         }
     }
 
@@ -127,7 +129,7 @@ class SumatraConversation : ViewerConversation() {
     private fun execute(vararg commands: String) {
         try {
             conversation!!.connect(server, topic)
-            conversation.execute(commands.joinToString(separator = "") { "[$it]" })
+            conversation!!.execute(commands.joinToString(separator = "") { "[$it]" })
         }
         catch (e: Exception) {
             throw TeXception("Connection to SumatraPDF was disrupted.", e)

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraConversation.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraConversation.kt
@@ -1,8 +1,10 @@
 package nl.hannahsten.texifyidea.run.sumatra
 
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import com.pretty_tools.dde.client.DDEClientConversation
 import nl.hannahsten.texifyidea.TeXception
+import nl.hannahsten.texifyidea.run.linuxpdfviewer.ViewerConversation
 import nl.hannahsten.texifyidea.util.Log
 import java.io.IOException
 
@@ -65,10 +67,10 @@ private fun isSumatraInstalled(): Boolean {
  * @author Sten Wessel
  * @since b0.4
  */
-object SumatraConversation {
+class SumatraConversation : ViewerConversation() {
 
-    private const val server = "SUMATRA"
-    private const val topic = "control"
+    private val server = "SUMATRA"
+    private val topic = "control"
     private val conversation: DDEClientConversation?
 
     init {
@@ -95,6 +97,10 @@ object SumatraConversation {
             }
             processBuilder.start()
         }
+    }
+
+    override fun forwardSearch(pdfPath: String?, sourceFilePath: String, line: Int, project: Project, focusAllowed: Boolean) {
+        forwardSearch(pdfPath, sourceFilePath, line, focus=focusAllowed)
     }
 
     /**

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraConversation.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraConversation.kt
@@ -100,7 +100,7 @@ class SumatraConversation : ViewerConversation() {
     }
 
     override fun forwardSearch(pdfPath: String?, sourceFilePath: String, line: Int, project: Project, focusAllowed: Boolean) {
-        forwardSearch(pdfPath, sourceFilePath, line, focus=focusAllowed)
+        forwardSearch(pdfPath, sourceFilePath, line, focus = focusAllowed)
     }
 
     /**

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraForwardSearchListener.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraForwardSearchListener.kt
@@ -3,11 +3,14 @@ package nl.hannahsten.texifyidea.run.sumatra
 import com.intellij.execution.process.ProcessEvent
 import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.util.Key
 import nl.hannahsten.texifyidea.TeXception
+import nl.hannahsten.texifyidea.action.ForwardSearchAction
 import nl.hannahsten.texifyidea.psi.LatexEnvironment
 import nl.hannahsten.texifyidea.run.latex.LatexRunConfiguration
+import nl.hannahsten.texifyidea.run.linuxpdfviewer.InternalPdfViewer
 import nl.hannahsten.texifyidea.util.caretOffset
 import nl.hannahsten.texifyidea.util.files.document
 import nl.hannahsten.texifyidea.util.files.isRoot
@@ -29,11 +32,13 @@ class SumatraForwardSearchListener(
         // First check if the user provided a custom path to SumatraPDF, if not, check if it is installed
         if (event.exitCode == 0 && (runConfig.sumatraPath != null || isSumatraAvailable)) {
             try {
-                SumatraConversation.openFile(runConfig.outputFilePath, sumatraPath = runConfig.sumatraPath)
+                SumatraConversation().openFile(runConfig.outputFilePath, sumatraPath = runConfig.sumatraPath)
             }
             catch (ignored: TeXception) {
             }
         }
+
+        (ActionManager.getInstance().getAction("texify.ForwardSearch") as? ForwardSearchAction)?.viewer = InternalPdfViewer.SUMATRA
 
         // Forward search.
         invokeLater {
@@ -63,7 +68,7 @@ class SumatraForwardSearchListener(
                     // Otherwise the person is out of luck ¯\_(ツ)_/¯
                     Thread.sleep(1250)
                     // Never focus, because forward search will work fine without focus, and the user might want to continue typing after doing forward search/compiling
-                    SumatraConversation.forwardSearch(sourceFilePath = psiFile.virtualFile.path, line = line, focus = false)
+                    SumatraConversation().forwardSearch(sourceFilePath = psiFile.virtualFile.path, line = line, focus = false)
                 }
                 catch (ignored: TeXception) {
                 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1896

#### Summary of additions and changes

* It got disabled when the workflow was changed for other pdf viewers, and sumatra is handled separately. This should be improved with the new run configuration, but at least it works now again.

#### How to test this pull request

Install Sumatra, compile, try to forward search.

