### PR TITLE
Add live templates for inserting Beamer frames

### DIFF
--- a/resources/liveTemplates/LaTeX.xml
+++ b/resources/liveTemplates/LaTeX.xml
@@ -26,6 +26,30 @@
         </context>
     </template>
 
+    <template name="frm0" value="\begin{frame}&#10;$END$&#10;\end{frame}" description="Frame without title" toReformat="true" toShortenFQNames="true">
+        <context>
+            <option name="LATEX" value="true"/>
+            <option name="LATEX_MATH" value="false"/>
+        </context>
+    </template>
+
+    <template name="frm1" value="\begin{frame}{$TITLE$}&#10;$END$&#10;\end{frame}" description="Frame with title" toReformat="true" toShortenFQNames="true">
+        <variable name="TITLE" expression="" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="LATEX" value="true"/>
+            <option name="LATEX_MATH" value="false"/>
+        </context>
+    </template>
+
+    <template name="frm2" value="\begin{frame}{$TITLE$}{$SUBTITLE$}&#10;$END$&#10;\end{frame}" description="Frame with title and subtitle" toReformat="true" toShortenFQNames="true">
+        <variable name="TITLE" expression="" defaultValue="" alwaysStopAt="true" />
+        <variable name="SUBTITLE" expression="" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="LATEX" value="true"/>
+            <option name="LATEX_MATH" value="false"/>
+        </context>
+    </template>
+
     <template name="enm" value="\begin{enumerate}&#10;    \item $END$&#10;\end{enumerate}" description="Enumerate environment" toReformat="false" toShortenFQNames="true">
         <context>
             <option name="LATEX" value="true"/>


### PR DESCRIPTION
#### Summary of additions and changes
I added three live templates to insert `frame` environments into a LaTeX document: `frm0`, `frm1`, and `frm2`. The names indicate the number of arguments given to frame, with `frm1` additionally inserting a title, and `frm2` additionally inserting a title and a subtitle.

Defining multiple variants of a live template is also done by default for Kotlin (`fun0`, `fun1`, `fun2`) and XML (`link:css`, `link:print`, `map`, `map+`, etc.).

_If you think that adding these live templates will clutter up the available live templates, please feel free to reject the PR! No offence taken!_

#### How to test this pull request
Open the editor and verify that each live template behaves appropriately. I did not see automated tests for other live templates, so I did not write any for this PR.

#### Wiki
- [ ] Updated the wiki: I will update the [Live templates](https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Live-templates) page after this PR has been merged.