### PR TITLE
Override names of LaTeX action groups in find action dialog

### DIFF
--- a/resources/META-INF/actions/actions.xml
+++ b/resources/META-INF/actions/actions.xml
@@ -16,6 +16,7 @@
         <!-- LaTeX Analyze menu -->
         <group id="texify.LatexMenuAnalyze" text="_LaTeX" description="Latex analysis actions" popup="true"
                class="nl.hannahsten.texifyidea.action.group.LatexAnalyzeMenuGroup">
+            <override-text place="GoToAction" text="Analyze _LaTeX"/>
             <!-- Do not add it to the group here, because that will be handled in AnalyzeMenuRegistration. -->
             <!--<add-to-group group-id="AnalyzeMenu" anchor="last"/>-->
 
@@ -28,6 +29,7 @@
         <!-- Generate Latex -->
         <group id="texify.LatexGenerate" text="_LaTeX" description="Latex generation actions" popup="true">
             <add-to-group group-id="GenerateGroup" anchor="last"/>
+            <override-text place="GoToAction" text="Generate _LaTeX"/>
 
             <!-- Table wizard -->
             <action class="nl.hannahsten.texifyidea.action.wizard.table.LatexTableWizardAction" id="texify.TableWizardPopup"

--- a/resources/META-INF/actions/actions.xml
+++ b/resources/META-INF/actions/actions.xml
@@ -14,17 +14,13 @@
         </action>
 
         <!-- LaTeX Analyze menu -->
-        <group id="texify.LatexMenuAnalyze" text="_LaTeX" description="Latex analysis actions" popup="true"
-               class="nl.hannahsten.texifyidea.action.group.LatexAnalyzeMenuGroup">
-            <override-text place="GoToAction" text="Analyze _LaTeX"/>
+        <action class="nl.hannahsten.texifyidea.action.analysis.WordCountAction" id="texify.analysis.WordCount"
+                text="_Word Count" description="Estimate the word count of the currently active .tex file and inclusions.">
+            <keyboard-shortcut first-keystroke="control alt W" keymap="$default"/>
+            <override-text place="GoToAction" text="LaTeX _Word Count"/>
             <!-- Do not add it to the group here, because that will be handled in AnalyzeMenuRegistration. -->
             <!--<add-to-group group-id="AnalyzeMenu" anchor="last"/>-->
-
-            <action class="nl.hannahsten.texifyidea.action.analysis.WordCountAction" id="texify.analysis.WordCount"
-                    text="_Word Count" description="Estimate the word count of the currently active .tex file and inclusions.">
-                <keyboard-shortcut first-keystroke="control alt W" keymap="$default"/>
-            </action>
-        </group>
+        </action>
 
         <!-- Generate Latex -->
         <group id="texify.LatexGenerate" text="_LaTeX" description="Latex generation actions" popup="true">

--- a/resources/META-INF/actions/editmenu.xml
+++ b/resources/META-INF/actions/editmenu.xml
@@ -4,6 +4,7 @@
                class="nl.hannahsten.texifyidea.action.group.LatexEditMenuGroup">
             <!-- MPS doesn't have the EditSmartGroup group, so we register directly in the Edit menu. -->
             <add-to-group group-id="EditMenu" anchor="last"/>
+            <override-text place="GoToAction" text="Edit _LaTeX"/>
 
             <!-- Toggle Star -->
             <action class="nl.hannahsten.texifyidea.action.LatexToggleStarAction" id="texify.ToggleStar" text="Toggle _Star"

--- a/resources/META-INF/actions/toolsmenu.xml
+++ b/resources/META-INF/actions/toolsmenu.xml
@@ -2,6 +2,7 @@
     <actions>
         <group id="texify.LatexMenuTools" text="_LaTeX" description="Latex tools" popup="true">
             <add-to-group group-id="ToolsMenu" anchor="last"/>
+            <override-text place="GoToAction" text="_LaTeX Tools"/>
 
             <!-- Clear files -->
             <action class="nl.hannahsten.texifyidea.action.DeleteAuxFiles" id="texify.ClearAuxFiles" text="Delete Auxiliary Files">

--- a/src/nl/hannahsten/texifyidea/startup/AnalyzeMenuRegistration.kt
+++ b/src/nl/hannahsten/texifyidea/startup/AnalyzeMenuRegistration.kt
@@ -17,15 +17,15 @@ class AnalyzeMenuRegistration : StartupActivity, DumbAware {
 
     @Synchronized
     override fun runActivity(project: Project) {
-        // Get the group which should be added to either the Analyze menu or something else
-        val latexAnalyzeMenuGroup = ActionManager.getInstance().getAction("texify.LatexMenuAnalyze") as DefaultActionGroup
+        // Get the action which should be added to either the Analyze menu or something else
+        val wordCountAction = ActionManager.getInstance().getAction("texify.analysis.WordCount")
 
         val analyzeGroup = getAnalyzeGroup() ?: return
 
         // Add the group which contains the LaTeX actions to the Analyze menu
         // First remove it, to avoid adding it twice
-        analyzeGroup.remove(latexAnalyzeMenuGroup)
-        analyzeGroup.add(latexAnalyzeMenuGroup)
+        analyzeGroup.remove(wordCountAction)
+        analyzeGroup.add(wordCountAction)
     }
 
     /**
@@ -46,8 +46,8 @@ class AnalyzeMenuRegistration : StartupActivity, DumbAware {
     }
 
     fun unload() {
-        val latexAnalyzeMenuGroup = ActionManager.getInstance().getAction("texify.LatexMenuAnalyze") as DefaultActionGroup
+        val wordCountAction = ActionManager.getInstance().getAction("texify.analysis.WordCount")
         val analyzeGroup = getAnalyzeGroup() ?: return
-        analyzeGroup.remove(latexAnalyzeMenuGroup)
+        analyzeGroup.remove(wordCountAction)
     }
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2206 

#### Summary of additions and changes

* Override the names of the different LaTeX menu groups so they are distinguishable in the find actions dialog. 
* Removed the action group that surrounded the word count action. It's not needed, we only show the word count action when a LaTeX file is active anyway. To avoid confusion, I have overridden the name of the action to be `LaTeX Word Count` in the find actions dialog.

#### How to test this pull request

Search for `latex` in the find actions dialog.