### PR TITLE
Don't send notification for SDK paths that are checked in the background

### DIFF
--- a/src/nl/hannahsten/texifyidea/completion/LatexCommandsAndEnvironmentsCompletionProvider.kt
+++ b/src/nl/hannahsten/texifyidea/completion/LatexCommandsAndEnvironmentsCompletionProvider.kt
@@ -5,6 +5,7 @@ import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.PsiFile
 import com.intellij.psi.search.GlobalSearchScope
@@ -97,22 +98,25 @@ class LatexCommandsAndEnvironmentsCompletionProvider internal constructor(privat
 
         // If using texlive, filter on commands which are in packages included in the project
         // The reason for doing this, is that the user probably is using texlive-full, in which case the
-        // completion would be floaded with duplicate commands from packages that nobody uses.
+        // completion would be flooded with duplicate commands from packages that nobody uses.
         // For example, the (initially) first suggestion for \enquote is the version from the aiaa package, which is unlikely to be correct.
         // Therefore, we limit ourselves to packages included somewhere in the project (directly or indirectly).
         val project = parameters.editor.project ?: return
-        val usesTexlive = TexliveSdk.isAvailable
-        val packagesInProject = if (!usesTexlive) emptyList() else includedPackages(LatexIncludesIndex.getItems(project), project)
+
+        // If TeX Live is available at all, either implicitly or explicitly, it could be in the index, so we filter commands
+        val usesTexlive = TexliveSdk.isAvailable || ProjectJdkTable.getInstance().allJdks.any { it.sdkType is TexliveSdk }
+
+        val packagesInProject = if (!usesTexlive) emptyList() else includedPackages(LatexIncludesIndex.getItems(project), project).plus(LatexPackage.DEFAULT)
 
         val commands = mutableSetOf<LookupElementBuilder>()
         FileBasedIndex.getInstance().getAllKeys(LatexExternalCommandIndex.id, project)
             .forEach { cmdWithSlash ->
                 val cmdWithoutSlash = cmdWithSlash.substring(1)
                 LatexCommand.lookupInIndex(cmdWithoutSlash, parameters.editor.project ?: return)
-                    .filter { it.dependency in packagesInProject }
+                    .filter { if (usesTexlive) it.dependency in packagesInProject else true }
                     .forEach { cmd ->
                     createCommandLookupElements(cmd)
-                        // Avoid duplicates of commands defined in LaTeX base, because they are often very similar commands defined in different document classes so it makes not
+                        // Avoid duplicates of commands defined in LaTeX base, because they are often very similar commands defined in different document classes, so it makes not
                         // much sense at the moment to have them separately in the autocompletion.
                         // Effectively this results in just taking the first one we found
                         .filter { newBuilder ->

--- a/src/nl/hannahsten/texifyidea/settings/sdk/LatexSdkUtil.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/LatexSdkUtil.kt
@@ -90,8 +90,10 @@ object LatexSdkUtil {
      * If not, also throw a notification in the currently open project (if any), because we cannot modify the actual message in the dialog which complains when an SDK is not valid.
      *
      * @param errorMessage Message to show to the user when directory is null. If this is null, no notification will be shown.
+     * @param suppressNotification If the directory is one of these, then don't send an error message (for example because it
+     * may be a directory that is automatically attempted in the background, so we don't need to give user feedback).
      */
-    fun isPdflatexPresent(directory: String?, errorMessage: String?, sdkName: String): Boolean {
+    fun isPdflatexPresent(directory: String?, errorMessage: String?, sdkName: String, suppressNotification: Collection<String?>): Boolean {
         val output = if (directory == null) {
             errorMessage
         }
@@ -104,6 +106,7 @@ object LatexSdkUtil {
 
         // Don't send notification if there is no message on purpose
         if (errorMessage == null) return false
+        if (directory in suppressNotification) return false
 
         // Show notification to explain the reason why the SDK is not valid, but only if any project is open
         // We have to do this because we can't customize the popup which says the SDK is not valid

--- a/src/nl/hannahsten/texifyidea/settings/sdk/MiktexLinuxSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/MiktexLinuxSdk.kt
@@ -38,13 +38,13 @@ class MiktexLinuxSdk : LatexSdk("MiKTeX Mac/Linux SDK") {
         return listOf(
             Paths.get(System.getProperty("user.home"), "bin").toString(),
             "/usr/local/bin"
-        ).filter { LatexSdkUtil.isPdflatexPresent(it, null, name) }.toMutableList()
+        ).toMutableList()
     }
 
     override fun isValidSdkHome(path: String): Boolean {
         // We just want a path where pdflatex is present
         val errorMessage = "Could not find $path/pdflatex"
-        return LatexSdkUtil.isPdflatexPresent(path, errorMessage, name)
+        return LatexSdkUtil.isPdflatexPresent(path, errorMessage, name, suppressNotification = suggestHomePaths().plus(suggestHomePath()))
     }
 
     override fun getVersionString(sdk: Sdk): String? {

--- a/src/nl/hannahsten/texifyidea/settings/sdk/MiktexWindowsSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/MiktexWindowsSdk.kt
@@ -60,7 +60,7 @@ class MiktexWindowsSdk : LatexSdk("MiKTeX Windows SDK") {
         // Assume path is of the form C:\Users\username\AppData\Local\Programs\MiKTeX 2.9\miktex\bin\x64\pdflatex.exe
         val directory = LatexSdkUtil.getPdflatexParentPath(Paths.get(path, "miktex").toString())
         val errorMessage = "Could not find $path/miktex/bin/*/pdflatex, please make sure you selected the MiKTeX installation directory."
-        return LatexSdkUtil.isPdflatexPresent(directory, errorMessage, name)
+        return LatexSdkUtil.isPdflatexPresent(directory, errorMessage, name, suppressNotification = suggestHomePaths().plus(suggestHomePath()))
     }
 
     override fun getVersionString(sdk: Sdk): String? {

--- a/src/nl/hannahsten/texifyidea/settings/sdk/NativeTexliveSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/NativeTexliveSdk.kt
@@ -48,7 +48,7 @@ class NativeTexliveSdk : TexliveSdk("Native TeX Live SDK") {
 
         // If this is a valid LaTeX installation, pdflatex should be present
         val errorMessage = "Could not find $path/pdflatex"
-        return LatexSdkUtil.isPdflatexPresent(path, errorMessage, name)
+        return LatexSdkUtil.isPdflatexPresent(path, errorMessage, name, suppressNotification = suggestHomePaths().plus(suggestHomePath()))
     }
 
     override fun getVersionString(sdkHome: String?): String {

--- a/src/nl/hannahsten/texifyidea/settings/sdk/TexliveSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/TexliveSdk.kt
@@ -82,7 +82,7 @@ open class TexliveSdk(name: String = "TeX Live SDK") : LatexSdk(name) {
         val parent = LatexSdkUtil.getPdflatexParentPath(path)
 
         val errorMessage = "Could not find $path/bin/*/pdflatex"
-        return LatexSdkUtil.isPdflatexPresent(parent, errorMessage, name)
+        return LatexSdkUtil.isPdflatexPresent(parent, errorMessage, name, suppressNotification = suggestHomePaths().plus(suggestHomePath()))
     }
 
     override fun getLatexDistributionType() = LatexDistributionType.TEXLIVE


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2184

#### Summary of additions and changes

* Don't give a notification in case the path that is checked probably comes from TeXiFy and not from the user.
* Fix autocompletion filtering for texlive, which caused indexed commands from the default package not to be included
