### PR TITLE
TEX-130: allow empty bib field

### DIFF
--- a/gen/nl/hannahsten/texifyidea/parser/BibtexParser.java
+++ b/gen/nl/hannahsten/texifyidea/parser/BibtexParser.java
@@ -57,7 +57,7 @@ public class BibtexParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // OPEN_BRACE normal_text+ CLOSE_BRACE
+  // OPEN_BRACE normal_text* CLOSE_BRACE
   public static boolean braced_string(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "braced_string")) return false;
     if (!nextTokenIs(b, OPEN_BRACE)) return false;
@@ -71,19 +71,15 @@ public class BibtexParser implements PsiParser, LightPsiParser {
     return r || p;
   }
 
-  // normal_text+
+  // normal_text*
   private static boolean braced_string_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "braced_string_1")) return false;
-    boolean r;
-    Marker m = enter_section_(b);
-    r = normal_text(b, l + 1);
-    while (r) {
+    while (true) {
       int c = current_position_(b);
       if (!normal_text(b, l + 1)) break;
       if (!empty_element_parsed_guard_(b, "braced_string_1", c)) break;
     }
-    exit_section_(b, m, null, r);
-    return r;
+    return true;
   }
 
   /* ********************************************************** */

--- a/gen/nl/hannahsten/texifyidea/psi/impl/BibtexEntryImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/BibtexEntryImpl.java
@@ -17,8 +17,8 @@ import com.intellij.psi.tree.IElementType;
 
 public class BibtexEntryImpl extends StubBasedPsiElementBase<BibtexEntryStub> implements BibtexEntry {
 
-  public BibtexEntryImpl(@NotNull BibtexEntryStub stub, @NotNull IStubElementType type) {
-    super(stub, type);
+  public BibtexEntryImpl(@NotNull BibtexEntryStub stub, @NotNull IStubElementType<?, ?> nodeType) {
+    super(stub, nodeType);
   }
 
   public BibtexEntryImpl(@NotNull ASTNode node) {

--- a/src/nl/hannahsten/texifyidea/BibtexParserDefinition.kt
+++ b/src/nl/hannahsten/texifyidea/BibtexParserDefinition.kt
@@ -50,7 +50,7 @@ class BibtexParserDefinition : ParserDefinition {
         val FILE = object : IStubFileElementType<BibtexFileStub>(
             Language.findInstance(BibtexLanguage::class.java)
         ) {
-            override fun getStubVersion(): Int = 7
+            override fun getStubVersion(): Int = 8
         }
     }
 

--- a/src/nl/hannahsten/texifyidea/grammar/Bibtex.bnf
+++ b/src/nl/hannahsten/texifyidea/grammar/Bibtex.bnf
@@ -55,7 +55,7 @@ defined_string ::= IDENTIFIER {
 
 quoted_string ::= QUOTES normal_text? END_QUOTES { pin=1 }
 
-braced_string ::= OPEN_BRACE normal_text+ CLOSE_BRACE { pin=1 }
+braced_string ::= OPEN_BRACE normal_text* CLOSE_BRACE { pin=1 }
 
 comment ::= COMMENT_TOKEN
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix [TEX-130](https://texify-idea.myjetbrains.com/youtrack/issue/TEX-130)

#### Summary of additions and changes

* Allow a bibtex field given in `{...}` to be empty.

#### How to test this pull request

```bibtex
@Book{knuth1990,
    author    = {Knuth, Donald E.},
    title     = {The {\TeX}book },
    year      = {1990},
    isbn      = {},
    publisher = {Addison\,\textendash\,Wesley},
}
```
should not give a parse error.