### PR TITLE
Avoid indexing commands in latex package sources, maybe fixes #1842

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,7 +135,7 @@ intellij {
     pluginName = "TeXiFy-IDEA"
 
     // indices plugin doesn't work in tests
-    setPlugins("tanvd.grazi", "java") // , "com.firsttimeinforever.intellij.pdf.viewer.intellij-pdf-viewer:0.10.0") // , "com.jetbrains.hackathon.indices.viewer:1.12")
+    setPlugins("tanvd.grazi", "java") // , "com.firsttimeinforever.intellij.pdf.viewer.intellij-pdf-viewer:0.10.0") // , "com.jetbrains.hackathon.indices.viewer:1.13")
 
     // Use the since build number from plugin.xml
     updateSinceUntilBuild = false

--- a/src/nl/hannahsten/texifyidea/completion/pathcompletion/LatexGraphicsPathProvider.kt
+++ b/src/nl/hannahsten/texifyidea/completion/pathcompletion/LatexGraphicsPathProvider.kt
@@ -3,10 +3,12 @@ package nl.hannahsten.texifyidea.completion.pathcompletion
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.index.LatexIncludesIndex
+import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexNormalText
 import nl.hannahsten.texifyidea.util.childrenOfType
 import nl.hannahsten.texifyidea.util.files.*
+import nl.hannahsten.texifyidea.util.magic.cmd
 import java.io.File
 
 /**
@@ -31,7 +33,7 @@ class LatexGraphicsPathProvider : LatexPathProviderBase() {
      */
     private fun getGraphicsPaths(file: PsiFile): List<String> {
         val graphicsPaths = mutableListOf<String>()
-        val graphicsPathCommands = file.commandsInFileSet().filter { it.name == "\\graphicspath" }
+        val graphicsPathCommands = file.commandsInFileSet().filter { it.name == LatexGenericRegularCommand.GRAPHICSPATH.cmd }
 
         // Is a graphicspath defined?
         if (graphicsPathCommands.isNotEmpty()) {

--- a/src/nl/hannahsten/texifyidea/index/stub/LatexCommandsStubElementType.kt
+++ b/src/nl/hannahsten/texifyidea/index/stub/LatexCommandsStubElementType.kt
@@ -1,11 +1,14 @@
 package nl.hannahsten.texifyidea.index.stub
 
+import com.intellij.openapi.project.Project
 import com.intellij.psi.stubs.*
+import com.intellij.testFramework.LightVirtualFile
 import nl.hannahsten.texifyidea.LatexLanguage
 import nl.hannahsten.texifyidea.index.LatexCommandsIndex
 import nl.hannahsten.texifyidea.index.LatexDefinitionIndex
 import nl.hannahsten.texifyidea.index.LatexIncludesIndex
 import nl.hannahsten.texifyidea.index.LatexParameterLabeledCommandsIndex
+import nl.hannahsten.texifyidea.index.file.LatexIndexableSetContributor
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.impl.LatexCommandsImpl
 import nl.hannahsten.texifyidea.psi.toStringMap
@@ -78,10 +81,19 @@ class LatexCommandsStubElementType(debugName: String) :
     }
 
     override fun indexStub(latexCommandsStub: LatexCommandsStub, indexSink: IndexSink) {
-        indexSink.occurrence(
-            LatexCommandsIndex.key(),
-            latexCommandsStub.commandToken
-        )
+        // We do not want all the commands from all package source files in this index, because
+        // then we end up with 200k keys for texlive full, but we need to iterate over all keys
+        // every time we need to get e.g. all commands in a file, so that would be too slow.
+        // Therefore, we check if the indexing of this file was caused by being in an extra project root or not
+        // It seems we cannot make a distinction that we do want to index with LatexExternalCommandIndex but not this index
+        // Unfortunately, this seems to make indexing five times slower
+        val pathOfCurrentlyIndexedFile = (latexCommandsStub.psi?.containingFile?.viewProvider?.virtualFile as? LightVirtualFile)?.originalFile?.path
+        if (getCachedProjectRoots(latexCommandsStub.psi?.project).none { pathOfCurrentlyIndexedFile?.contains(it) == true }) {
+            indexSink.occurrence(
+                LatexCommandsIndex.key(),
+                latexCommandsStub.commandToken
+            )
+        }
         val token = latexCommandsStub.commandToken
         if (getIncludeCommands().contains(token)) {
             indexSink.occurrence(LatexIncludesIndex.key(), token)
@@ -114,5 +126,14 @@ class LatexCommandsStubElementType(debugName: String) :
         private val LIST_ELEMENT_SEPARATOR =
             Pattern.compile("\u1923\u9123\u2d20 hello\u0012")
         private val KEY_VALUE_SEPARATOR = "=".toRegex()
+
+        private var projectRootsCache: List<String>? = null
+
+        fun getCachedProjectRoots(project: Project?): List<String> {
+            if (projectRootsCache == null && project != null) {
+                projectRootsCache = LatexIndexableSetContributor().getAdditionalProjectRootsToIndex(project).map { it.path }
+            }
+            return projectRootsCache ?: emptyList()
+        }
     }
 }

--- a/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
@@ -11,12 +11,14 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiReferenceBase
 import nl.hannahsten.texifyidea.completion.pathcompletion.LatexGraphicsPathProvider
+import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexPsiHelper
 import nl.hannahsten.texifyidea.run.latex.LatexRunConfiguration
 import nl.hannahsten.texifyidea.settings.sdk.LatexSdkUtil
 import nl.hannahsten.texifyidea.util.expandCommandsOnce
 import nl.hannahsten.texifyidea.util.files.*
+import nl.hannahsten.texifyidea.util.includedPackages
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 
 /**
@@ -127,7 +129,8 @@ class InputFileReference(
 
         // Try search paths
         if (targetFile == null) {
-            if (!isBuildingFileset) {
+            // If we are not building the fileset, we can make use of it
+            if (!isBuildingFileset && element.containingFile.includedPackages().contains(LatexGenericRegularCommand.GRAPHICSPATH.dependency)) {
                 // Add the graphics paths to the search paths
                 searchPaths.addAll(LatexGraphicsPathProvider().getGraphicsPathsWithoutFileSet(element))
             }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1842 
Fix #1952 
Fix #1979

#### Summary of additions and changes

We were indexing commands from all package sources also in the normal commands index (instead of only in external commands index), but we loop over all keys (200k) e.g. when finding all commands in one file, so this happens for basically every inspection but takes 3 seconds for 200k keys.
* When adding a command to the index, first check if it's being indexed because it's a package source.
This makes indexing between five and ten times slower, unfortunately, because of the string match check.
