### PR TITLE
Fix newlines in reading dummy text input

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 group = "nl.hannahsten"
-version = "0.7.13"
+version = "0.7.14-alpha.1"
 
 repositories {
     mavenCentral()

--- a/src/nl/hannahsten/texifyidea/util/text/TexifyIpsumGenerator.kt
+++ b/src/nl/hannahsten/texifyidea/util/text/TexifyIpsumGenerator.kt
@@ -1,6 +1,7 @@
 package nl.hannahsten.texifyidea.util.text
 
 import nl.hannahsten.texifyidea.util.capitalizeFirst
+import java.util.regex.Pattern
 import kotlin.random.Random
 
 /**
@@ -63,7 +64,8 @@ open class TexifyIpsumGenerator(
      */
     private val template: Map<String, List<String>> by lazy {
         val input = ipsum.generateInput()
-        val parts = input.split(System.lineSeparator() + System.lineSeparator())
+        // Whether the newlines are Windows or Unix style depends on which system the plugin was built, so catch both
+        val parts = input.split(Pattern.compile("(\\r?\\n){2,}"))
 
         parts.associate { templatePart ->
             val lines = templatePart.lines()


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2189

#### Summary of additions and changes

* The plugin was built on Linux, but the line separator of the user was used so Windows users couldn't read the dummy text file.