### PR TITLE
Ignore nested enumerations when finding the item marker

### DIFF
--- a/resources/META-INF/extensions/editor/editor.xml
+++ b/resources/META-INF/extensions/editor/editor.xml
@@ -22,7 +22,7 @@
         <codeInsight.parameterInfo language="Latex" implementationClass="nl.hannahsten.texifyidea.documentation.LatexParameterInfoHandler"/>
         <typedHandler implementation="nl.hannahsten.texifyidea.highlighting.LatexTypedHandler"/>
         <lookup.charFilter implementation="nl.hannahsten.texifyidea.completion.LatexCharFilter" id="latex"/>
-        <enterHandlerDelegate implementation="nl.hannahsten.texifyidea.editor.InsertEnumerationItem"/>
+        <enterHandlerDelegate implementation="nl.hannahsten.texifyidea.editor.typedhandlers.LatexEnterInEnumerationHandler"/>
         <typedHandler implementation="nl.hannahsten.texifyidea.editor.ShiftTracker"/>
         <typedHandler implementation="nl.hannahsten.texifyidea.editor.typedhandlers.UpDownAutoBracket"/>
         <typedHandler implementation="nl.hannahsten.texifyidea.editor.typedhandlers.BibtexQuoteInsertHandler"/>

--- a/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexEnterInEnumerationHandlerTest.kt
+++ b/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexEnterInEnumerationHandlerTest.kt
@@ -44,5 +44,4 @@ class LatexEnterInEnumerationHandlerTest : BasePlatformTestCase() {
             \end{enumerate}
         """.trimIndent())
     }
-
 }

--- a/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexEnterInEnumerationHandlerTest.kt
+++ b/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexEnterInEnumerationHandlerTest.kt
@@ -1,0 +1,48 @@
+package nl.hannahsten.texifyidea.editor.typedhandlers
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import nl.hannahsten.texifyidea.file.LatexFileType
+
+class LatexEnterInEnumerationHandlerTest : BasePlatformTestCase() {
+
+    fun testItemize() {
+        myFixture.configureByText(LatexFileType, """
+            \begin{itemize}
+                \item <caret>
+            \end{itemize}
+        """.trimIndent())
+        myFixture.type("\n")
+        myFixture.checkResult("""
+            \begin{itemize}
+                \item 
+                \item <caret>
+            \end{itemize}
+        """.trimIndent())
+    }
+
+    fun `test nested enumeration with prefix`() {
+        myFixture.configureByText(LatexFileType, """
+            \begin{enumerate}
+                \item foo
+                \item[whoo] bar
+                \begin{labeling}{foobar:}
+                    \item[foobar:]
+                    \item[barfoo:]
+                \end{labeling} <caret>
+            \end{enumerate}
+        """.trimIndent())
+        myFixture.type("\n")
+        myFixture.checkResult("""
+            \begin{enumerate}
+                \item foo
+                \item[whoo] bar
+                \begin{labeling}{foobar:}
+                    \item[foobar:]
+                    \item[barfoo:]
+                \end{labeling} 
+                \item[whoo] <caret>
+            \end{enumerate}
+        """.trimIndent())
+    }
+
+}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2137

#### Summary of additions and changes

* Ignore nested items when finding the last \item in an environment

#### How to test this pull request

```latex
\documentclass[11pt]{article}

\begin{document}
    \begin{enumerate}
        \item foo
        \item[bla] bar
        \begin{itemize}
            \item[floo]
        \end{itemize} <caret>
    \end{enumerate}
\end{document}
```
