### PR TITLE
Add angular bracket parameter to parser

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 group = "nl.hannahsten"
-version = "0.7.10-2"
+version = "0.7.11-alpha.1"
 
 repositories {
     mavenCentral()
@@ -167,7 +167,7 @@ tasks.publishPlugin {
 
     // Specify channel as per the tutorial.
     // More documentation: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/README.md#publishing-dsl
-    channels.set(listOf("stable"))
+    channels.set(listOf("alpha"))
 }
 
 tasks.test {

--- a/gen/nl/hannahsten/texifyidea/parser/LatexParser.java
+++ b/gen/nl/hannahsten/texifyidea/parser/LatexParser.java
@@ -37,6 +37,56 @@ public class LatexParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
+  // OPEN_ANGLE_BRACKET angle_param_content* CLOSE_ANGLE_BRACKET
+  public static boolean angle_param(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "angle_param")) return false;
+    if (!nextTokenIs(b, OPEN_ANGLE_BRACKET)) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = consumeToken(b, OPEN_ANGLE_BRACKET);
+    r = r && angle_param_1(b, l + 1);
+    r = r && consumeToken(b, CLOSE_ANGLE_BRACKET);
+    exit_section_(b, m, ANGLE_PARAM, r);
+    return r;
+  }
+
+  // angle_param_content*
+  private static boolean angle_param_1(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "angle_param_1")) return false;
+    while (true) {
+      int c = current_position_(b);
+      if (!angle_param_content(b, l + 1)) break;
+      if (!empty_element_parsed_guard_(b, "angle_param_1", c)) break;
+    }
+    return true;
+  }
+
+  /* ********************************************************** */
+  // raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | parameter_text | BACKSLASH | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET
+  public static boolean angle_param_content(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "angle_param_content")) return false;
+    boolean r;
+    Marker m = enter_section_(b, l, _NONE_, ANGLE_PARAM_CONTENT, "<angle param content>");
+    r = raw_text(b, l + 1);
+    if (!r) r = magic_comment(b, l + 1);
+    if (!r) r = comment(b, l + 1);
+    if (!r) r = environment(b, l + 1);
+    if (!r) r = pseudocode_block(b, l + 1);
+    if (!r) r = math_environment(b, l + 1);
+    if (!r) r = consumeToken(b, COMMAND_IFNEXTCHAR);
+    if (!r) r = commands(b, l + 1);
+    if (!r) r = group(b, l + 1);
+    if (!r) r = parameter_text(b, l + 1);
+    if (!r) r = consumeToken(b, BACKSLASH);
+    if (!r) r = consumeToken(b, COMMA);
+    if (!r) r = consumeToken(b, EQUALS);
+    if (!r) r = consumeToken(b, OPEN_BRACKET);
+    if (!r) r = consumeToken(b, CLOSE_BRACKET);
+    exit_section_(b, l, m, r, false, null);
+    return r;
+  }
+
+  /* ********************************************************** */
   // BEGIN_TOKEN STAR? parameter*
   public static boolean begin_command(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "begin_command")) return false;
@@ -535,7 +585,7 @@ public class LatexParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | OPEN_PAREN | CLOSE_PAREN | parameter_text | BACKSLASH
+  // raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | OPEN_PAREN | CLOSE_PAREN | parameter_text | BACKSLASH | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET
   public static boolean optional_param_content(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "optional_param_content")) return false;
     boolean r;
@@ -553,12 +603,14 @@ public class LatexParser implements PsiParser, LightPsiParser {
     if (!r) r = consumeToken(b, CLOSE_PAREN);
     if (!r) r = parameter_text(b, l + 1);
     if (!r) r = consumeToken(b, BACKSLASH);
+    if (!r) r = consumeToken(b, OPEN_ANGLE_BRACKET);
+    if (!r) r = consumeToken(b, CLOSE_ANGLE_BRACKET);
     exit_section_(b, l, m, r, false, null);
     return r;
   }
 
   /* ********************************************************** */
-  // optional_param | required_param | picture_param
+  // optional_param | required_param | picture_param | angle_param
   public static boolean parameter(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "parameter")) return false;
     boolean r;
@@ -566,6 +618,7 @@ public class LatexParser implements PsiParser, LightPsiParser {
     r = optional_param(b, l + 1);
     if (!r) r = required_param(b, l + 1);
     if (!r) r = picture_param(b, l + 1);
+    if (!r) r = angle_param(b, l + 1);
     exit_section_(b, l, m, r, false, null);
     return r;
   }
@@ -613,7 +666,7 @@ public class LatexParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // (commands | NORMAL_TEXT_WORD | STAR | AMPERSAND | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET | QUOTATION_MARK | PIPE | EXCLAMATION_MARK | DASH)+
+  // (commands | NORMAL_TEXT_WORD | STAR | AMPERSAND | QUOTATION_MARK | PIPE | EXCLAMATION_MARK | DASH)+
   public static boolean parameter_text(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "parameter_text")) return false;
     boolean r;
@@ -628,7 +681,7 @@ public class LatexParser implements PsiParser, LightPsiParser {
     return r;
   }
 
-  // commands | NORMAL_TEXT_WORD | STAR | AMPERSAND | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET | QUOTATION_MARK | PIPE | EXCLAMATION_MARK | DASH
+  // commands | NORMAL_TEXT_WORD | STAR | AMPERSAND | QUOTATION_MARK | PIPE | EXCLAMATION_MARK | DASH
   private static boolean parameter_text_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "parameter_text_0")) return false;
     boolean r;
@@ -636,8 +689,6 @@ public class LatexParser implements PsiParser, LightPsiParser {
     if (!r) r = consumeToken(b, NORMAL_TEXT_WORD);
     if (!r) r = consumeToken(b, STAR);
     if (!r) r = consumeToken(b, AMPERSAND);
-    if (!r) r = consumeToken(b, OPEN_ANGLE_BRACKET);
-    if (!r) r = consumeToken(b, CLOSE_ANGLE_BRACKET);
     if (!r) r = consumeToken(b, QUOTATION_MARK);
     if (!r) r = consumeToken(b, PIPE);
     if (!r) r = consumeToken(b, EXCLAMATION_MARK);
@@ -671,7 +722,7 @@ public class LatexParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | parameter_text | BACKSLASH | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET
+  // raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | parameter_text | BACKSLASH | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET
   public static boolean picture_param_content(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "picture_param_content")) return false;
     boolean r;
@@ -691,6 +742,8 @@ public class LatexParser implements PsiParser, LightPsiParser {
     if (!r) r = consumeToken(b, EQUALS);
     if (!r) r = consumeToken(b, OPEN_BRACKET);
     if (!r) r = consumeToken(b, CLOSE_BRACKET);
+    if (!r) r = consumeToken(b, OPEN_ANGLE_BRACKET);
+    if (!r) r = consumeToken(b, CLOSE_ANGLE_BRACKET);
     exit_section_(b, l, m, r, false, null);
     return r;
   }
@@ -838,7 +891,7 @@ public class LatexParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | group | OPEN_PAREN | CLOSE_PAREN | parameter_text | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET | BACKSLASH
+  // raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | group | OPEN_PAREN | CLOSE_PAREN | parameter_text | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET | BACKSLASH | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET
   public static boolean required_param_content(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "required_param_content")) return false;
     boolean r;
@@ -859,6 +912,8 @@ public class LatexParser implements PsiParser, LightPsiParser {
     if (!r) r = consumeToken(b, OPEN_BRACKET);
     if (!r) r = consumeToken(b, CLOSE_BRACKET);
     if (!r) r = consumeToken(b, BACKSLASH);
+    if (!r) r = consumeToken(b, OPEN_ANGLE_BRACKET);
+    if (!r) r = consumeToken(b, CLOSE_ANGLE_BRACKET);
     exit_section_(b, l, m, r, false, null);
     return r;
   }

--- a/gen/nl/hannahsten/texifyidea/psi/LatexAngleParam.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexAngleParam.java
@@ -1,0 +1,13 @@
+// This is a generated file. Not intended for manual editing.
+package nl.hannahsten.texifyidea.psi;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElement;
+
+public interface LatexAngleParam extends PsiElement {
+
+  @NotNull
+  List<LatexAngleParamContent> getAngleParamContentList();
+
+}

--- a/gen/nl/hannahsten/texifyidea/psi/LatexAngleParamContent.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexAngleParamContent.java
@@ -1,0 +1,40 @@
+// This is a generated file. Not intended for manual editing.
+package nl.hannahsten.texifyidea.psi;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElement;
+
+public interface LatexAngleParamContent extends PsiElement {
+
+  @Nullable
+  LatexCommands getCommands();
+
+  @Nullable
+  LatexComment getComment();
+
+  @Nullable
+  LatexEnvironment getEnvironment();
+
+  @Nullable
+  LatexGroup getGroup();
+
+  @Nullable
+  LatexMagicComment getMagicComment();
+
+  @Nullable
+  LatexMathEnvironment getMathEnvironment();
+
+  @Nullable
+  LatexParameterText getParameterText();
+
+  @Nullable
+  LatexPseudocodeBlock getPseudocodeBlock();
+
+  @Nullable
+  LatexRawText getRawText();
+
+  @Nullable
+  PsiElement getCommandIfnextchar();
+
+}

--- a/gen/nl/hannahsten/texifyidea/psi/LatexParameter.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexParameter.java
@@ -10,6 +10,9 @@ import com.intellij.psi.LiteralTextEscaper;
 public interface LatexParameter extends PsiLanguageInjectionHost {
 
   @Nullable
+  LatexAngleParam getAngleParam();
+
+  @Nullable
   LatexOptionalParam getOptionalParam();
 
   @Nullable

--- a/gen/nl/hannahsten/texifyidea/psi/LatexTypes.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexTypes.java
@@ -11,6 +11,8 @@ import nl.hannahsten.texifyidea.psi.impl.*;
 
 public interface LatexTypes {
 
+  IElementType ANGLE_PARAM = new LatexElementType("ANGLE_PARAM");
+  IElementType ANGLE_PARAM_CONTENT = new LatexElementType("ANGLE_PARAM_CONTENT");
   IElementType BEGIN_COMMAND = new LatexElementType("BEGIN_COMMAND");
   IElementType COMMANDS = new LatexCommandsStubElementType("COMMANDS");
   IElementType COMMENT = new LatexElementType("COMMENT");
@@ -81,7 +83,13 @@ public interface LatexTypes {
   class Factory {
     public static PsiElement createElement(ASTNode node) {
       IElementType type = node.getElementType();
-      if (type == BEGIN_COMMAND) {
+      if (type == ANGLE_PARAM) {
+        return new LatexAngleParamImpl(node);
+      }
+      else if (type == ANGLE_PARAM_CONTENT) {
+        return new LatexAngleParamContentImpl(node);
+      }
+      else if (type == BEGIN_COMMAND) {
         return new LatexBeginCommandImpl(node);
       }
       else if (type == COMMANDS) {

--- a/gen/nl/hannahsten/texifyidea/psi/LatexVisitor.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexVisitor.java
@@ -9,6 +9,14 @@ import com.intellij.psi.PsiLanguageInjectionHost;
 
 public class LatexVisitor extends PsiElementVisitor {
 
+  public void visitAngleParam(@NotNull LatexAngleParam o) {
+    visitPsiElement(o);
+  }
+
+  public void visitAngleParamContent(@NotNull LatexAngleParamContent o) {
+    visitPsiElement(o);
+  }
+
   public void visitBeginCommand(@NotNull LatexBeginCommand o) {
     visitCommandWithParams(o);
   }

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexAngleParamContentImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexAngleParamContentImpl.java
@@ -1,0 +1,90 @@
+// This is a generated file. Not intended for manual editing.
+package nl.hannahsten.texifyidea.psi.impl;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
+import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import nl.hannahsten.texifyidea.psi.*;
+
+public class LatexAngleParamContentImpl extends ASTWrapperPsiElement implements LatexAngleParamContent {
+
+  public LatexAngleParamContentImpl(@NotNull ASTNode node) {
+    super(node);
+  }
+
+  public void accept(@NotNull LatexVisitor visitor) {
+    visitor.visitAngleParamContent(this);
+  }
+
+  @Override
+  public void accept(@NotNull PsiElementVisitor visitor) {
+    if (visitor instanceof LatexVisitor) accept((LatexVisitor)visitor);
+    else super.accept(visitor);
+  }
+
+  @Override
+  @Nullable
+  public LatexCommands getCommands() {
+    return PsiTreeUtil.getChildOfType(this, LatexCommands.class);
+  }
+
+  @Override
+  @Nullable
+  public LatexComment getComment() {
+    return PsiTreeUtil.getChildOfType(this, LatexComment.class);
+  }
+
+  @Override
+  @Nullable
+  public LatexEnvironment getEnvironment() {
+    return PsiTreeUtil.getChildOfType(this, LatexEnvironment.class);
+  }
+
+  @Override
+  @Nullable
+  public LatexGroup getGroup() {
+    return PsiTreeUtil.getChildOfType(this, LatexGroup.class);
+  }
+
+  @Override
+  @Nullable
+  public LatexMagicComment getMagicComment() {
+    return PsiTreeUtil.getChildOfType(this, LatexMagicComment.class);
+  }
+
+  @Override
+  @Nullable
+  public LatexMathEnvironment getMathEnvironment() {
+    return PsiTreeUtil.getChildOfType(this, LatexMathEnvironment.class);
+  }
+
+  @Override
+  @Nullable
+  public LatexParameterText getParameterText() {
+    return PsiTreeUtil.getChildOfType(this, LatexParameterText.class);
+  }
+
+  @Override
+  @Nullable
+  public LatexPseudocodeBlock getPseudocodeBlock() {
+    return PsiTreeUtil.getChildOfType(this, LatexPseudocodeBlock.class);
+  }
+
+  @Override
+  @Nullable
+  public LatexRawText getRawText() {
+    return PsiTreeUtil.getChildOfType(this, LatexRawText.class);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getCommandIfnextchar() {
+    return findChildByType(COMMAND_IFNEXTCHAR);
+  }
+
+}

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexAngleParamImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexAngleParamImpl.java
@@ -1,0 +1,36 @@
+// This is a generated file. Not intended for manual editing.
+package nl.hannahsten.texifyidea.psi.impl;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
+import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import nl.hannahsten.texifyidea.psi.*;
+
+public class LatexAngleParamImpl extends ASTWrapperPsiElement implements LatexAngleParam {
+
+  public LatexAngleParamImpl(@NotNull ASTNode node) {
+    super(node);
+  }
+
+  public void accept(@NotNull LatexVisitor visitor) {
+    visitor.visitAngleParam(this);
+  }
+
+  @Override
+  public void accept(@NotNull PsiElementVisitor visitor) {
+    if (visitor instanceof LatexVisitor) accept((LatexVisitor)visitor);
+    else super.accept(visitor);
+  }
+
+  @Override
+  @NotNull
+  public List<LatexAngleParamContent> getAngleParamContentList() {
+    return PsiTreeUtil.getChildrenOfTypeAsList(this, LatexAngleParamContent.class);
+  }
+
+}

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexParameterImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexParameterImpl.java
@@ -31,6 +31,12 @@ public class LatexParameterImpl extends ASTWrapperPsiElement implements LatexPar
 
   @Override
   @Nullable
+  public LatexAngleParam getAngleParam() {
+    return PsiTreeUtil.getChildOfType(this, LatexAngleParam.class);
+  }
+
+  @Override
+  @Nullable
   public LatexOptionalParam getOptionalParam() {
     return PsiTreeUtil.getChildOfType(this, LatexOptionalParam.class);
   }

--- a/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
+++ b/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
@@ -101,7 +101,7 @@ begin_command ::= BEGIN_TOKEN STAR? parameter* {
 
 end_command ::= END_TOKEN STAR? parameter* { pin=1 }
 
-parameter ::= optional_param | required_param | picture_param {
+parameter ::= optional_param | required_param | picture_param | angle_param {
     methods=[isValidHost updateText createLiteralTextEscaper]
 }
 
@@ -116,12 +116,18 @@ required_param ::= OPEN_BRACE required_param_content* CLOSE_BRACE { pin=1 }
 
 picture_param ::= OPEN_PAREN picture_param_content* CLOSE_PAREN { pin=3 }
 
+// e.g. overlay specifier in beamer
+angle_param ::= OPEN_ANGLE_BRACKET angle_param_content* CLOSE_ANGLE_BRACKET { pin=3 }
+
 // These are like content, but no brackets and with parameter_text instead of normal_text
 // We have to separate optional and required parameter content, because required parameter content
 // can contain mismatched brackets, but optional parameters not (then we wouldn't know what to match)
-optional_param_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | OPEN_PAREN | CLOSE_PAREN | parameter_text | BACKSLASH
-required_param_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | group | OPEN_PAREN | CLOSE_PAREN | parameter_text | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET | BACKSLASH
-picture_param_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | parameter_text | BACKSLASH | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET
+optional_param_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | OPEN_PAREN | CLOSE_PAREN | parameter_text | BACKSLASH | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET
+required_param_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | group | OPEN_PAREN | CLOSE_PAREN | parameter_text | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET | BACKSLASH | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET
+// Cannot contain ( or )
+picture_param_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | parameter_text | BACKSLASH | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET
+// Cannot contain < or >
+angle_param_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | parameter_text | BACKSLASH | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET
 
 keyval_pair ::= keyval_key (EQUALS keyval_value?)?
 keyval_key ::= keyval_content+ {
@@ -138,7 +144,7 @@ keyval_content ::= parameter_text | parameter_group
 // So, the following is like normal_text
 // This assumes that parameter text which is a reference, appears directly under param_content
 // Commands is here instead of in required_param_content because it can be part of reference text for example to a file
-parameter_text ::= (commands | NORMAL_TEXT_WORD | STAR | AMPERSAND | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET | QUOTATION_MARK | PIPE | EXCLAMATION_MARK | DASH)+ {
+parameter_text ::= (commands | NORMAL_TEXT_WORD | STAR | AMPERSAND | QUOTATION_MARK | PIPE | EXCLAMATION_MARK | DASH)+ {
    methods=[getReferences getReference getNameIdentifier getName setName delete]
 }
 

--- a/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
+++ b/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
@@ -28,7 +28,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
         ): MutableList<String> {
             // For now only support custom executable for TeX Live
             // At least avoids prepending a full path to a supposed TeX Live executable when in fact it will be prepended by a docker command
-            val executable = LatexSdkUtil.getExecutableName(executableName, runConfig.project)
+            val executable = LatexSdkUtil.getExecutableName(executableName, runConfig.project, runConfig.getLatexDistributionType())
             val command = mutableListOf(runConfig.compilerPath ?: executable)
 
             command.add("-file-line-error")
@@ -63,7 +63,11 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
             moduleRoot: VirtualFile?,
             moduleRoots: Array<VirtualFile>
         ): MutableList<String> {
-            val command = mutableListOf(runConfig.compilerPath ?: LatexSdkUtil.getExecutableName(executableName, runConfig.project))
+            val command = mutableListOf(runConfig.compilerPath ?: LatexSdkUtil.getExecutableName(
+                executableName,
+                runConfig.project,
+                runConfig.getLatexDistributionType()
+            ))
 
             // Some commands are the same as for pdflatex
             command.add("-file-line-error")
@@ -95,7 +99,11 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
             moduleRoot: VirtualFile?,
             moduleRoots: Array<VirtualFile>
         ): MutableList<String> {
-            val command = mutableListOf(runConfig.compilerPath ?: LatexSdkUtil.getExecutableName(executableName, runConfig.project))
+            val command = mutableListOf(runConfig.compilerPath ?: LatexSdkUtil.getExecutableName(
+                executableName,
+                runConfig.project,
+                runConfig.getLatexDistributionType()
+            ))
 
             val isLatexmkRcFilePresent = LatexmkRcFileFinder.isLatexmkRcFilePresent(runConfig)
 
@@ -134,7 +142,11 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
             moduleRoot: VirtualFile?,
             moduleRoots: Array<VirtualFile>
         ): MutableList<String> {
-            val command = mutableListOf(runConfig.compilerPath ?: LatexSdkUtil.getExecutableName(executableName, runConfig.project))
+            val command = mutableListOf(runConfig.compilerPath ?: LatexSdkUtil.getExecutableName(
+                executableName,
+                runConfig.project,
+                runConfig.getLatexDistributionType()
+            ))
 
             // As usual, available command line options can be viewed with xelatex --help
             // On TeX Live, installing collection-xetex should be sufficient to get xelatex
@@ -174,7 +186,11 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
             moduleRoot: VirtualFile?,
             moduleRoots: Array<VirtualFile>
         ): MutableList<String> {
-            val command = mutableListOf(runConfig.compilerPath ?: LatexSdkUtil.getExecutableName(executableName, runConfig.project))
+            val command = mutableListOf(runConfig.compilerPath ?: LatexSdkUtil.getExecutableName(
+                executableName,
+                runConfig.project,
+                runConfig.getLatexDistributionType()
+            ))
 
             // texliveonfly is a Python script which calls other compilers (by default pdflatex), main feature is downloading packages automatically
             // commands can be passed to those compilers with the arguments flag, however apparently IntelliJ cannot handle quotes so we cannot pass multiple arguments to pdflatex.

--- a/src/nl/hannahsten/texifyidea/settings/sdk/LatexSdkUtil.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/LatexSdkUtil.kt
@@ -122,7 +122,10 @@ object LatexSdkUtil {
     /**
      * Get executable name of pdflatex, which in case it is not in PATH may be prefixed by the full path (or even by a docker command).
      */
-    fun getExecutableName(executableName: String, project: Project): String {
+    fun getExecutableName(executableName: String, project: Project, latexDistributionType: LatexDistributionType? = null): String {
+        // Prefixing the LaTeX compiler is not relevant for Docker MiKTeX (perhaps the path to the docker executable)
+        if (latexDistributionType == LatexDistributionType.DOCKER_MIKTEX) return executableName
+
         // Give preference to the project SDK if a valid LaTeX SDK is selected
         getLatexProjectSdk(project)?.let { sdk ->
             if (sdk.homePath != null) {

--- a/test/nl/hannahsten/texifyidea/formatting/LatexFormattingTest.kt
+++ b/test/nl/hannahsten/texifyidea/formatting/LatexFormattingTest.kt
@@ -69,6 +69,36 @@ class LatexFormattingTest : BasePlatformTestCase() {
         """.trimIndent()
     }
 
+    fun `test angle parameter formatting`() {
+        """
+            \documentclass{beamer}
+            
+            \begin{document}
+                \begin{frame}
+                    \begin{block}{Title}<1->
+                    Appel.
+                    \end{block}
+                    \begin{block}{Title}<2->
+                    Peer.
+                    \end{block}
+                \end{frame}
+            \end{document}
+        """.trimIndent() `should be reformatted to` """
+            \documentclass{beamer}
+            
+            \begin{document}
+                \begin{frame}
+                    \begin{block}{Title}<1->
+                        Appel.
+                    \end{block}
+                    \begin{block}{Title}<2->
+                        Peer.
+                    \end{block}
+                \end{frame}
+            \end{document}
+        """.trimIndent()
+    }
+
     fun `test indentation in parameter`() {
         """
             \documentclass[


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2044

#### Summary of additions and changes

* Apparently beamer decided that using yet another symbol for parameters is a good idea: `<...>`

#### How to test this pull request

Formatting now doesn't break the document anymore:
```latex
\documentclass{beamer}

\begin{document}
    \begin{frame}
        \begin{block}{1-}<1->
        Contents 1.
        \end{block}
        \begin{block}{Title}<2->
        Contents 2.
        \end{block}
    \end{frame}
\end{document}

```

