### PR TITLE
Fixes bidirectional programming in Latex

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -85,6 +85,8 @@
     <extensions defaultExtensionNs="com.intellij">
         <!-- Other inspections -->
         <spellchecker.support language="Latex" implementationClass="nl.hannahsten.texifyidea.inspections.LatexSpellcheckingStrategy"/>
+
+        <bidiRegionsSeparator language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.LatexBidiRegionsSeparator" />
     </extensions>
 
     <extensionPoints>

--- a/src/nl/hannahsten/texifyidea/editor/LatexBidiRegionsSeparator.kt
+++ b/src/nl/hannahsten/texifyidea/editor/LatexBidiRegionsSeparator.kt
@@ -1,0 +1,13 @@
+package nl.hannahsten.texifyidea.editor
+
+import com.intellij.openapi.editor.bidi.TokenSetBidiRegionsSeparator
+import com.intellij.psi.tree.IElementType
+
+/**
+ * Considers all tokens united. Let's the editor handle bidirectional text
+ */
+class LatexBidiRegionsSeparator : TokenSetBidiRegionsSeparator(null) {
+    override fun createBorderBetweenTokens(previousTokenType: IElementType, tokenType: IElementType): Boolean {
+        return false
+    }
+}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1996

#### Summary of additions and changes
* Tokens should now be automatically passed to the IDE for it to decide on their bidirectional position.
* Bidirectional programming in the IDE should be natively supported.

#### How to test this pull request

```latex
\documentclass{article}
\begin{document}
    שלום! זוהי דוגמה. בדיקה. abc. בדיקה.
\end{document}
```

#### Wiki
There should not be a need for an updated wiki page for this commit.