### PR TITLE
Implement 'build project' button

### DIFF
--- a/resources/META-INF/extensions/run-configurations.xml
+++ b/resources/META-INF/extensions/run-configurations.xml
@@ -5,5 +5,6 @@
         <configurationType implementation="nl.hannahsten.texifyidea.run.makeindex.MakeindexRunConfigurationType"/>
         <configurationType implementation="nl.hannahsten.texifyidea.run.latex.externaltool.ExternalToolRunConfigurationType"/>
         <runConfigurationProducer implementation="nl.hannahsten.texifyidea.run.latex.LatexRunConfigurationProducer"/>
+        <projectTaskRunner implementation="nl.hannahsten.texifyidea.run.LatexProjectTaskRunner" />
     </extensions>
 </idea-plugin>

--- a/src/nl/hannahsten/texifyidea/run/LatexProjectTaskRunner.kt
+++ b/src/nl/hannahsten/texifyidea/run/LatexProjectTaskRunner.kt
@@ -1,0 +1,45 @@
+package nl.hannahsten.texifyidea.run
+
+import com.intellij.execution.RunManager
+import com.intellij.execution.executors.DefaultRunExecutor
+import com.intellij.execution.impl.RunConfigurationBeforeRunProvider
+import com.intellij.execution.impl.RunManagerImpl
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.execution.runners.ExecutionEnvironmentBuilder
+import com.intellij.openapi.project.Project
+import com.intellij.task.*
+import nl.hannahsten.texifyidea.modules.LatexModuleType
+import nl.hannahsten.texifyidea.util.getLatexRunConfigurations
+import org.jetbrains.concurrency.AsyncPromise
+import org.jetbrains.concurrency.Promise
+
+/**
+ * This implements the 'build project' button, to the left of the run config dropdown.
+ * It's not completely clear what it should be doing, but I think in other languages it just builds
+ * the complete project, so I think the most sensible is to run all run configurations.
+ */
+class LatexProjectTaskRunner : ProjectTaskRunner() {
+    override fun canRun(projectTask: ProjectTask): Boolean {
+        return projectTask is ModuleBuildTask && projectTask.module.moduleTypeName == LatexModuleType.ID
+    }
+
+    override fun run(project: Project, context: ProjectTaskContext, vararg tasks: ProjectTask?): Promise<Result> {
+        // Each task will probably be a module, but we don't use it
+
+
+        project.getLatexRunConfigurations().forEach { runConfig ->
+            val latexSettings = RunManagerImpl.getInstanceImpl(project).getSettings(runConfig) ?: return@forEach
+            val environment = ExecutionEnvironmentBuilder.createOrNull(DefaultRunExecutor.getRunExecutorInstance(), latexSettings)?.build() ?: return@forEach
+            RunConfigurationBeforeRunProvider.doExecuteTask(environment, latexSettings, null)
+        }
+
+        // Not sure what we're suppose to return
+        val promise = AsyncPromise<Result>()
+        // TaskRunnerResults.SUCCESS is experimental, we cannot use it
+        promise.setResult(object : Result {
+            override fun isAborted() = false
+            override fun hasErrors() = false
+        })
+        return promise
+    }
+}

--- a/src/nl/hannahsten/texifyidea/run/LatexProjectTaskRunner.kt
+++ b/src/nl/hannahsten/texifyidea/run/LatexProjectTaskRunner.kt
@@ -1,10 +1,8 @@
 package nl.hannahsten.texifyidea.run
 
-import com.intellij.execution.RunManager
 import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.execution.impl.RunConfigurationBeforeRunProvider
 import com.intellij.execution.impl.RunManagerImpl
-import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.ExecutionEnvironmentBuilder
 import com.intellij.openapi.project.Project
 import com.intellij.task.*
@@ -19,6 +17,7 @@ import org.jetbrains.concurrency.Promise
  * the complete project, so I think the most sensible is to run all run configurations.
  */
 class LatexProjectTaskRunner : ProjectTaskRunner() {
+
     override fun canRun(projectTask: ProjectTask): Boolean {
         return projectTask is ModuleBuildTask && projectTask.module.moduleTypeName == LatexModuleType.ID
     }
@@ -26,10 +25,10 @@ class LatexProjectTaskRunner : ProjectTaskRunner() {
     override fun run(project: Project, context: ProjectTaskContext, vararg tasks: ProjectTask?): Promise<Result> {
         // Each task will probably be a module, but we don't use it
 
-
         project.getLatexRunConfigurations().forEach { runConfig ->
             val latexSettings = RunManagerImpl.getInstanceImpl(project).getSettings(runConfig) ?: return@forEach
-            val environment = ExecutionEnvironmentBuilder.createOrNull(DefaultRunExecutor.getRunExecutorInstance(), latexSettings)?.build() ?: return@forEach
+            val environment = ExecutionEnvironmentBuilder.createOrNull(DefaultRunExecutor.getRunExecutorInstance(), latexSettings)?.build()
+                ?: return@forEach
             RunConfigurationBeforeRunProvider.doExecuteTask(environment, latexSettings, null)
         }
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1965 

#### Summary of additions and changes

* The 'build project' button will now run all run configurations in the project (because I had to choose something, and this seemed the most sensible thing)

#### How to test this pull request

Click 'build project'

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki