### PR TITLE
Fix #1977 add implementation for fill paragraph action

### DIFF
--- a/resources/META-INF/extensions/editor/editor.xml
+++ b/resources/META-INF/extensions/editor/editor.xml
@@ -9,6 +9,7 @@
         <lang.formatter language="Latex" implementationClass="nl.hannahsten.texifyidea.formatting.LatexFormattingModelBuilder"/>
         <lang.formatter language="Bibtex" implementationClass="nl.hannahsten.texifyidea.formatting.BibtexFormattingModelBuilder"/>
         <lang.formatter.restriction implementation="nl.hannahsten.texifyidea.formatting.LatexLanguageFormattingRestriction"/>
+        <codeInsight.fillParagraph language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.LatexParagraphFillHandler"/>
         <completion.contributor language="Latex" implementationClass="nl.hannahsten.texifyidea.completion.LatexCompletionContributor"/>
         <completion.contributor language="Bibtex" implementationClass="nl.hannahsten.texifyidea.completion.BibtexCompletionContributor"/>
         <lang.elementManipulator forClass="nl.hannahsten.texifyidea.psi.LatexCommands" implementationClass="nl.hannahsten.texifyidea.completion.LatexCommandElementManipulators"/>

--- a/src/nl/hannahsten/texifyidea/editor/LatexParagraphFillHandler.kt
+++ b/src/nl/hannahsten/texifyidea/editor/LatexParagraphFillHandler.kt
@@ -1,0 +1,137 @@
+package nl.hannahsten.texifyidea.editor
+
+import com.intellij.application.options.CodeStyle
+import com.intellij.codeInsight.editorActions.fillParagraph.ParagraphFillHandler
+import com.intellij.formatting.FormatterTagHandler
+import com.intellij.openapi.command.CommandProcessor
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.ex.util.EditorFacade
+import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.util.UnfairTextRange
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.util.nextLeaf
+import com.intellij.psi.util.prevLeaf
+import com.intellij.refactoring.suggested.startOffset
+import nl.hannahsten.texifyidea.file.LatexFile
+import nl.hannahsten.texifyidea.psi.LatexBeginCommand
+import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.psi.LatexDisplayMath
+import nl.hannahsten.texifyidea.psi.LatexEndCommand
+import nl.hannahsten.texifyidea.util.endOffset
+import nl.hannahsten.texifyidea.util.hasParent
+import nl.hannahsten.texifyidea.util.magic.CommandMagic
+import nl.hannahsten.texifyidea.util.parentOfType
+
+/**
+ * Implements the paragraph fill handler action.
+ *
+ * @author Abby Berkers
+ */
+class LatexParagraphFillHandler : ParagraphFillHandler() {
+
+    override fun isAvailableForFile(psiFile: PsiFile?): Boolean {
+        return psiFile is LatexFile
+    }
+
+    /**
+     * Given the leaf [element] at the caret at the time of invoking the fill paragraph action, replace the text of the
+     * current paragraph with the same text such that the new text fills the editor evenly.
+     *
+     * Based on the super implementation, which wasn't custom enough. We now have finer control over when an element ends.
+     */
+    override fun performOnElement(element: PsiElement, editor: Editor) {
+        val document = editor.document
+
+        val (textRange, preFix, postFix) = getParagraphTextRange(element)
+        if (textRange.isEmpty) return
+        val text = textRange.substring(element.containingFile.text)
+
+        val subStrings = StringUtil.split(text, "\n", true)
+        // Join the paragraph text to a single line, so it can be wrapped later.
+        val replacementText = preFix + subStrings.joinToString(" ") { it.trim() } + postFix
+
+        CommandProcessor.getInstance().executeCommand(element.project, {
+            document.replaceString(
+                textRange.startOffset, textRange.endOffset,
+                replacementText
+            )
+            val file = element.containingFile
+            val formatterTagHandler = FormatterTagHandler(CodeStyle.getSettings(file))
+            val enabledRanges = formatterTagHandler.getEnabledRanges(file.node, TextRange.create(0, document.textLength))
+            // Deprecated ("a temporary solution") but there doesn't seem anything to replace it yet. Used all over by IJ as well.
+            EditorFacade.getInstance().doWrapLongLinesIfNecessary(
+                editor, element.project, document,
+                textRange.startOffset,
+                textRange.startOffset + replacementText.length + 1,
+                enabledRanges,
+                CodeStyle.getSettings(file).getRightMargin(element.language)
+            )
+        }, null, document)
+    }
+
+    /**
+     * Get the text range of the paragraph of the current element, along with a prefix and postfix.
+     *
+     * Note that these paragraphs are different from the paragraphs as outputted by TeX. The paragraphs we are dealing
+     * with here are the walls of text as they appear in the editor. E.g., these paragraphs are separated by a display
+     * math environment, while for TeX a display math environment is part of the paragraph.
+     */
+    private fun getParagraphTextRange(element: PsiElement): Triple<TextRange, String, String> {
+        // The final element of the paragraph.
+        var endElement = element
+        // The last element is the last element we checked. At the end the last element will be the first element that
+        // is not part of the current paragraph.
+        var lastElement = element.nextLeaf(true)
+        while (lastElement != null && !separatesParagraph(lastElement)) {
+            endElement = lastElement
+            lastElement = lastElement.nextLeaf(true)
+        }
+        val postFix = if (endElement.isPostOrPreFix()) endElement.text else ""
+
+        // The first element of the paragraph.
+        var startElement = element
+        // The last element that we checked. At the end the first element will be the last element that is not part of
+        // the current paragraph, i.e., the paragraph starts at the next element after firstElement.
+        var firstElement = element.prevLeaf(true)
+        while (firstElement != null && !separatesParagraph(firstElement)) {
+            startElement = firstElement
+            firstElement = firstElement.prevLeaf(true)
+        }
+        val preFix = if (startElement.isPostOrPreFix()) startElement.text else ""
+
+        return Triple(UnfairTextRange(startElement.startOffset, endElement.endOffset()), preFix, postFix)
+    }
+
+    /**
+     * A paragraph ends when we encounter
+     * - multiple new lines, or
+     * - the begin of an environment (display math counts for this as well, inline math does not), or
+     * - the end of the file.
+     * In that case the current element is the first element that is not part of the paragraph anymore. If the last
+     * element before the current element is a white space, that white space is still part of the paragraph.
+     */
+    private fun separatesParagraph(element: PsiElement): Boolean {
+        return when {
+            element is PsiWhiteSpace -> element.text.count { it == '\n' } >= 2
+            element.hasParent(LatexBeginCommand::class) -> true
+            element.hasParent(LatexEndCommand::class) -> true
+            element.hasParent(LatexDisplayMath::class) -> true
+            element.hasParent(LatexCommands::class) -> {
+                CommandMagic.sectionMarkers.contains(element.parentOfType(LatexCommands::class)?.commandToken?.text)
+            }
+            else -> false
+        }
+    }
+
+    /**
+     * If the first or last element of a paragraph is a white space, this white space should be preserved.
+     *
+     * For example, when the paragraph is ended by an environment, the `\begin{env}` is the element that separates this
+     * paragraph. The last element of the paragraph then is the new line before the `\begin{env}`. White spaces are
+     * trimmed when creating the replacement text, but this white space should be preserved.
+     */
+    private fun PsiElement.isPostOrPreFix() = this is PsiWhiteSpace
+}

--- a/test/nl/hannahsten/texifyidea/editor/LatexParagraphFillHandlerTest.kt
+++ b/test/nl/hannahsten/texifyidea/editor/LatexParagraphFillHandlerTest.kt
@@ -1,0 +1,156 @@
+package nl.hannahsten.texifyidea.editor
+
+import com.intellij.application.options.CodeStyle
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import nl.hannahsten.texifyidea.file.LatexFileType
+
+class LatexParagraphFillHandlerTest : BasePlatformTestCase() {
+
+    fun `test single sentence`() {
+        testFillParagraph("This is a nor<caret>mal sentence.", "This is a normal sentence.")
+    }
+
+    fun `test single sentence with inline math`() {
+        testFillParagraph("This is a nor<caret>mal \$a + \\alpha\$ sentence.", "This is a normal \$a + \\alpha\$ sentence.")
+    }
+
+    fun `test at start of environment`() {
+        testFillParagraph("""
+            \begin{document}
+                Lorem ipsum dolor sit <caret>amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+            \end{document}
+        """.trimIndent(), """
+            \begin{document}
+                Lorem ipsum dolor sit amet, consectetur 
+                adipiscing elit, sed do eiusmod tempor 
+                incididunt ut labore et dolore magna aliqua. 
+            \end{document}
+        """.trimIndent())
+    }
+
+    fun `test after begin section with new line`() {
+        testFillParagraph("""
+            \section{hallo}
+            Lorem <caret>ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+        """.trimIndent(), """
+            \section{hallo}
+            Lorem ipsum dolor sit amet, consectetur 
+            adipiscing elit, sed do eiusmod tempor 
+            incididunt ut labore et dolore magna aliqua. 
+        """.trimIndent())
+    }
+
+    fun `test after begin section without new line`() {
+        testFillParagraph("""
+            \section{hallo} Lorem <caret>ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+        """.trimIndent(), """
+            \section{hallo} Lorem ipsum dolor sit amet, 
+            consectetur adipiscing elit, sed do eiusmod 
+            tempor incididunt ut labore et dolore magna 
+            aliqua. 
+        """.trimIndent())
+    }
+
+    fun `test lorem ipsum paragraph`() {
+        testFillParagraph("""
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+            Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+            Duis aute iru<caret>re dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. 
+            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        """.trimIndent(), """
+            Lorem ipsum dolor sit amet, consectetur
+            adipiscing elit, sed do eiusmod tempor 
+            incididunt ut labore et dolore magna aliqua. Ut 
+            enim ad minim veniam, quis nostrud exercitation 
+            ullamco laboris nisi ut aliquip ex ea commodo 
+            consequat. Duis aute irure dolor in 
+            reprehenderit in voluptate velit esse cillum 
+            dolore eu fugiat nulla pariatur. Excepteur sint 
+            occaecat cupidatat non proident, sunt in culpa 
+            qui officia deserunt mollit anim id est laborum.
+        """.trimIndent())
+    }
+
+    fun `test paragraph that was good`() {
+        testFillParagraph("""
+            Lorem ipsum dolor sit amet, consectetur
+            adipiscing elit, sed do eiusmod tempor NEW WORDS HERE
+            incididunt ut labore et dolore magna aliqua. Ut 
+            enim ad minim veniam, quis nostrud exercitation 
+            ullamco laboris nisi ut aliquip ex ea commodo 
+            consequat. Duis aute irure dolor in 
+            reprehenderit in voluptate velit esse cillum 
+            dolore eu fugiat nulla pariatur. Excepteur sint 
+            occaecat cupidatat non proident, sunt in culpa 
+            qui officia deserunt mollit anim id est laborum.
+        """.trimIndent(), """
+            Lorem ipsum dolor sit amet, consectetur 
+            adipiscing elit, sed do eiusmod tempor NEW 
+            WORDS HERE incididunt ut labore et dolore magna
+            aliqua. Ut enim ad minim veniam, quis nostrud 
+            exercitation ullamco laboris nisi ut aliquip ex
+            ea commodo consequat. Duis aute irure dolor in 
+            reprehenderit in voluptate velit esse cillum 
+            dolore eu fugiat nulla pariatur. Excepteur sint
+            occaecat cupidatat non proident, sunt in culpa 
+            qui officia deserunt mollit anim id est laborum.
+        """.trimIndent())
+    }
+
+    fun `test paragraph separated by blank lines`() {
+        testFillParagraph("""
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore ma<caret>gna aliqua. 
+
+            Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+        """.trimIndent(), """
+            Lorem ipsum dolor sit amet, consectetur
+            adipiscing elit, sed do eiusmod tempor 
+            incididunt ut labore et dolore magna aliqua. 
+
+            Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+        """.trimIndent())
+    }
+
+    fun `test paragraph separated by environment`() {
+        testFillParagraph("""
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore ma<caret>gna aliqua. 
+            \begin{center}
+                bla
+            \end{center}
+            Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+        """.trimIndent(), """
+            Lorem ipsum dolor sit amet, consectetur 
+            adipiscing elit, sed do eiusmod tempor 
+            incididunt ut labore et dolore magna aliqua.
+            \begin{center}
+                bla
+            \end{center}
+            Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+        """.trimIndent())
+    }
+
+    fun `test paragraph separated by display math`() {
+        testFillParagraph("""
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore ma<caret>gna aliqua. 
+            \[
+                \sum_{i=1}^\infty \frac{e^i}{i!}
+            \]
+            Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+        """.trimIndent(), """
+            Lorem ipsum dolor sit amet, consectetur
+            adipiscing elit, sed do eiusmod tempor 
+            incididunt ut labore et dolore magna aliqua. 
+            \[
+                \sum_{i=1}^\infty \frac{e^i}{i!}
+            \]
+            Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+        """.trimIndent())
+    }
+
+    private fun testFillParagraph(input: String, expectedOutput: String) {
+        myFixture.configureByText(LatexFileType, input)
+        CodeStyle.getLanguageSettings(myFixture.file).RIGHT_MARGIN = 50
+        myFixture.performEditorAction("FillParagraph")
+        myFixture.checkResult(expectedOutput, true)
+    }
+}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #1977 

#### Summary of additions and changes

* Implement the fill paragraph handler so the fill paragraph action is available and working.

#### How to test this pull request
Invoke the **edit > fill paragraph** action while the cursor is somewhere in one of the two paragraphs below.

```latex
\documentclass{article}

\title{It shall flow that this is the sore visual developing the partial desks that markets are monitoring.}

\begin{document}
    Settled selections are able to find nice levels when they identify politicians and procede activities and failures.
    These schools are to be produced by the hour according to their observed insurance companies.
    All identities flown by the accepted girlfriends can be settled by the media.
    On average 89 quietly objective applications are enquiring drawings during these data sets.
    On average 27 inspiringly inexpensive speeches are concluding blood cells during these conclusions.
    The little complex $x$ damages the relationship of a establishment on feasable need.
    In summary , we add Sophie and girlfriends.
    \[
        \infty
    \]
    It appears to resolve more filthy during periods of comfortable threshold when ludicrous agencies are caught and settling it.
    For example, purposes, users, and reports.
    This staff contains the services for the duck.
    Indicating of businesses relies this.
    This hot period is drawn every 382 queens and is concluded on the intriguing threshold it took to develop one situation.
    It shall horribly license the satisfyling mud balls.
\end{document}
```

#### Wiki

<!-- Add link to updated wiki page -->
- [ ] Updated the wiki: