### PR TITLE
Override display names of filetypes to avoid conflict

### DIFF
--- a/src/nl/hannahsten/texifyidea/file/BibtexFileType.kt
+++ b/src/nl/hannahsten/texifyidea/file/BibtexFileType.kt
@@ -16,4 +16,6 @@ object BibtexFileType : LanguageFileType(BibtexLanguage) {
     override fun getDefaultExtension() = "bib"
 
     override fun getIcon() = TexifyIcons.BIBLIOGRAPHY_FILE
+
+    override fun getDisplayName() = name
 }

--- a/src/nl/hannahsten/texifyidea/file/ClassFileType.kt
+++ b/src/nl/hannahsten/texifyidea/file/ClassFileType.kt
@@ -16,4 +16,6 @@ object ClassFileType : LanguageFileType(LatexLanguage) {
     override fun getDefaultExtension() = "cls"
 
     override fun getIcon() = TexifyIcons.CLASS_FILE
+
+    override fun getDisplayName() = name
 }

--- a/src/nl/hannahsten/texifyidea/file/LatexFileType.kt
+++ b/src/nl/hannahsten/texifyidea/file/LatexFileType.kt
@@ -16,4 +16,7 @@ object LatexFileType : LanguageFileType(LatexLanguage) {
     override fun getDefaultExtension() = "tex"
 
     override fun getIcon() = TexifyIcons.LATEX_FILE
+
+    // Fix https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2195#issuecomment-1024344147
+    override fun getDisplayName() = name
 }

--- a/src/nl/hannahsten/texifyidea/file/LatexSourceFileType.kt
+++ b/src/nl/hannahsten/texifyidea/file/LatexSourceFileType.kt
@@ -11,9 +11,11 @@ object LatexSourceFileType : LanguageFileType(PlainTextLanguage.INSTANCE) {
 
     override fun getName() = "LaTeX source file (dtx)"
 
-    override fun getDescription() = "LaTeX source file"
+    override fun getDescription() = "LaTeX source file (dtx)"
 
     override fun getDefaultExtension() = "dtx"
 
     override fun getIcon() = TexifyIcons.FILE
+
+    override fun getDisplayName() = name
 }

--- a/src/nl/hannahsten/texifyidea/file/StyleFileType.kt
+++ b/src/nl/hannahsten/texifyidea/file/StyleFileType.kt
@@ -16,4 +16,6 @@ object StyleFileType : LanguageFileType(LatexLanguage) {
     override fun getDefaultExtension() = "sty"
 
     override fun getIcon() = TexifyIcons.STYLE_FILE
+
+    override fun getDisplayName() = name
 }

--- a/src/nl/hannahsten/texifyidea/file/TikzFileType.kt
+++ b/src/nl/hannahsten/texifyidea/file/TikzFileType.kt
@@ -16,4 +16,6 @@ object TikzFileType : LanguageFileType(LatexLanguage) {
     override fun getDefaultExtension() = "tikz"
 
     override fun getIcon() = TexifyIcons.TIKZ_FILE
+
+    override fun getDisplayName() = name
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnresolvedReferenceInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnresolvedReferenceInspectionTest.kt
@@ -57,7 +57,7 @@ class LatexUnresolvedReferenceInspectionTest : TexifyInspectionTestBase(LatexUnr
             ~\ref{sec:some-sec}
             """.trimIndent()
         )
-        CommandManager.updateAliases(setOf("\\label"), project)
+        CommandManager.updateAliases(setOf("\\mylabel"), project)
         myFixture.checkHighlighting()
     }
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2193
Fix #2195

#### Summary of additions and changes

* There must be something really odd going on with localisation, otherwise I can't image how this occurred.
