### PR TITLE
Inspect only strict duplicated command definitions.

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/redundancy/LatexDuplicateDefinitionInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/redundancy/LatexDuplicateDefinitionInspection.kt
@@ -30,7 +30,7 @@ open class LatexDuplicateDefinitionInspection : TexifyInspectionBase() {
 
         // Find all defined commands.
         val defined = HashMultiset.create<String>()
-        val definitions = file.definitionsInFileSet().filter { it.name in CommandMagic.regularCommandDefinitions }
+        val definitions = file.definitionsInFileSet().filter { it.name in CommandMagic.regularStrictCommandDefinitions }
         for (command in definitions) {
             val name = command.definedCommandName() ?: continue
             defined.add(name)
@@ -38,7 +38,6 @@ open class LatexDuplicateDefinitionInspection : TexifyInspectionBase() {
 
         // Go monkeys.
         file.definitions()
-            .filter { it.name in CommandMagic.regularStrictCommandDefinitions }
             .forEach {
                 val definedCmd = it.definedCommandName() ?: return@forEach
                 if (defined.count(definedCmd) > 1) {

--- a/test/nl/hannahsten/texifyidea/inspections/latex/redundancy/LatexDuplicateDefinitionInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/redundancy/LatexDuplicateDefinitionInspectionTest.kt
@@ -11,9 +11,6 @@ class LatexDuplicateDefinitionInspectionTest : TexifyInspectionTestBase(LatexDup
             """
             <error descr="Command '\cmdtwo' is defined multiple times">\newcommand{\cmdtwo}{a}</error>
             <error descr="Command '\cmdtwo' is defined multiple times">\newcommand{\cmdtwo}{a}</error>
-            
-            \providecommand{\test}{}
-            <error descr="Command '\test' is defined multiple times">\newcommand{\test}{}</error>
             """.trimIndent()
         )
         myFixture.checkHighlighting()
@@ -27,6 +24,17 @@ class LatexDuplicateDefinitionInspectionTest : TexifyInspectionTestBase(LatexDup
             \renewcommand{\cmd}{a}
             
             \providecommand{\provided}{}
+            """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun testNewcommand() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \newcommand{\foo}{}
+            \renewcommand{\foo}{}
             """.trimIndent()
         )
         myFixture.checkHighlighting()


### PR DESCRIPTION
<!-- This is my first open-source pull request. Feedback is much appreciated. -->

Per issue #2199, a strict command definition followed by a non-strict command definition is valid LaTeX. This change ensures this use case is not incorrectly flagged as an error by the plugin inspector.

<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2199.

#### Summary of additions and changes

* Duplicate definition inspection will now only inspect strict command definitions instead of all command definitions.

#### Known Issues

* A single `\renewcommand` for an undefined command will not compile, but is not flagged as an error by the inspector. This was an issue before this PR, and is addressed by #2201, so this is not a regression.
* Placing the `\renewcommand` before the `\newcommand` before a particular command will not be flagged as an error, but will not compile. This is _technically_ a regression, as this would be flagged before this PR, but the _correct_ ordering of `\newcommand` before `\renewcommand` would have been flagged before the PR, so I think this regression is justified.

I am not aware of any issues involving any other command definitions. Strict definitions behave the same as before the PR, and redefinitions that are not `\renewcommand` all support multiple definitions, so their behavior now matches expected behavior.

