### PR TITLE
Auxil path won't be overwritten anymore when using placeholders

### DIFF
--- a/src/nl/hannahsten/texifyidea/run/latex/ui/LatexSettingsEditor.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/ui/LatexSettingsEditor.kt
@@ -101,7 +101,7 @@ class LatexSettingsEditor(private var project: Project?) : SettingsEditor<LatexR
 
         if (auxilPath != null) {
             val auxilPathTextField = auxilPath!!.component as TextFieldWithBrowseButton
-            auxilPathTextField.text = runConfiguration.auxilPath.virtualFile?.path ?: runConfiguration.outputPath.pathString
+            auxilPathTextField.text = runConfiguration.auxilPath.virtualFile?.path ?: runConfiguration.auxilPath.pathString
         }
 
         val outputPathTextField = outputPath.component as TextFieldWithBrowseButton


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2114 

#### Summary of additions and changes

* Auxil path won't be overwritten anymore when using placeholders

#### How to test this pull request

Open the Run configuration template for LaTeX files and change the auxiliary path to something that uses the placeholder