### PR TITLE
Number required parameters in auto completion (#2106)

### DIFF
--- a/src/nl/hannahsten/texifyidea/completion/LatexCommandsAndEnvironmentsCompletionProvider.kt
+++ b/src/nl/hannahsten/texifyidea/completion/LatexCommandsAndEnvironmentsCompletionProvider.kt
@@ -1,6 +1,5 @@
 package nl.hannahsten.texifyidea.completion
 
-import com.google.common.base.Strings
 import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionResultSet
@@ -258,7 +257,12 @@ class LatexCommandsAndEnvironmentsCompletionProvider internal constructor(privat
                     catch (ignore: NumberFormatException) {
                     }
                 }
-                (if (optional.size == 2) "[args]" else "") + Strings.repeat("{param}", requiredParameterCount)
+
+                (if (optional.size == 2) "[args]" else "") +
+                        if (requiredParameterCount == 1) "{param}"
+                        // Number the required parameters so a toSet call won't merge them. This way the
+                        // user can keep them apart as well.
+                        else (1..requiredParameterCount).joinToString("") { "{param$it}" }
             }
 
             "\\DeclarePairedDelimiter" -> "{param}"


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2106

#### Summary of additions and changes

* Number the required parameters in autocompletion, which fixes #2106.

#### How to test this pull request

```latex
\documentclass{article}

\newcommand{\test}[3][1]{#1#2#3}
\newcommand{\foo}[2]{#1#2}

% Document
\begin{document}
    \test
    \foo
\end{document}
```

Unfortunately it's not possible to write a test that checks for two arguments in the tail text of the autocompletion. The `LookupElementPresentation` that contains the tail text is private in the `LookupElementBuilder`, and we cannot access it.