### PR TITLE
Remove empty tooltip

### DIFF
--- a/src/nl/hannahsten/texifyidea/TeXception.kt
+++ b/src/nl/hannahsten/texifyidea/TeXception.kt
@@ -2,6 +2,7 @@ package nl.hannahsten.texifyidea
 
 /**
  * Exception that is thrown by problems within TeXiFy-IDEA.
+ * Consider using PluginException if the exception is not caught within TeXiFy, otherwise the real exception message will be hidden.
  *
  * @author Hannah Schellekens
  */

--- a/src/nl/hannahsten/texifyidea/inspections/LatexGrammarCheckingStrategy.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/LatexGrammarCheckingStrategy.kt
@@ -48,7 +48,7 @@ class LatexGrammarCheckingStrategy : GrammarCheckingStrategy {
             .also { it.add(root.endOffset) }
             // To get the ranges that we need to ignore
             .chunked(2) { IntRange(it[0], it[1]) }
-            .filter { it.first < it.last && it.first >= 0 && it.last <= text.length }
+            .filter { it.first < it.last && it.first >= 0 && it.last < text.length }
             .toMutableSet()
 
         // There is still a bit of a problem, because when stitching together the NormalTexts, whitespace is lost


### PR DESCRIPTION
* Change annotation with empty message to silent annotation
* Fix #1981 (stealthy ranges off by one)

Old situation:
![image](https://user-images.githubusercontent.com/15669080/124448760-10f6dc00-dd83-11eb-847f-c05be8104d4e.png)
