### PR TITLE
Reduce number of commands in autocompletion for TeX Live

### DIFF
--- a/src/nl/hannahsten/texifyidea/completion/LatexXColorProvider.kt
+++ b/src/nl/hannahsten/texifyidea/completion/LatexXColorProvider.kt
@@ -5,19 +5,16 @@ import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.psi.PsiFile
-import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.util.ProcessingContext
 import com.intellij.util.ui.ColorIcon
-import nl.hannahsten.texifyidea.index.LatexCommandsIndex
 import nl.hannahsten.texifyidea.gutter.LatexElementColorProvider
 import nl.hannahsten.texifyidea.util.Kindness
 import nl.hannahsten.texifyidea.util.files.referencedFileSet
+import nl.hannahsten.texifyidea.util.getCommandsInFiles
 import nl.hannahsten.texifyidea.util.getRequiredArgumentValueByName
 import nl.hannahsten.texifyidea.util.isColorDefinition
 import nl.hannahsten.texifyidea.util.magic.ColorMagic
 import java.awt.Color
-import java.util.*
-import java.util.stream.Collectors
 
 object LatexXColorProvider : CompletionProvider<CompletionParameters>() {
 
@@ -36,15 +33,9 @@ object LatexXColorProvider : CompletionProvider<CompletionParameters>() {
     }
 
     private fun addCustomColors(parameters: CompletionParameters, result: CompletionResultSet) {
-        val project = parameters.editor.project ?: return
         val file = parameters.originalFile
         val files: MutableSet<PsiFile> = HashSet(file.referencedFileSet())
-        val searchFiles = files.stream()
-            .map { obj: PsiFile -> obj.virtualFile }
-            .collect(Collectors.toSet())
-        searchFiles.add(file.virtualFile)
-        val scope = GlobalSearchScope.filesScope(project, searchFiles)
-        val cmds = LatexCommandsIndex.getItems(project, scope)
+        val cmds = getCommandsInFiles(files, file)
         for (cmd in cmds) {
             if (!cmd.isColorDefinition()) {
                 continue

--- a/src/nl/hannahsten/texifyidea/index/LatexIncludesIndex.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexIncludesIndex.kt
@@ -5,6 +5,7 @@ import nl.hannahsten.texifyidea.LatexParserDefinition
 import nl.hannahsten.texifyidea.psi.LatexCommands
 
 /**
+ * Index all commands that include other files, see [nl.hannahsten.texifyidea.util.getIncludeCommands].
  * @author Hannah Schellekens
  */
 class LatexIncludesIndex : StringStubIndexExtension<LatexCommands>() {

--- a/src/nl/hannahsten/texifyidea/util/Commands.kt
+++ b/src/nl/hannahsten/texifyidea/util/Commands.kt
@@ -71,7 +71,6 @@ fun LatexCommands.defaultCommand(): LatexCommand? {
 fun LatexCommands.isFigureLabel(): Boolean =
     name in project.getLabelDefinitionCommands() && inDirectEnvironment(EnvironmentMagic.figures)
 
-
 fun getCommandsInFiles(files: MutableSet<PsiFile>, originalFile: PsiFile): Collection<LatexCommands> {
     val project = originalFile.project
     val searchFiles = files.stream()

--- a/src/nl/hannahsten/texifyidea/util/Commands.kt
+++ b/src/nl/hannahsten/texifyidea/util/Commands.kt
@@ -2,6 +2,7 @@ package nl.hannahsten.texifyidea.util
 
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
+import com.intellij.psi.search.GlobalSearchScope
 import nl.hannahsten.texifyidea.index.LatexCommandsIndex
 import nl.hannahsten.texifyidea.index.LatexDefinitionIndex
 import nl.hannahsten.texifyidea.lang.commands.LatexCommand
@@ -13,6 +14,7 @@ import nl.hannahsten.texifyidea.psi.LatexParameter
 import nl.hannahsten.texifyidea.psi.LatexPsiHelper
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.magic.EnvironmentMagic
+import java.util.stream.Collectors
 
 /**
  * Finds all defined commands within the project.
@@ -68,3 +70,14 @@ fun LatexCommands.defaultCommand(): LatexCommand? {
 
 fun LatexCommands.isFigureLabel(): Boolean =
     name in project.getLabelDefinitionCommands() && inDirectEnvironment(EnvironmentMagic.figures)
+
+
+fun getCommandsInFiles(files: MutableSet<PsiFile>, originalFile: PsiFile): Collection<LatexCommands> {
+    val project = originalFile.project
+    val searchFiles = files.stream()
+        .map { obj: PsiFile -> obj.virtualFile }
+        .collect(Collectors.toSet())
+    searchFiles.add(originalFile.virtualFile)
+    val scope = GlobalSearchScope.filesScope(project, searchFiles)
+    return LatexCommandsIndex.getItems(project, scope)
+}

--- a/src/nl/hannahsten/texifyidea/util/Packages.kt
+++ b/src/nl/hannahsten/texifyidea/util/Packages.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.util
 
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
@@ -282,7 +283,15 @@ fun PsiFile.insertUsepackage(pack: LatexPackage) = PackageUtils.insertUsepackage
  */
 fun PsiFile.includedPackages(onlyDirectInclusions: Boolean = false): List<LatexPackage> {
     val commands = this.commandsInFileSet()
+    return includedPackages(commands, project, onlyDirectInclusions)
+}
+
+/**
+ * See [includedPackages].
+ */
+fun includedPackages(commands: Collection<LatexCommands>, project: Project, onlyDirectInclusions: Boolean = false): List<LatexPackage> {
     val directIncludes = PackageUtils.getPackagesFromCommands(commands, CommandMagic.packageInclusionCommands, mutableListOf())
         .map { LatexPackage(it) }
     return if (onlyDirectInclusions) directIncludes else LatexExternalPackageInclusionCache.getAllIndirectlyIncludedPackages(directIncludes, project).toList()
+
 }

--- a/src/nl/hannahsten/texifyidea/util/Packages.kt
+++ b/src/nl/hannahsten/texifyidea/util/Packages.kt
@@ -293,5 +293,4 @@ fun includedPackages(commands: Collection<LatexCommands>, project: Project, only
     val directIncludes = PackageUtils.getPackagesFromCommands(commands, CommandMagic.packageInclusionCommands, mutableListOf())
         .map { LatexPackage(it) }
     return if (onlyDirectInclusions) directIncludes else LatexExternalPackageInclusionCache.getAllIndirectlyIncludedPackages(directIncludes, project).toList()
-
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2027

#### Summary of additions and changes

* When TeX Live  is the system default, the autocompletion will only contain external commands from packages that are included anywhere in the project, directly or indirectly.

Since commands are only added to autocompletion during certain initialisation phases (at least startup, that I checked), commands will not directly be added when you add an extra package.

This at least avoids the many duplicates of the same commands, and also avoids putting commands in the autocompletion that nobody uses.
Now, this is still not ideal, because sometimes you _do_ want to suggest commands from not-included packages. But I don't see this happen unless we have some statistics on how much all commands are used (texstudio is maintaining that information manually, I believe) and from which package.

#### How to test this pull request

Try e.g. completion of `\foo` and count the duplicates.

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: