### PR TITLE
Fix #2041 formatting of section-like commands used in definitions

### DIFF
--- a/src/nl/hannahsten/texifyidea/formatting/LatexSpacingRules.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexSpacingRules.kt
@@ -5,10 +5,13 @@ import com.intellij.psi.codeStyle.CodeStyleSettings
 import nl.hannahsten.texifyidea.LatexLanguage
 import nl.hannahsten.texifyidea.formatting.spacingrules.leftTableSpaceAlign
 import nl.hannahsten.texifyidea.formatting.spacingrules.rightTableSpaceAlign
+import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexTypes.*
 import nl.hannahsten.texifyidea.settings.codestyle.LatexCodeStyleSettings
 import nl.hannahsten.texifyidea.util.inDirectEnvironment
+import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.magic.EnvironmentMagic
+import nl.hannahsten.texifyidea.util.parentOfType
 
 fun createSpacing(minSpaces: Int, maxSpaces: Int, minLineFeeds: Int, keepLineBreaks: Boolean, keepBlankLines: Int): Spacing =
     Spacing.createSpacing(minSpaces, maxSpaces, minLineFeeds, keepLineBreaks, keepBlankLines)
@@ -86,7 +89,8 @@ fun createSpacingBuilder(settings: CodeStyleSettings): TexSpacingBuilder {
             // BUG OR FEATURE? Does not work for a command that immediately follows \begin{document}.
             customRule { _, _, right ->
                 LatexCodeStyleSettings.blankLinesOptions.forEach {
-                    if (right.node?.text?.matches(Regex("\\" + "${it.value}\\{.*\\}")) == true) {
+                    if (right.node?.text?.matches(Regex("\\" + "${it.value}\\{.*\\}")) == true &&
+                        !CommandMagic.definitions.contains(right.node?.psi?.parentOfType(LatexCommands::class)?.name)) {
                         return@customRule createSpacing(
                             minSpaces = 0,
                             maxSpaces = Int.MAX_VALUE,

--- a/test/nl/hannahsten/texifyidea/formatting/LatexFormattingTest.kt
+++ b/test/nl/hannahsten/texifyidea/formatting/LatexFormattingTest.kt
@@ -188,6 +188,24 @@ fun Int?.ifPositiveAddTwo(): Int =
         """.trimIndent()
     }
 
+    fun `test section used in command definition`() {
+        """
+            \documentclass{article}
+            \newcommand{\sectionlorem}[2]{\section{#1}\label{#2}}
+
+            \begin{document}
+                \sectionlorem{Title}{sec:label}
+            \end{document}
+        """.trimIndent() `should be reformatted to` """
+            \documentclass{article}
+            \newcommand{\sectionlorem}[2]{\section{#1}\label{#2}}
+
+            \begin{document}
+                \sectionlorem{Title}{sec:label}
+            \end{document}
+        """.trimIndent()
+    }
+
     fun testComments() {
         // Wanted to test line breaking, but not sure how to enable it in test
         val text = """


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2041 

#### Summary of additions and changes

* Check if section-like command is inside a definition on formatting, and do nothing when it is

#### How to test this pull request

Cases from issue:
```latex
\documentclass{article}
\newcommand{\sectionlorem}[2]{\section{#1}\label{#2}}

\begin{document}
    \sectionlorem{Title}{sec:label}
\end{document}
```

```latex
\documentclass{article}
\newenvironment{sectionitemize}[2]{\section{#1}\label{#2}\begin{itemize}}{\end{itemize}}

\begin{document}
    \begin{sectionitemize}{Title}{sec:label}
        \item Lorem
        \item Ipsum
    \end{sectionitemize}
\end{document}
```

#### Wiki
Nothing to add