### PR TITLE
Add 'reformat with bibtex-tidy' action

### DIFF
--- a/resources/META-INF/actions/actions.xml
+++ b/resources/META-INF/actions/actions.xml
@@ -6,7 +6,10 @@
         </action>
 
         <!-- LaTeX Code menu -->
-        <action id="texify.ReformatLatexindent" class="nl.hannahsten.texifyidea.action.ReformatWithLatexindent" description="Run latexindent.pl" >
+        <action id="texify.ReformatLatexindent" class="nl.hannahsten.texifyidea.action.reformat.ReformatWithLatexindent" description="Run latexindent.pl" >
+            <add-to-group group-id="CodeFormatGroup" anchor="after" relative-to-action="ShowReformatFileDialog" />
+        </action>
+        <action id="texify.ReformatBibtexTidy" class="nl.hannahsten.texifyidea.action.reformat.ReformatWithBibtexTidy" description="Run bibtex-tidy" >
             <add-to-group group-id="CodeFormatGroup" anchor="after" relative-to-action="ShowReformatFileDialog" />
         </action>
 

--- a/src/nl/hannahsten/texifyidea/action/reformat/ReformatWithBibtexTidy.kt
+++ b/src/nl/hannahsten/texifyidea/action/reformat/ReformatWithBibtexTidy.kt
@@ -1,0 +1,16 @@
+package nl.hannahsten.texifyidea.action.reformat
+
+import nl.hannahsten.texifyidea.file.BibtexFileType
+
+/**
+ * Run external tool 'bibtex-tidy' to reformat the file.
+ * This action is placed next to the standard Reformat action in the Code menu.
+ *
+ * @author Thomas
+ */
+class ReformatWithBibtexTidy : ExternalReformatAction("Reformat File with bibtex-tidy", { it.fileType == BibtexFileType } ) {
+
+    override fun getCommand(fileName: String): List<String> {
+        return listOf("bibtex-tidy", fileName, "--no-backup")
+    }
+}

--- a/src/nl/hannahsten/texifyidea/action/reformat/ReformatWithBibtexTidy.kt
+++ b/src/nl/hannahsten/texifyidea/action/reformat/ReformatWithBibtexTidy.kt
@@ -1,6 +1,10 @@
 package nl.hannahsten.texifyidea.action.reformat
 
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.file.BibtexFileType
+import nl.hannahsten.texifyidea.util.runCommand
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion
 
 /**
  * Run external tool 'bibtex-tidy' to reformat the file.
@@ -10,7 +14,25 @@ import nl.hannahsten.texifyidea.file.BibtexFileType
  */
 class ReformatWithBibtexTidy : ExternalReformatAction("Reformat File with bibtex-tidy", { it.fileType == BibtexFileType } ) {
 
-    override fun getCommand(fileName: String): List<String> {
-        return listOf("bibtex-tidy", fileName, "--no-backup")
+    companion object {
+        val bibtexTidyVersion by lazy { DefaultArtifactVersion(runCommand("bibtex-tidy", "-v") ?: "0.0.0") }
+    }
+
+    override fun getCommand(file: PsiFile): List<String> {
+        // Outputting to stdout was introduced in 1.7.2
+        return if (bibtexTidyVersion < DefaultArtifactVersion("v1.7.2")) {
+            listOf("bibtex-tidy", file.name, "--no-backup")
+        }
+        else {
+            // We have to use shell in order to make the pipe work
+            // We have to use a special string to escape all the single quotes
+            listOf("/bin/sh", "-c", "echo '${file.text.replace("'", "'\"'\"'")}' | bibtex-tidy -")
+        }
+    }
+
+    override fun processOutput(output: String, file: PsiFile, project: Project) {
+        if (bibtexTidyVersion < DefaultArtifactVersion("v1.7.2")) return
+        // Otherwise, we can use the stdout output
+        replaceBibtexFileContent(output, file, project)
     }
 }

--- a/src/nl/hannahsten/texifyidea/action/reformat/ReformatWithBibtexTidy.kt
+++ b/src/nl/hannahsten/texifyidea/action/reformat/ReformatWithBibtexTidy.kt
@@ -12,9 +12,10 @@ import org.apache.maven.artifact.versioning.DefaultArtifactVersion
  *
  * @author Thomas
  */
-class ReformatWithBibtexTidy : ExternalReformatAction("Reformat File with bibtex-tidy", { it.fileType == BibtexFileType } ) {
+class ReformatWithBibtexTidy : ExternalReformatAction("Reformat File with bibtex-tidy", { it.fileType == BibtexFileType }) {
 
     companion object {
+
         val bibtexTidyVersion by lazy { DefaultArtifactVersion(runCommand("bibtex-tidy", "-v") ?: "0.0.0") }
     }
 

--- a/src/nl/hannahsten/texifyidea/action/reformat/ReformatWithLatexindent.kt
+++ b/src/nl/hannahsten/texifyidea/action/reformat/ReformatWithLatexindent.kt
@@ -1,0 +1,28 @@
+package nl.hannahsten.texifyidea.action.reformat
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import nl.hannahsten.texifyidea.psi.LatexPsiHelper
+import nl.hannahsten.texifyidea.util.files.isLatexFile
+import nl.hannahsten.texifyidea.util.runWriteCommandAction
+
+/**
+ * Run external tool 'latexindent.pl' to reformat the file.
+ * This action is placed next to the standard Reformat action in the Code menu.
+ *
+ * @author Thomas
+ */
+class ReformatWithLatexindent : ExternalReformatAction("Reformat File with Latexindent", { it.isLatexFile() } ) {
+
+    override fun getCommand(fileName: String): List<String> {
+        return listOf("latexindent.pl", fileName)
+    }
+
+    override fun processOutput(output: String, file: PsiFile, project: Project) {
+        // Assumes first child is LatexContent
+        val newFile = LatexPsiHelper(project).createFromText(output)
+        runWriteCommandAction(project) {
+            file.node.replaceChild(file.node.firstChildNode, newFile.node.firstChildNode)
+        }
+    }
+}

--- a/src/nl/hannahsten/texifyidea/action/reformat/ReformatWithLatexindent.kt
+++ b/src/nl/hannahsten/texifyidea/action/reformat/ReformatWithLatexindent.kt
@@ -1,10 +1,10 @@
 package nl.hannahsten.texifyidea.action.reformat
 
+import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
-import nl.hannahsten.texifyidea.psi.LatexPsiHelper
 import nl.hannahsten.texifyidea.util.files.isLatexFile
-import nl.hannahsten.texifyidea.util.runWriteCommandAction
 
 /**
  * Run external tool 'latexindent.pl' to reformat the file.
@@ -14,15 +14,16 @@ import nl.hannahsten.texifyidea.util.runWriteCommandAction
  */
 class ReformatWithLatexindent : ExternalReformatAction("Reformat File with Latexindent", { it.isLatexFile() } ) {
 
-    override fun getCommand(fileName: String): List<String> {
-        return listOf("latexindent.pl", fileName)
+    override fun getCommand(file: PsiFile): List<String> {
+        // Ensure the document is saved, before we run anything on it
+        val document = PsiDocumentManager.getInstance(file.project).getDocument(file)
+        if (document != null) {
+            FileDocumentManager.getInstance().saveDocument(document)
+        }
+        return listOf("latexindent.pl", file.name)
     }
 
     override fun processOutput(output: String, file: PsiFile, project: Project) {
-        // Assumes first child is LatexContent
-        val newFile = LatexPsiHelper(project).createFromText(output)
-        runWriteCommandAction(project) {
-            file.node.replaceChild(file.node.firstChildNode, newFile.node.firstChildNode)
-        }
+        replaceLatexFileContent(output, file, project)
     }
 }

--- a/src/nl/hannahsten/texifyidea/action/reformat/ReformatWithLatexindent.kt
+++ b/src/nl/hannahsten/texifyidea/action/reformat/ReformatWithLatexindent.kt
@@ -12,7 +12,7 @@ import nl.hannahsten.texifyidea.util.files.isLatexFile
  *
  * @author Thomas
  */
-class ReformatWithLatexindent : ExternalReformatAction("Reformat File with Latexindent", { it.isLatexFile() } ) {
+class ReformatWithLatexindent : ExternalReformatAction("Reformat File with Latexindent", { it.isLatexFile() }) {
 
     override fun getCommand(file: PsiFile): List<String> {
         // Ensure the document is saved, before we run anything on it

--- a/src/nl/hannahsten/texifyidea/util/SystemEnvironment.kt
+++ b/src/nl/hannahsten/texifyidea/util/SystemEnvironment.kt
@@ -36,7 +36,6 @@ class SystemEnvironment {
 
 /**
  * Run a command in the terminal.
- * Consider using GeneralCommandLine instead.
  *
  * @return The output of the command or null if an exception was thrown.
  */


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2030

#### Summary of additions and changes

* Add action to run bibtex-tidy on the contents of a bib file (depending on the bibtex-tidy version, it will replace the psi tree or just run it on the actual file)

#### How to test this pull request

Open bib file
code > reformat with bibtex-tidy

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: