### PR TITLE
Add missing cases in usepackage in package inspection

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexUsePackageInPackageInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexUsePackageInPackageInspection.kt
@@ -9,9 +9,10 @@ class LatexUsePackageInPackageInspection : TexifyRegexInspection(
     inspectionDisplayName = "Use of \\usepackage{...} instead of \\RequirePackage{...}",
     inspectionId = "UsePackageInPackage",
     errorMessage = { "Use \\RequirePackage{...} instead of \\usepackage{...}" },
-    pattern = Pattern.compile("(\\\\usepackage\\{)([\\w:]+)(})"),
+    // The \usepackage syntax is \usepackage[<options>]{<package name>}[<version info>].
+    pattern = Pattern.compile("\\\\usepackage(\\[[^]]*])?\\{([^}]*)}(\\[[^]]*])?"),
     quickFixName = { "Replace with \\RequirePackage" },
-    replacement = { matcher, _ -> "\\RequirePackage{${matcher.group(2)}}" },
+    replacement = { matcher, _ -> "\\RequirePackage${matcher.group(1) ?: ""}{${matcher.group(2)}}${matcher.group(3) ?: ""}" },
     cancelIf = { _, psiFile ->
         // Cancel if the usepackage was found outside a class or style file.
         psiFile.virtualFile?.extension !in setOf(ClassFileType.defaultExtension, StyleFileType.defaultExtension)

--- a/test/nl/hannahsten/texifyidea/inspections/TexifyInspectionTestBase.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/TexifyInspectionTestBase.kt
@@ -23,8 +23,9 @@ abstract class TexifyInspectionTestBase(vararg val inspections: LocalInspectionT
         after: String,
         numberOfFixes: Int = 1,
         selectedFix: Int = 1,
+        fileName: String = "test.tex"
     ) {
-        myFixture.configureByText(LatexFileType, before)
+        myFixture.configureByText(fileName, before)
         // Collect the quick fixed before going into write action, to avoid AssertionError: Must not start highlighting from within write action.
         val quickFixes = myFixture.getAllQuickFixes()
         assertEquals("Expected number of quick fixes:", numberOfFixes, quickFixes.size)

--- a/test/nl/hannahsten/texifyidea/inspections/latex/TexifyRegexInspectionTestBase.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/TexifyRegexInspectionTestBase.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.inspections.latex
 
+import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
 import nl.hannahsten.texifyidea.inspections.TexifyRegexInspection
 import org.junit.Test
 import kotlin.test.assertFalse
@@ -8,7 +9,7 @@ import kotlin.test.assertTrue
 /**
  * @author Hannah Schellekens
  */
-abstract class TexifyRegexInspectionTestBase(regexInspection: TexifyRegexInspection) {
+abstract class TexifyRegexInspectionTestBase(regexInspection: TexifyRegexInspection) : TexifyInspectionTestBase(regexInspection) {
 
     val pattern = regexInspection.pattern
 

--- a/test/nl/hannahsten/texifyidea/inspections/latex/TexifyRegexInspectionTestBase.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/TexifyRegexInspectionTestBase.kt
@@ -1,6 +1,5 @@
 package nl.hannahsten.texifyidea.inspections.latex
 
-import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
 import nl.hannahsten.texifyidea.inspections.TexifyRegexInspection
 import org.junit.Test
 import kotlin.test.assertFalse
@@ -9,7 +8,7 @@ import kotlin.test.assertTrue
 /**
  * @author Hannah Schellekens
  */
-abstract class TexifyRegexInspectionTestBase(regexInspection: TexifyRegexInspection) : TexifyInspectionTestBase(regexInspection) {
+abstract class TexifyRegexInspectionTestBase(regexInspection: TexifyRegexInspection) {
 
     val pattern = regexInspection.pattern
 

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexUsePackageInPackageInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexUsePackageInPackageInspectionTest.kt
@@ -1,8 +1,9 @@
 package nl.hannahsten.texifyidea.inspections.latex.codestyle
 
+import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
 import nl.hannahsten.texifyidea.inspections.latex.TexifyRegexInspectionTestBase
 
-class LatexUsePackageInPackageInspectionTest : TexifyRegexInspectionTestBase(LatexUsePackageInPackageInspection()) {
+class LatexUsePackageInPackageInspectionRegexTest : TexifyRegexInspectionTestBase(LatexUsePackageInPackageInspection()) {
 
     override val successfulMatches: List<String> = listOf(
         """\usepackage{xcolor, twee}""",
@@ -15,6 +16,9 @@ class LatexUsePackageInPackageInspectionTest : TexifyRegexInspectionTestBase(Lat
     override val failingMatches: List<String> = listOf(
         """\usepackage[a][b]{test}"""
     )
+}
+
+class LatexUsePackageInPackageInspectionQuickFixTest : TexifyInspectionTestBase(LatexUsePackageInPackageInspection()) {
 
     fun testRequiredArgumentQuickFix() = testQuickFix(
         before = """\usepackage{xcolor}""",

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexUsePackageInPackageInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexUsePackageInPackageInspectionTest.kt
@@ -1,0 +1,42 @@
+package nl.hannahsten.texifyidea.inspections.latex.codestyle
+
+import nl.hannahsten.texifyidea.inspections.latex.TexifyRegexInspectionTestBase
+
+class LatexUsePackageInPackageInspectionTest : TexifyRegexInspectionTestBase(LatexUsePackageInPackageInspection()) {
+
+    override val successfulMatches: List<String> = listOf(
+        """\usepackage{xcolor, twee}""",
+        """\usepackage[colorlinks]{hyperref}""",
+        """\usepackage[aaa, bbb]{test}""",
+        """\usepackage[options]{packagename}[version]""",
+        """\usepackage{name}[version]"""
+    )
+
+    override val failingMatches: List<String> = listOf(
+        """\usepackage[a][b]{test}"""
+    )
+
+    fun testRequiredArgumentQuickFix() = testQuickFix(
+        before = """\usepackage{xcolor}""",
+        after = """\RequirePackage{xcolor}""",
+        fileName = "mypackage.sty"
+    )
+
+    fun testOptionalArgumentQuickFix() = testQuickFix(
+        before = """\usepackage[optional]{xcolor}""",
+        after = """\RequirePackage[optional]{xcolor}""",
+        fileName = "mypackage.sty"
+    )
+
+    fun testVersionArgumentQuickFix() = testQuickFix(
+        before = """\usepackage{xcolor}[version]""",
+        after = """\RequirePackage{xcolor}[version]""",
+        fileName = "mypackage.sty"
+    )
+
+    fun testOptionalAndVersionArgumentQuickFix() = testQuickFix(
+        before = """\usepackage[optional]{xcolor}[version]""",
+        after = """\RequirePackage[optional]{xcolor}[version]""",
+        fileName = "mypackage.sty"
+    )
+}


### PR DESCRIPTION
#### Summary of additions and changes

The `\usepackage in package` inspection only checked for a required argument, while the `\usepackage` syntax is

```latex
\usepackage[<options>]{<package name>}[<version info>]
```

I've added the missing cases to the inspection. Tests included.

#### How to test this pull request

* See test cases.
* Try the quick fis in a sty file:

    ```latex
    \usepackage{xcolor}
    \usepackage[colorlinks]{hyperref}
    ```