### PR TITLE
Also return error output in case of timeout when running a command

### DIFF
--- a/src/nl/hannahsten/texifyidea/ui/PreviewFormUpdater.kt
+++ b/src/nl/hannahsten/texifyidea/ui/PreviewFormUpdater.kt
@@ -170,7 +170,7 @@ $previewCode
         val result = runCommandWithExitCode(command, *args, workingDirectory = workDirectory, timeout = waitTime)
 
         if (result.second != 0) {
-            previewForm.setLatexErrorMessage("$command exited with ${result.second}\n${result.first}")
+            previewForm.setLatexErrorMessage("$command exited with ${result.second}\n${result.first ?: ""}")
             return null
         }
 

--- a/src/nl/hannahsten/texifyidea/util/SystemEnvironment.kt
+++ b/src/nl/hannahsten/texifyidea/util/SystemEnvironment.kt
@@ -59,9 +59,10 @@ fun runCommandWithExitCode(vararg commands: String, workingDirectory: File? = nu
             return Pair(output, proc.exitValue())
         }
         else {
+            val output = proc.inputStream.bufferedReader().readText().trim() + proc.errorStream.bufferedReader().readText().trim()
             proc.destroy()
             proc.waitFor()
-            Pair(null, proc.exitValue())
+            Pair(output, proc.exitValue())
         }
     }
     catch (e: IOException) {


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2012

#### Summary of additions and changes

* When we timeout a command, there may still be error output, so that should be shown as well.