### PR TITLE
Do not prefix Tectonic executable with SDK path

### DIFF
--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexCommand.kt
@@ -4,6 +4,7 @@ import nl.hannahsten.texifyidea.lang.Dependend
 import com.intellij.openapi.project.Project
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.util.indexing.FileBasedIndex
+import kotlinx.coroutines.runBlocking
 import nl.hannahsten.texifyidea.index.file.LatexExternalCommandIndex
 import nl.hannahsten.texifyidea.lang.Described
 import nl.hannahsten.texifyidea.lang.LatexPackage
@@ -164,7 +165,9 @@ interface LatexCommand : Described, Dependend {
                 LatexMathCommand[cmdWithoutSlash]
             }
             else {
-                lookupInIndex(cmdWithoutSlash, command.project)
+                runBlocking {
+                    lookupInIndex(cmdWithoutSlash, command.project)
+                }
             }
         }
     }

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexCommand.kt
@@ -165,6 +165,7 @@ interface LatexCommand : Described, Dependend {
                 LatexMathCommand[cmdWithoutSlash]
             }
             else {
+                // Attempt to avoid an error about slow operations on EDT
                 runBlocking {
                     lookupInIndex(cmdWithoutSlash, command.project)
                 }

--- a/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
+++ b/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
@@ -205,7 +205,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
         ): MutableList<String> {
 
             // The available command line arguments can be found at https://github.com/tectonic-typesetting/tectonic/blob/d7a8497c90deb08b5e5792a11d6e8b082f53bbb7/src/bin/tectonic.rs#L158
-            val command = mutableListOf(runConfig.compilerPath ?: LatexSdkUtil.getExecutableName(executableName, runConfig.project))
+            val command = mutableListOf(runConfig.compilerPath ?: executableName)
 
             command.add("--synctex")
 


### PR DESCRIPTION
I inadvertently broke the Tectonic compilation, I forgot it's not installed with LaTeX but separately.