### PR TITLE
Get plugin version from JetBrains Marketplace API instead of from our GitHub releases

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,6 +87,11 @@ dependencies {
     // Parsing json
     implementation("com.beust:klaxon:5.5")
 
+    // Parsing xml
+    implementation("com.fasterxml.jackson.core:jackson-core:2.12.4")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.4")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.4")
+
     // Comparing versions
     implementation("org.apache.maven:maven-artifact:3.8.1")
 

--- a/src/nl/hannahsten/texifyidea/LatexErrorReportSubmitter.kt
+++ b/src/nl/hannahsten/texifyidea/LatexErrorReportSubmitter.kt
@@ -129,8 +129,9 @@ class LatexErrorReportSubmitter : ErrorReportSubmitter() {
                 val inputString: String = inputStream.reader().use { it.readText() }
                 latestVersionCached = mapper.readValue(inputString, PluginRepo::class.java)
                     .category
-                    ?.firstOrNull()
+                    ?.maxByOrNull { it.version }
                     ?.version
+                    ?.toString()
                     ?: latestVersionCached
 
                 return latestVersionCached
@@ -158,5 +159,5 @@ class LatexErrorReportSubmitter : ErrorReportSubmitter() {
      * Data class specifying all the properties we need from the idea-plugin tag from the xml response.
      * All properties have to have a default value, because the class needs to have an empty constructor.
      */
-    data class IdeaPlugin(val version: String = "")
+    data class IdeaPlugin(val version: DefaultArtifactVersion = DefaultArtifactVersion(""))
 }

--- a/src/nl/hannahsten/texifyidea/LatexErrorReportSubmitter.kt
+++ b/src/nl/hannahsten/texifyidea/LatexErrorReportSubmitter.kt
@@ -70,7 +70,7 @@ class LatexErrorReportSubmitter : ErrorReportSubmitter() {
             ?: "Crash Report: <Fill in title>"
         val body = event?.throwableText ?: "Please paste the full stacktrace from the IDEA error popup."
 
-        val builder = StringBuilder(URL)
+        val builder = StringBuilder(ISSUE_URL)
         try {
             builder.append(URLEncoder.encode(title, ENCODING))
             builder.append("&body=")
@@ -108,8 +108,9 @@ class LatexErrorReportSubmitter : ErrorReportSubmitter() {
 
     companion object {
 
-        private const val URL = "https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/new?labels=crash-report&title="
-        private const val API = "https://plugins.jetbrains.com/plugins/list?pluginId=9473"
+        private const val ISSUE_URL = "https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/new?labels=crash-report&title="
+
+        private const val JETBRAINS_API_URL = "https://plugins.jetbrains.com/plugins/list?pluginId=9473"
 
         private const val ENCODING = "UTF-8"
 
@@ -121,7 +122,7 @@ class LatexErrorReportSubmitter : ErrorReportSubmitter() {
             // Create xml mapper that doesn't fail on unknown properties. This allows us to only define the properties we need.
             val mapper = XmlMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 
-            with(URL(API).openConnection() as HttpURLConnection) {
+            with(URL(JETBRAINS_API_URL).openConnection() as HttpURLConnection) {
                 requestMethod = "GET"
                 connectTimeout = 1000
                 readTimeout = 1000

--- a/test/nl/hannahsten/texifyidea/util/LatestTexifyVersionTest.kt
+++ b/test/nl/hannahsten/texifyidea/util/LatestTexifyVersionTest.kt
@@ -7,6 +7,6 @@ class LatestTexifyVersionTest : BasePlatformTestCase() {
 
     fun testVersion() {
         val version = LatexErrorReportSubmitter.getLatestVersion()
-        assertTrue(version.isNotBlank())
+        assertTrue(version.version.toString().isNotBlank())
     }
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1980 

#### Summary of additions and changes

* Get the latest available TeXiFy version from the JetBrains Marketplace instead of from our GitHub releases. 
* Marketplace API responds with XML instead of JSON, so this needed a different parser.

#### How to test this pull request
Create error and use the error submitter.

![image](https://user-images.githubusercontent.com/15669080/125415330-488cb01c-e29b-46a6-ae0a-3b6ed3a903d6.png)
