### PR TITLE
Add verbatim toggle intention

### DIFF
--- a/resources/META-INF/extensions/intentions.xml
+++ b/resources/META-INF/extensions/intentions.xml
@@ -71,5 +71,11 @@
             <category>LaTeX</category>
             <descriptionDirectoryName>LatexLanguageInjectionIntention</descriptionDirectoryName>
         </intentionAction>
+
+        <intentionAction>
+            <className>nl.hannahsten.texifyidea.intentions.LatexVerbatimToggle</className>
+            <category>LaTeX</category>
+            <descriptionDirectoryName>LatexVerbatimToggleIntention</descriptionDirectoryName>
+        </intentionAction>
     </extensions>
 </idea-plugin>

--- a/src/nl/hannahsten/texifyidea/intentions/LatexVerbatimToggle.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexVerbatimToggle.kt
@@ -1,0 +1,114 @@
+package nl.hannahsten.texifyidea.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiWhiteSpace
+import nl.hannahsten.texifyidea.lang.Environment
+import nl.hannahsten.texifyidea.lang.LatexPackage
+import nl.hannahsten.texifyidea.lang.commands.LatexCommand
+import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.psi.LatexEnvironment
+import nl.hannahsten.texifyidea.psi.LatexPsiHelper
+import nl.hannahsten.texifyidea.ui.PopupChooserCellRenderer
+import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.files.getAllRequiredArguments
+import nl.hannahsten.texifyidea.util.files.isLatexFile
+import nl.hannahsten.texifyidea.util.magic.CommandMagic
+import nl.hannahsten.texifyidea.util.magic.EnvironmentMagic
+
+class LatexVerbatimToggle : TexifyIntentionBase("Convert to other verbatim command or environment") {
+
+    override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean {
+        if (editor == null || file == null || !file.isLatexFile()) {
+            return false
+        }
+
+        val element = file.findElementAt(editor.caretModel.offset) ?: return false
+
+       return element.isVerbCommand() || element.isVerbEnvironment()
+    }
+
+    override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
+        if (editor == null || file == null || !file.isLatexFile()) {
+            return
+        }
+
+        val element = file.findElementAt(editor.caretModel.offset) ?: return
+
+        val availableEnvironments: List<String> = (CommandMagic.verbatim.keys + EnvironmentMagic.verbatim)
+            .filter { it != element.getVerbatimName() }
+
+        // Ask for the new environment name.
+        JBPopupFactory.getInstance()
+            .createPopupChooserBuilder(availableEnvironments)
+            .setTitle("Verbatim Environments")
+            .setItemChosenCallback { replaceVerbatim(element, it, file, project) }
+            .setRenderer(PopupChooserCellRenderer())
+            .createPopup()
+            .showInBestPositionFor(editor)
+    }
+
+    private fun PsiElement.isVerbCommand() = getVerbatimName() in CommandMagic.verbatim
+
+    private fun PsiElement.isVerbEnvironment() = getVerbatimName() in EnvironmentMagic.verbatim
+
+    private fun PsiElement.getVerbatimName(): String? =
+        firstParentOfType(LatexCommands::class)?.name?.removePrefix("\\")
+        ?: firstParentOfType(LatexEnvironment::class)?.name()?.name
+
+    private fun replaceVerbatim(oldVerbatim: PsiElement, newVerbatim: String, file: PsiFile, project: Project) {
+        val (content, parent, oldArgCharacter) = if (oldVerbatim.isVerbCommand()) {
+            val content = oldVerbatim.firstParentOfType(LatexCommands::class)?.getAllRequiredArguments()?.firstOrNull()
+            val parent = oldVerbatim.firstParentOfType(LatexCommands::class)?.parent
+            Triple(content, parent, CommandMagic.verbatim[oldVerbatim.getVerbatimName()] == true)
+        }
+        else if (oldVerbatim.isVerbEnvironment()) {
+            val content = oldVerbatim.firstParentOfType(LatexEnvironment::class)?.environmentContent?.text
+            val parent = oldVerbatim.firstParentOfType(LatexEnvironment::class)?.parent
+            Triple(content, parent, false)
+        }
+        else Triple(null, null, false)
+
+        val newElement = if (newVerbatim in CommandMagic.verbatim.keys) {
+            val newArgCharacter = CommandMagic.verbatim[newVerbatim] == true
+            val arg = when {
+                oldArgCharacter && newArgCharacter -> content
+                oldArgCharacter && !newArgCharacter -> "{${content?.drop(1)?.dropLast(1)}}"
+                !oldArgCharacter && newArgCharacter -> "|$content|"
+                else -> "{$content}"
+            }
+            LatexPsiHelper(project).createFromText("\\$newVerbatim$arg")
+                .firstChildOfType(LatexCommands::class)
+        }
+        else {
+            val environmentContent = if (oldArgCharacter) content?.drop(1)?.dropLast(1) else content
+            LatexPsiHelper(project).createFromText("\\begin{$newVerbatim}\n$environmentContent\n\\end{$newVerbatim}")
+                .firstChildOfType(LatexEnvironment::class)
+        } ?: return
+
+        runWriteCommandAction(project) {
+            parent?.node?.replaceChild(parent.firstChild.node, newElement.node)
+
+            if (oldVerbatim.isVerbCommand() && newVerbatim in EnvironmentMagic.verbatim) {
+               LatexPsiHelper(project).createFromText("\n")
+                    .firstChildOfType(PsiWhiteSpace::class)
+                    ?.node
+                    ?.let {
+                        parent?.node?.addChild(it, newElement.node)
+                    }
+            }
+
+            findDependency(newElement)?.let { file.insertUsepackage(it) }
+        }
+    }
+
+    private fun findDependency(verbatim: PsiElement): LatexPackage? =
+        (verbatim as? LatexCommands)?.let {
+            LatexCommand.lookup(it)?.firstOrNull()?.dependency
+        } ?: verbatim.getVerbatimName()?.let {
+            Environment.lookup(it)?.dependency
+        }
+}

--- a/src/nl/hannahsten/texifyidea/intentions/LatexVerbatimToggle.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexVerbatimToggle.kt
@@ -41,14 +41,19 @@ class LatexVerbatimToggle : TexifyIntentionBase("Convert to other verbatim comma
         val availableEnvironments: List<String> = (CommandMagic.verbatim.keys + EnvironmentMagic.verbatim)
             .filter { it != element.getName() }
 
-        // Ask for the new environment name.
-        JBPopupFactory.getInstance()
-            .createPopupChooserBuilder(availableEnvironments)
-            .setTitle("Verbatim Environments")
-            .setItemChosenCallback { replaceVerbatim(element, it, file, project) }
-            .setRenderer(PopupChooserCellRenderer())
-            .createPopup()
-            .showInBestPositionFor(editor)
+        if (availableEnvironments.size == 1) {
+            replaceVerbatim(element, availableEnvironments.firstOrNull()!!, file, project)
+        }
+        // Ask for the new environment name when there are multiple options.
+        else {
+            JBPopupFactory.getInstance()
+                .createPopupChooserBuilder(availableEnvironments)
+                .setTitle("Verbatim Environments")
+                .setItemChosenCallback { replaceVerbatim(element, it, file, project) }
+                .setRenderer(PopupChooserCellRenderer())
+                .createPopup()
+                .showInBestPositionFor(editor)
+        }
     }
 
     private fun PsiElement.isVerbCommand() = getName() in CommandMagic.verbatim

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexListingCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexListingCommand.kt
@@ -2,6 +2,7 @@ package nl.hannahsten.texifyidea.lang.commands
 
 import nl.hannahsten.texifyidea.lang.LatexPackage
 import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.LISTINGS
+import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.LUACODE
 
 /**
  * @author Hannah Schellekens
@@ -15,7 +16,9 @@ enum class LatexListingCommand(
         val collapse: Boolean = false
 ) : LatexCommand {
 
-    LSTINPUTLISTING("lstinputlisting", "options".asOptional(), RequiredFileArgument("filename", false, commaSeparatesArguments = false), dependency = LISTINGS)
+    LSTINPUTLISTING("lstinputlisting", "options".asOptional(), RequiredFileArgument("filename", false, commaSeparatesArguments = false), dependency = LISTINGS),
+    DIRECTLUA("directlua", dependency = LUACODE),
+    LUAEXEC("luaexec", dependency = LUACODE),
     ;
 
     override val identifyer: String

--- a/src/nl/hannahsten/texifyidea/psi/LatexPsiHelper.kt
+++ b/src/nl/hannahsten/texifyidea/psi/LatexPsiHelper.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import nl.hannahsten.texifyidea.LatexLanguage
 import nl.hannahsten.texifyidea.psi.LatexTypes.*
@@ -150,4 +151,11 @@ class LatexPsiHelper(private val project: Project) {
             closeBracket.prevSibling as LatexKeyvalPair
         }
     }
+
+    /**
+     * Create a [PsiWhiteSpace] element that contains the first spacing of the string [space].
+     */
+    fun createSpacing(space: String = " "): PsiWhiteSpace? = LatexPsiHelper(project)
+        .createFromText(space)
+        .firstChildOfType(PsiWhiteSpace::class)
 }

--- a/src/nl/hannahsten/texifyidea/ui/PopupChooserCellRenderer.kt
+++ b/src/nl/hannahsten/texifyidea/ui/PopupChooserCellRenderer.kt
@@ -13,7 +13,7 @@ import javax.swing.border.EmptyBorder
  *
  * @author Abby Berkers
  */
-class PopupChooserCellRenderer : ListCellRenderer<String> {
+open class PopupChooserCellRenderer : ListCellRenderer<String> {
 
     override fun getListCellRendererComponent(list: JList<out String>?, value: String?, position: Int, isSelected: Boolean, hasFocus: Boolean): Component {
         val renderer = DefaultListCellRenderer().getListCellRendererComponent(

--- a/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
@@ -7,6 +7,7 @@ import nl.hannahsten.texifyidea.lang.CommandManager
 import nl.hannahsten.texifyidea.lang.commands.LatexBiblatexCommand.*
 import nl.hannahsten.texifyidea.lang.commands.LatexCommand
 import nl.hannahsten.texifyidea.lang.commands.LatexGenericMathCommand.*
+import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
 import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand.*
 import nl.hannahsten.texifyidea.lang.commands.LatexIfCommand.*
 import nl.hannahsten.texifyidea.lang.commands.LatexListingCommand.LSTINPUTLISTING
@@ -385,4 +386,18 @@ object CommandMagic {
             DIRECTLUA.cmd to "Lua",
             LUAEXEC.cmd to "Lua"
     )
+
+    /**
+     * Commands that have a verbatim argument.
+     *
+     * Maps a command to a boolean that is true when the required argument can be specified with any pair of characters.
+     */
+    val verbatim = hashMapOf(
+        "verb" to true,
+        "verb*" to true,
+        "directlua" to false,
+        "luaexec" to false,
+        "lstinline" to true
+    )
+
 }

--- a/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
@@ -7,7 +7,6 @@ import nl.hannahsten.texifyidea.lang.CommandManager
 import nl.hannahsten.texifyidea.lang.commands.LatexBiblatexCommand.*
 import nl.hannahsten.texifyidea.lang.commands.LatexCommand
 import nl.hannahsten.texifyidea.lang.commands.LatexGenericMathCommand.*
-import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
 import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand.*
 import nl.hannahsten.texifyidea.lang.commands.LatexIfCommand.*
 import nl.hannahsten.texifyidea.lang.commands.LatexListingCommand.LSTINPUTLISTING
@@ -399,5 +398,4 @@ object CommandMagic {
         "luaexec" to false,
         "lstinline" to true
     )
-
 }

--- a/src/nl/hannahsten/texifyidea/util/magic/EnvironmentMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/EnvironmentMagic.kt
@@ -34,7 +34,8 @@ object EnvironmentMagic {
 
     // Note: used in the lexer
     @JvmField
-    val verbatim = hashSetOf(VERBATIM.env, VERBATIM_CAPITAL.env, LISTINGS.env, "plantuml", LUACODE.env,
+    val verbatim = hashSetOf(
+        VERBATIM.env, VERBATIM_CAPITAL.env, LISTINGS.env, "plantuml", LUACODE.env,
         LUACODE_STAR.env, "sagesilent", "sageblock", "sagecommandline", "sageverbatim", "sageexample", "minted"
     )
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix [TEX-41](https://texify-idea.myjetbrains.com/youtrack/issue/TEX-41)

#### Summary of additions and changes

* Added intention to toggle between different verbatim environments/commands (similar to the math environments toggle)

#### How to test this pull request

```latex
\documentclass{article}

\begin{document}
    Have some \verb|\verb?test?| in this sentence
\end{document}
```

#### Wiki

<!-- Add link to updated wiki page -->
- [ ] Updated the wiki: