### PR TITLE
Add live templates for generic environments

### DIFF
--- a/resources/liveTemplates/LaTeX.xml
+++ b/resources/liveTemplates/LaTeX.xml
@@ -33,6 +33,44 @@
         </context>
     </template>
 
+    <template name="begin" value="\begin{$NAME$}&#10;    $END$&#10;\end{$NAME$}" description="Environment" toReformat="false" toShortenFQNames="true">
+        <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="LATEX" value="true"/>
+            <option name="LATEX_MATH" value="false"/>
+        </context>
+    </template>
+
+    <template name="begin1" value="\begin{$NAME$}{$ARG1$}&#10;    $END$&#10;\end{$NAME$}" description="Environment with 1 parameter" toReformat="false" toShortenFQNames="true">
+        <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
+        <variable name="ARG1" expression="" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="LATEX" value="true"/>
+            <option name="LATEX_MATH" value="false"/>
+        </context>
+    </template>
+
+    <template name="begin2" value="\begin{$NAME$}{$ARG1$}{$ARG2$}&#10;    $END$&#10;\end{$NAME$}" description="Environment with 2 parameters" toReformat="false" toShortenFQNames="true">
+        <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
+        <variable name="ARG1" expression="" defaultValue="" alwaysStopAt="true" />
+        <variable name="ARG2" expression="" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="LATEX" value="true"/>
+            <option name="LATEX_MATH" value="false"/>
+        </context>
+    </template>
+
+    <template name="begin3" value="\begin{$NAME$}{$ARG1$}{$ARG2$}{$ARG3$}&#10;    $END$&#10;\end{$NAME$}" description="Environment with 3 parameters" toReformat="false" toShortenFQNames="true">
+        <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
+        <variable name="ARG1" expression="" defaultValue="" alwaysStopAt="true" />
+        <variable name="ARG2" expression="" defaultValue="" alwaysStopAt="true" />
+        <variable name="ARG3" expression="" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="LATEX" value="true"/>
+            <option name="LATEX_MATH" value="false"/>
+        </context>
+    </template>
+
     <template name="\partl" value="\part{$TITLE$}\label{$LABEL$}$END$" description="Part with label" toReformat="false" toShortenFQNames="true">
         <variable name="TITLE" expression="" defaultValue="" alwaysStopAt="true" />
         <variable name="LABEL" expression="latexFormatAsLabel(TITLE)" defaultValue="" alwaysStopAt="true" />


### PR DESCRIPTION
(This is the "better idea" I mentioned in the closing comment in #2042.)

#### Summary of additions and changes
I added four live templates to insert generic environments into a LaTeX document: `begin`, `begin1`, `begin2`, and `begin3`. The names indicate the number of arguments given to environment. For example, `begin` inserts
```latex
\begin{$NAME$}
    $END$
\end{$NAME$}
```
where the user first gets to enter `$NAME$` and ends at `$END$`. Meanwhile, `begin2` inserts
```latex
\begin{$NAME$}{$ARG1$}{$ARG2$}
    $END$
\end{$NAME$}
```
for similarly defined variables.

While live templates exist for several environments already, there will never be enough for all environments. I think that these live templates will be very useful for all users who want to quickly create a environment that does not (yet) have a live template.

#### How to test this pull request
Open the editor and verify that each live template behaves appropriately. I did not see automated tests for other live templates, so I did not write any for this PR.

#### Wiki
- [ ] Updated the wiki: I will update the [Live templates](https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Live-templates) page after this PR has been merged. (Or do you want me to do it now?)