### PR TITLE
Add Tectonic SDK

### DIFF
--- a/resources/META-INF/extensions/project-settings.xml
+++ b/resources/META-INF/extensions/project-settings.xml
@@ -6,6 +6,7 @@
         <sdkType implementation="nl.hannahsten.texifyidea.settings.sdk.MiktexWindowsSdk" />
         <sdkType implementation="nl.hannahsten.texifyidea.settings.sdk.NativeTexliveSdk" />
         <sdkType implementation="nl.hannahsten.texifyidea.settings.sdk.MiktexLinuxSdk" />
+        <sdkType implementation="nl.hannahsten.texifyidea.settings.sdk.TectonicSdk" />
         <projectSdkSetupValidator implementation="nl.hannahsten.texifyidea.settings.sdk.LatexProjectSdkSetupValidator" />
     </extensions>
 </idea-plugin>

--- a/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
@@ -127,7 +127,7 @@ class InputFileReference(
             }
         }
 
-        // Try search paths
+        // Try graphicspaths
         if (targetFile == null) {
             // If we are not building the fileset, we can make use of it
             if (!isBuildingFileset && element.containingFile.includedPackages().contains(LatexGenericRegularCommand.GRAPHICSPATH.dependency)) {

--- a/src/nl/hannahsten/texifyidea/settings/sdk/LatexSdkUtil.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/LatexSdkUtil.kt
@@ -163,7 +163,7 @@ object LatexSdkUtil {
     /**
      * If a LaTeX SDK is selected as project SDK, return it, otherwise return null.
      */
-    private fun getLatexProjectSdk(project: Project): Sdk? {
+    fun getLatexProjectSdk(project: Project): Sdk? {
         val sdk = ProjectRootManager.getInstance(project).projectSdk
         if (sdk?.sdkType is LatexSdk) {
             return sdk

--- a/src/nl/hannahsten/texifyidea/settings/sdk/TectonicSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/TectonicSdk.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.settings.sdk
 
+import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import nl.hannahsten.texifyidea.run.latex.LatexDistributionType
@@ -15,7 +16,6 @@ class TectonicSdk : LatexSdk("Tectonic SDK") {
     companion object {
 
         // Map readable file name (e.g. article.sty) to actual file path on disk
-        // todo make thread safe
         var fileLocationCache: Map<String, String>? = null
     }
 
@@ -26,19 +26,22 @@ class TectonicSdk : LatexSdk("Tectonic SDK") {
     fun getPackageLocation(name: String, homePath: String?): String {
         if (homePath == null) return ""
 
-        if (fileLocationCache != null) {
-            fileLocationCache = File("$homePath/urls").listFiles()
-                // Get manifest names
-                ?.mapNotNull { it.readText().trim() }
-                // Get manifest contents
-                ?.flatMap { File("$homePath/manifests/$it.txt").readLines().map { line -> line.trim() } }
-                // Example line: article.sty 1741 9697d28bf5cc3d2f...
-                ?.map { it.split(" ").filter { word -> word.isNotBlank() } }
-                ?.filter { it.size >= 2 }
-                // Map human readable file name to file name on disk
-                ?.associate { Pair(it.first(), it.last()) }
-                // Tectonic stores files like this, currently
-                ?.mapValues { "$homePath/files/${it.value.take(2)}/${it.value.drop(2)}" } ?: return ""
+        // Avoid many threads trying to fill the cache at the same time
+        synchronized(this) {
+            if (fileLocationCache == null) {
+                fileLocationCache = File("$homePath/urls").listFiles()
+                    // Get manifest names
+                    ?.mapNotNull { it.readText().trim() }
+                    // Get manifest contents
+                    ?.flatMap { File("$homePath/manifests/$it.txt").readLines().map { line -> line.trim() } }
+                    // Example line: article.sty 1741 9697d28bf5cc3d2f...
+                    ?.map { it.split(" ").filter { word -> word.isNotBlank() } }
+                    ?.filter { it.size >= 2 }
+                    // Map human readable file name to file name on disk
+                    ?.associate { Pair(it.first(), it.last()) }
+                    // Tectonic stores files like this, currently
+                    ?.mapValues { "$homePath/files/${it.value.take(2)}/${it.value.drop(2)}" } ?: return ""
+            }
         }
         return fileLocationCache?.get(name) ?: ""
     }
@@ -48,8 +51,12 @@ class TectonicSdk : LatexSdk("Tectonic SDK") {
     // We assume Tectonic is in PATH.
     override fun getExecutableName(executable: String, homePath: String) = executable
 
-    override fun suggestHomePath(): String? {
-        return "~/.cache/Tectonic" // todo see github issue
+    override fun suggestHomePath(): String {
+        // https://github.com/tectonic-typesetting/tectonic/issues/159
+        val home = System.getProperty("user.home")
+        return if (SystemInfo.isMac) "$home/Library/Caches/Tectonic"
+        else if (SystemInfo.isWindows) "$home/TectonicProject/Tectonic" // Did not test if this works
+        else "$home/.cache/Tectonic"
     }
 
     // The home path we are interested in, is actually the cache path, as it contains all the LaTeX files.

--- a/src/nl/hannahsten/texifyidea/settings/sdk/TectonicSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/TectonicSdk.kt
@@ -1,0 +1,47 @@
+package nl.hannahsten.texifyidea.settings.sdk
+
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import nl.hannahsten.texifyidea.run.latex.LatexDistributionType
+import java.io.File
+
+/**
+ * Tectonic has its own source, which is in effect TeX Live, but since it is stored not in TeX Live format
+ * but in a Tectonic-specific cache it warrants its own SDK.
+ */
+class TectonicSdk : LatexSdk("Tectonic SDK") {
+    override fun getLatexDistributionType() = LatexDistributionType.TEXLIVE
+
+    // We assume Tectonic is in PATH.
+    override fun getExecutableName(executable: String, homePath: String) = executable
+
+    override fun suggestHomePath(): String? {
+        return "~/.cache/Tectonic"
+    }
+
+    // The home path we are interested in, is actually the cache path, as it contains all the LaTeX files.
+    override fun isValidSdkHome(path: String): Boolean {
+        return File(path).run {
+            // We are looking for a urls directory as bootstrap
+            exists() && isDirectory && listFiles()?.map { it.name }?.contains("urls") == true
+        }
+    }
+
+    override fun getInvalidHomeMessage(path: String) = "Please select the caches path for Tectonic"
+
+    // todo tectonic -X bundle search
+
+    // todo is this possible?
+//    override fun getVersionString(sdkHome: String?): String? {
+//        return super.getVersionString(sdkHome)
+//    }
+
+    // todo actually there are no dtx files, just sty, def, clo, cls, tec, cfg, otf, fd, ltx, enc, pfb, tex and ini?
+    override fun getDefaultSourcesPath(homePath: String): VirtualFile? {
+        return LocalFileSystem.getInstance().findFileByPath("$homePath/files")
+    }
+
+    override fun getDefaultStyleFilesPath(homePath: String): VirtualFile? {
+        return getDefaultSourcesPath(homePath)
+    }
+}

--- a/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
@@ -2,6 +2,7 @@ package nl.hannahsten.texifyidea.util.files
 
 import com.intellij.openapi.project.Project
 import nl.hannahsten.texifyidea.settings.sdk.LatexSdkUtil
+import nl.hannahsten.texifyidea.settings.sdk.TectonicSdk
 import nl.hannahsten.texifyidea.util.runCommand
 import java.io.IOException
 
@@ -24,7 +25,14 @@ object LatexPackageLocationCache {
      */
     fun getPackageLocation(name: String, project: Project): String? {
         if (cache.containsKey(name).not()) {
-            val path = runKpsewhich(name, project)
+            // Tectonic does not have kpsewhich, but works a little differently
+            val projectSdk = LatexSdkUtil.getLatexProjectSdk(project)
+            val path = if (projectSdk?.sdkType is TectonicSdk) {
+                (projectSdk.sdkType as TectonicSdk).getPackageLocation(name, projectSdk.homePath)
+            }
+            else {
+                runKpsewhich(name, project)
+            }
             if (path?.isBlank() == true) return null
             cache[name] = path
             return path


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2080

#### Summary of additions and changes

* Add Tectonic SDK
* Implement input file reference resolving for package/class files

#### How to test this pull request

Install Tectonic, use Tectonic SDK and see that `\documentclass{article}` will resolve to the right file.

#### Wiki

<!-- Add link to updated wiki page -->
- [ ] Updated the wiki: