### PR TITLE
Recognise custom environments as defining a tabular environment

### DIFF
--- a/src/nl/hannahsten/texifyidea/action/preview/JlatexmathPreviewer.kt
+++ b/src/nl/hannahsten/texifyidea/action/preview/JlatexmathPreviewer.kt
@@ -20,6 +20,7 @@ import java.awt.Color
 import java.awt.Dimension
 import java.awt.Insets
 import java.io.*
+import java.nio.file.Paths
 import javax.imageio.ImageIO
 import javax.swing.JLabel
 import javax.swing.SwingUtilities
@@ -27,7 +28,7 @@ import javax.swing.SwingUtilities
 class JlatexmathPreviewer : Previewer {
 
     override fun preview(input: String, previewForm: PreviewForm, project: Project, preamble: String, waitTime: Long) {
-        val tempBaseName = "temp"
+        val tempBaseName = Paths.get(System.getProperty("java.io.tmpdir"), "temp").toString()
         try {
             // Fonts should be shapes, otherwise the user would have needed to install the font to render it
             // when converting to png (because fonts are not saved in svg).

--- a/src/nl/hannahsten/texifyidea/completion/LatexCompletionContributor.kt
+++ b/src/nl/hannahsten/texifyidea/completion/LatexCompletionContributor.kt
@@ -13,7 +13,7 @@ import nl.hannahsten.texifyidea.completion.pathcompletion.LatexGraphicsPathProvi
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.ALL_TEXIFY_INSPECTIONS
 import nl.hannahsten.texifyidea.inspections.InsightGroup
-import nl.hannahsten.texifyidea.lang.CommandManager
+import nl.hannahsten.texifyidea.lang.alias.CommandManager
 import nl.hannahsten.texifyidea.lang.LatexMode
 import nl.hannahsten.texifyidea.lang.commands.*
 import nl.hannahsten.texifyidea.psi.*

--- a/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexLabelConventionInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexLabelConventionInspection.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.inspections.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
-import nl.hannahsten.texifyidea.lang.CommandManager
+import nl.hannahsten.texifyidea.lang.alias.CommandManager
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.*
 import nl.hannahsten.texifyidea.util.*

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexEscapeAmpersandInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexEscapeAmpersandInspection.kt
@@ -36,7 +36,7 @@ class LatexEscapeAmpersandInspection : TexifyRegexInspection(
         if (this.isComment()) return true
 
         // Do not trigger in environments that use the ampersand as special character.
-        if (this.inDirectEnvironment(EnvironmentMagic.tableEnvironments)) return true
+        if (this.inDirectEnvironment(EnvironmentMagic.getAllTableEnvironments(project))) return true
         if (this.inDirectEnvironment(EnvironmentMagic.alignableEnvironments)) return true
 
         // Other exceptions

--- a/src/nl/hannahsten/texifyidea/inspections/latex/redundancy/LatexDuplicateLabelInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/redundancy/LatexDuplicateLabelInspection.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.refactoring.suggested.startOffset
 import nl.hannahsten.texifyidea.inspections.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
-import nl.hannahsten.texifyidea.lang.CommandManager
+import nl.hannahsten.texifyidea.lang.alias.CommandManager
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexEnvironment

--- a/src/nl/hannahsten/texifyidea/lang/DefaultEnvironment.kt
+++ b/src/nl/hannahsten/texifyidea/lang/DefaultEnvironment.kt
@@ -64,6 +64,7 @@ enum class DefaultEnvironment(
     TABU(environmentName = "tabu", arguments = arrayOf(RequiredArgument("cols"))),
     TABULAR(environmentName = "tabular", arguments = arrayOf(OptionalArgument("pos"), RequiredArgument("cols"))),
     TABULARX(environmentName = "tabularx", arguments = arrayOf(RequiredArgument("width"), RequiredArgument("cols"))),
+    TABULARY(environmentName = "tabulary", arguments = arrayOf(RequiredArgument("length"), RequiredArgument("pream"))),
     TABULAR_STAR(environmentName = "tabular*", arguments = arrayOf(RequiredArgument("width"), OptionalArgument("pos"), RequiredArgument("cols"))),
     THEBIBLIOGRAPHY(environmentName = "thebibliography", arguments = arrayOf(RequiredArgument("widestlabel"))),
     THEINDEX(environmentName = "theindex"),

--- a/src/nl/hannahsten/texifyidea/lang/alias/AliasManager.kt
+++ b/src/nl/hannahsten/texifyidea/lang/alias/AliasManager.kt
@@ -1,0 +1,7 @@
+package nl.hannahsten.texifyidea.lang.alias
+
+/**
+ * Manage aliases.
+ */
+class AliasManager {
+}

--- a/src/nl/hannahsten/texifyidea/lang/alias/AliasManager.kt
+++ b/src/nl/hannahsten/texifyidea/lang/alias/AliasManager.kt
@@ -1,7 +1,164 @@
 package nl.hannahsten.texifyidea.lang.alias
 
+import com.intellij.openapi.project.Project
+import nl.hannahsten.texifyidea.index.LatexDefinitionIndex
+import nl.hannahsten.texifyidea.psi.LatexCommands
+import java.util.concurrent.ConcurrentHashMap
+
 /**
- * Manage aliases.
+ * Manage aliases for commands and environments.
  */
-class AliasManager {
+abstract class AliasManager {
+
+    /**
+     * Maps a command to a set of aliases including the command itself.
+     * Similar for environments.
+     *
+     * All elements of the set are in the map as keys as well linking to the set in which they
+     * are themselves. This means that the set of all keys that are aliases of each other all
+     * link to the same set of aliases. This ensures that you only have to modify the alias sets
+     * once and automatically update for all others.
+     *
+     *
+     * The commands are stored including the backslash.
+     *
+     *
+     * *Example:*
+     *
+     *
+     * Definitions:<br></br>
+     * `A := {\one, \een, \ein}`<br></br>
+     * `B := {\twee}`<br></br>
+     * `C := {\drie, \three}`
+     *
+     *
+     * Map:<br></br>
+     * `\one => A`<br></br>
+     * `\een => A`<br></br>
+     * `\ein => A`<br></br>
+     * `\twee => B`<br></br>
+     * `\three => C`<br></br>
+     * `\drie => C`
+     */
+    open val aliases = ConcurrentHashMap<String, MutableSet<String>>()
+
+    /**
+     * We have to somehow know when we need to look for new aliases.
+     * We do this by keeping a count of the number of \newcommand-like commands in the index,
+     * and when this changes we go gather new aliases.
+     */
+    open var numberOfIndexedCommandDefinitions = 0
+
+    /**
+     * Register a new item, which creates a new alias set.
+     */
+    fun register(alias: String) {
+        require(!isRegistered(alias)) { "alias '$alias' has already been registered" }
+        synchronized(aliases) {
+            aliases[alias] = mutableSetOf(alias)
+        }
+    }
+
+    /**
+     * Checks if the given alias has been registered to the alias manager.
+     *
+     * @param alias
+     * The alias to check if it has been registered
+     * *E.g. `\begin`*
+     * @return `true` if the given alias is present in the alias manager, `false`
+     * otherwise.
+     */
+    fun isRegistered(alias: String): Boolean {
+        synchronized(aliases) {
+            return aliases.containsKey(alias)
+        }
+    }
+
+    /**
+     * Register an alias for a given item.
+     *
+     *
+     * The alias will be added to the set of aliases for the given item.
+     *
+     * @param item
+     * An existing item to register the alias for starting with a backslash. *E.g.
+     * `\begin`*
+     * @param alias
+     * The alias to register for the item. This could be either
+     * a new item, or an existing item *E.g. `\start`*
+     */
+    @Synchronized
+    fun registerAlias(item: String, alias: String) {
+        synchronized(aliases) {
+            val aliasSet = aliases[item] ?: mutableSetOf()
+
+            // If the alias is already assigned: unassign it.
+            if (isRegistered(alias)) {
+                val previousAliases = aliases[alias]
+                previousAliases?.remove(alias)
+                aliases.remove(alias)
+            }
+            aliasSet.add(alias)
+            aliases[alias] = aliasSet
+        }
+    }
+
+    /**
+     * Get an unmodifiable set with all the aliases for the given item.
+     *
+     * @param item
+     * An existing item to get all aliases of starting with a backslash. *E.g. `\begin`*
+     * @return An unmodifiable set of all aliases including the item itself. Returns the empty set if the item is not registered.
+     */
+    fun getAliases(item: String): Set<String> {
+        if (!isRegistered(item)) return emptySet()
+        synchronized(aliases) {
+            return aliases[item]?.toSet() ?: emptySet()
+        }
+    }
+
+    /**
+     * If needed (based on the number of indexed \newcommand-like commands) check for new aliases of the given alias set. This alias can be any alias of its alias set.
+     * If the alias set is not yet registered, it will be registered as a new alias set.
+     */
+    @Synchronized
+    fun updateAliases(aliasSet: Collection<String>, project: Project) {
+        // Register if needed
+        if (aliasSet.isEmpty()) return
+        val firstAlias = aliasSet.first()
+        var wasRegistered = false
+        if (!isRegistered(firstAlias)) {
+            register(firstAlias)
+            wasRegistered = true
+            aliasSet.forEach { registerAlias(firstAlias, it) }
+        }
+
+        // If the command name itself is not directly in the given set, check if it is perhaps an alias of a command in the set
+        // Uses projectScope now, may be improved to filesetscope
+        val indexedCommandDefinitions = LatexDefinitionIndex.getItems(project)
+
+        // Also do this the first time something is registered, because then we have to update aliases as well
+        if (numberOfIndexedCommandDefinitions != indexedCommandDefinitions.size || wasRegistered) {
+            // Update everything, since it is difficult to know beforehand what aliases could be added or not
+            // Alternatively we could save a numberOfIndexedCommandDefinitions per alias set, and only update the
+            // requested alias set (otherwise only the first alias set requesting an update will get it)
+            // We have to deepcopy the set of alias sets before iterating over it, because we want to modify aliases
+            synchronized(aliases) {
+                val deepCopy = aliases.values.map { it1 -> it1.map { it }.toSet() }.toSet()
+                for (copiedAliasSet in deepCopy) {
+                    findAllAliases(copiedAliasSet, indexedCommandDefinitions)
+                }
+            }
+
+            numberOfIndexedCommandDefinitions = indexedCommandDefinitions.size
+        }
+    }
+
+    /**
+     * Find all aliases that are defined in the [indexedDefinitions] and register them.
+     */
+    abstract fun findAllAliases(
+        aliasSet: Set<String>,
+        indexedDefinitions: Collection<LatexCommands>
+    )
 }

--- a/src/nl/hannahsten/texifyidea/lang/alias/CommandManager.kt
+++ b/src/nl/hannahsten/texifyidea/lang/alias/CommandManager.kt
@@ -1,7 +1,8 @@
-package nl.hannahsten.texifyidea.lang
+package nl.hannahsten.texifyidea.lang.alias
 
 import com.intellij.openapi.project.Project
 import nl.hannahsten.texifyidea.index.LatexDefinitionIndex
+import nl.hannahsten.texifyidea.lang.LabelingCommandInformation
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.util.*
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
@@ -290,7 +291,6 @@ object CommandManager : Iterable<String?>, Serializable {
                     ?.requiredParamContentList
                     ?.flatMap { it.childrenOfType(LatexCommands::class) }
                     ?.asSequence()
-                    ?.filterNotNull()
 
                 // Positions of label parameters in the custom commands (starting from 0)
                 val positions = parameterCommands
@@ -322,7 +322,7 @@ object CommandManager : Iterable<String?>, Serializable {
                     .map {
                         if (it.indexOf('#') != -1) {
                             val prefix = it.substring(0, it.indexOf('#'))
-                            if (prefix.isNotBlank()) prefix else ""
+                            prefix.ifBlank { "" }
                         }
                         else ""
                     }.firstOrNull() ?: ""

--- a/src/nl/hannahsten/texifyidea/lang/alias/CommandManager.kt
+++ b/src/nl/hannahsten/texifyidea/lang/alias/CommandManager.kt
@@ -1,7 +1,5 @@
 package nl.hannahsten.texifyidea.lang.alias
 
-import com.intellij.openapi.project.Project
-import nl.hannahsten.texifyidea.index.LatexDefinitionIndex
 import nl.hannahsten.texifyidea.lang.LabelingCommandInformation
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.util.*
@@ -32,39 +30,7 @@ import java.util.stream.StreamSupport
  * @author Hannah Schellekens
  */
 // Currently it is a singleton, in the future this may be one instance per fileset
-object CommandManager : Iterable<String?>, Serializable {
-
-    /**
-     * Maps a command to a set of aliases including the command itself.
-     *
-     *
-     * All elements of the set are in the map as keys as well linking to the set in which they
-     * are themselves. This means that the set of all keys that are aliases of each other all
-     * link to the same set of aliases. This ensures that you only have to modify the alias sets
-     * once and automatically update for all others.
-     *
-     *
-     * The commands are stored including the backslash.
-     *
-     *
-     * *Example:*
-     *
-     *
-     * Definitions:<br></br>
-     * `A := {\one, \een, \ein}`<br></br>
-     * `B := {\twee}`<br></br>
-     * `C := {\drie, \three}`
-     *
-     *
-     * Map:<br></br>
-     * `\one => A`<br></br>
-     * `\een => A`<br></br>
-     * `\ein => A`<br></br>
-     * `\twee => B`<br></br>
-     * `\three => C`<br></br>
-     * `\drie => C`
-     */
-    private val aliases = ConcurrentHashMap<String, MutableSet<String>>()
+object CommandManager : Iterable<String?>, Serializable, AliasManager() {
 
     /**
      * Maps an original command to the set of current aliases.
@@ -99,13 +65,6 @@ object CommandManager : Iterable<String?>, Serializable {
     private val original = ConcurrentHashMap<String, Set<String>>()
 
     /**
-     * We have to somehow know when we need to look for new aliases.
-     * We do this by keeping a count of the number of \newcommand-like commands in the index,
-     * and when this changes we go gather new aliases.
-     */
-    private var numberOfIndexedCommandDefinitions = 0
-
-    /**
      * Map commands that define labels to the positions of the label parameter.
      * For example, in \newcommand{\mylabel}[2]{\section{#1}\label{sec:#2} the label parameter is second, so \mylabel maps to [2].
      * It is not so nice to have to maintain this separately, but maintaining
@@ -132,13 +91,8 @@ object CommandManager : Iterable<String?>, Serializable {
      */
     @Throws(IllegalArgumentException::class)
     fun registerCommand(command: String) {
-        require(!isRegistered(command)) { "command '$command' has already been registered" }
-        val aliasSet: MutableSet<String> = HashSet()
-        aliasSet.add(command)
-        original[command] = aliasSet
-        synchronized(aliases) {
-            aliases[command] = aliasSet
-        }
+        super.register(command)
+        original[command] = aliases[command] ?: mutableSetOf(command)
     }
 
     /**
@@ -165,36 +119,6 @@ object CommandManager : Iterable<String?>, Serializable {
      * The alias will be added to the set of aliases for the given command. The alias will be
      * removed from its original alias set if the alias is an existing command.
      *
-     * @param command
-     * An existing command to register the alias for starting with a backslash. *E.g.
-     * `\begin`*
-     * @param alias
-     * The alias to register for the command starting with a backslash. This could be either
-     * a new command, or an existing command *E.g. `\start`*
-     */
-    @Synchronized
-    fun registerAlias(command: String, alias: String) {
-        synchronized(aliases) {
-            val aliasSet = aliases[command] ?: mutableSetOf()
-
-            // If the alias is already assigned: unassign it.
-            if (isRegistered(alias)) {
-                val previousAliases = aliases[alias]
-                previousAliases?.remove(alias)
-                aliases.remove(alias)
-            }
-            aliasSet.add(alias)
-            aliases[alias] = aliasSet
-        }
-    }
-
-    /**
-     * Register an alias for a given command.
-     *
-     *
-     * The alias will be added to the set of aliases for the given command. The alias will be
-     * removed from its original alias set if the alias is an existing command.
-     *
      * @param commandNoSlash
      * An existing command to register the alias for starting without the command backslash.
      * *E.g. `begin`*
@@ -209,67 +133,15 @@ object CommandManager : Iterable<String?>, Serializable {
         registerAlias("\\" + commandNoSlash, "\\" + aliasNoSlash)
     }
 
-    /**
-     * Get an unmodifiable set with all the aliases for the given command.
-     *
-     * @param command
-     * An existing command to get all aliases of starting with a backslash. *E.g. `\begin`*
-     * @return An unmodifiable set of all aliases including the command itself. All aliases include
-     * a command backslash. Returns the empty set if the command is not registered.
-     */
-    fun getAliases(command: String): Set<String> {
-        if (!isRegistered(command)) return emptySet()
-        synchronized(aliases) {
-            return aliases[command]?.toSet() ?: emptySet()
-        }
-    }
-
-    /**
-     * If needed (based on the number of indexed \newcommand-like commands) check for new aliases of the given alias set. This alias can be any alias of its alias set.
-     * If the alias set is not yet registered, it will be registered as a new alias set.
-     */
-    @Synchronized
-    fun updateAliases(aliasSet: Set<String>, project: Project) {
-        // Register if needed
-        if (aliasSet.isEmpty()) return
-        val firstAlias = aliasSet.first()
-        var wasRegistered = false
-        if (!isRegistered(firstAlias)) {
-            registerCommand(firstAlias)
-            wasRegistered = true
-            aliasSet.forEach { registerAlias(firstAlias, it) }
-        }
-
-        // If the command name itself is not directly in the given set, check if it is perhaps an alias of a command in the set
-        // Uses projectScope now, may be improved to filesetscope
-        val indexedCommandDefinitions = LatexDefinitionIndex.getItems(project)
-
-        // Also do this the first time something is registered, because then we have to update aliases as well
-        if (numberOfIndexedCommandDefinitions != indexedCommandDefinitions.size || wasRegistered) {
-            // Update everything, since it is difficult to know beforehand what aliases could be added or not
-            // Alternatively we could save a numberOfIndexedCommandDefinitions per alias set, and only update the
-            // requested alias set (otherwise only the first alias set requesting an update will get it)
-            // We have to deepcopy the set of alias sets before iterating over it, because we want to modify aliases
-            synchronized(aliases) {
-                val deepCopy = aliases.values.map { it1 -> it1.map { it }.toSet() }.toSet()
-                for (copiedAliasSet in deepCopy) {
-                    findAllAliases(copiedAliasSet, indexedCommandDefinitions)
-                }
-            }
-
-            numberOfIndexedCommandDefinitions = indexedCommandDefinitions.size
-        }
-    }
-
-    private fun findAllAliases(
+    override fun findAllAliases(
         aliasSet: Set<String>,
-        indexedCommandDefinitions: Collection<LatexCommands>
+        indexedDefinitions: Collection<LatexCommands>
     ) {
         val firstAlias = aliasSet.first()
 
         // Get definitions which define one of the commands in the given command names set
         // These will be aliases of the given set (which is assumed to be an alias set itself)
-        indexedCommandDefinitions.filter {
+        indexedDefinitions.filter {
             // Assume the parameter definition has the command being defined in the first required parameter,
             // and the command definition itself in the second
             it.requiredParameter(1)?.containsAny(aliasSet) == true
@@ -281,7 +153,7 @@ object CommandManager : Iterable<String?>, Serializable {
         // Assumes the predefined label definitions all have the label parameter in the same position
         // For example, in \newcommand{\mylabel}[2]{\section{#1}\label{sec:#2}} we want to parse out the 2 in #2
         if (aliasSet.intersect(CommandMagic.labelDefinitionsWithoutCustomCommands).isNotEmpty()) {
-            indexedCommandDefinitions.forEach { commandDefinition ->
+            indexedDefinitions.forEach { commandDefinition ->
                 val definedCommand = commandDefinition.requiredParameter(0) ?: return@forEach
                 if (definedCommand.isBlank()) return@forEach
 
@@ -399,21 +271,6 @@ object CommandManager : Iterable<String?>, Serializable {
      */
     val allCommands: Set<String>
         get() = Collections.unmodifiableSet(aliases.keys)
-
-    /**
-     * Checks if the given command has been registered to the command manager.
-     *
-     * @param command
-     * The command to check if it has been registered starting with the command backslash.
-     * *E.g. `\begin`*
-     * @return `true` if the given command is present in the command manager, `false`
-     * otherwise.
-     */
-    fun isRegistered(command: String): Boolean {
-        synchronized(aliases) {
-            return aliases.containsKey(command)
-        }
-    }
 
     /**
      * Checks if the given command has been registered to the command manager.

--- a/src/nl/hannahsten/texifyidea/lang/alias/EnvironmentManager.kt
+++ b/src/nl/hannahsten/texifyidea/lang/alias/EnvironmentManager.kt
@@ -1,7 +1,23 @@
 package nl.hannahsten.texifyidea.lang.alias
 
+import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.util.containsAny
+import nl.hannahsten.texifyidea.util.requiredParameter
+
 /**
  * Similar to the [CommandManager], this manages aliases of environments.
  */
-class EnvironmentManager {
+object EnvironmentManager : AliasManager() {
+
+    override fun findAllAliases(aliasSet: Set<String>, indexedDefinitions: Collection<LatexCommands>) {
+        val firstAlias = aliasSet.first()
+
+        // Assume the environment that is defined is the first parameter, and that the first part of the definition is in the second
+        // e.g. \newenvironment{mytabl}{\begin{tabular}{cc}}{\end{tabular}}
+        indexedDefinitions.filter { definition ->
+            definition.requiredParameter(1)?.containsAny(aliasSet.map { "\\begin{$it}" }.toSet()) == true
+        }
+            .mapNotNull { it.requiredParameter(0) }
+            .forEach { registerAlias(firstAlias, it) }
+    }
 }

--- a/src/nl/hannahsten/texifyidea/lang/alias/EnvironmentManager.kt
+++ b/src/nl/hannahsten/texifyidea/lang/alias/EnvironmentManager.kt
@@ -1,0 +1,7 @@
+package nl.hannahsten.texifyidea.lang.alias
+
+/**
+ * Similar to the [CommandManager], this manages aliases of environments.
+ */
+class EnvironmentManager {
+}

--- a/src/nl/hannahsten/texifyidea/psi/LatexCommandsImplUtil.kt
+++ b/src/nl/hannahsten/texifyidea/psi/LatexCommandsImplUtil.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiReference
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.util.nextLeaf
 import com.intellij.util.containers.toArray
-import nl.hannahsten.texifyidea.lang.CommandManager
+import nl.hannahsten.texifyidea.lang.alias.CommandManager
 import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.SUBFILES
 import nl.hannahsten.texifyidea.lang.commands.*
 import nl.hannahsten.texifyidea.reference.CommandDefinitionReference

--- a/src/nl/hannahsten/texifyidea/psi/LatexEnvironmentUtil.kt
+++ b/src/nl/hannahsten/texifyidea/psi/LatexEnvironmentUtil.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.psi
 
 import com.intellij.psi.util.PsiTreeUtil
-import nl.hannahsten.texifyidea.lang.CommandManager
+import nl.hannahsten.texifyidea.lang.alias.CommandManager
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.magic.EnvironmentMagic
 

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexLabelPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexLabelPresentation.kt
@@ -3,7 +3,7 @@ package nl.hannahsten.texifyidea.structure.latex
 import com.intellij.navigation.ItemPresentation
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import nl.hannahsten.texifyidea.TexifyIcons
-import nl.hannahsten.texifyidea.lang.CommandManager
+import nl.hannahsten.texifyidea.lang.alias.CommandManager
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.util.labels.getLabelDefinitionCommands
 import nl.hannahsten.texifyidea.util.requiredParameter

--- a/src/nl/hannahsten/texifyidea/util/labels/LabelExtraction.kt
+++ b/src/nl/hannahsten/texifyidea/util/labels/LabelExtraction.kt
@@ -2,7 +2,7 @@ package nl.hannahsten.texifyidea.util.labels
 
 import com.intellij.psi.PsiElement
 import com.jetbrains.rd.util.first
-import nl.hannahsten.texifyidea.lang.CommandManager
+import nl.hannahsten.texifyidea.lang.alias.CommandManager
 import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
 import nl.hannahsten.texifyidea.psi.*
 import nl.hannahsten.texifyidea.util.firstChildOfType

--- a/src/nl/hannahsten/texifyidea/util/labels/ProjectLabels.kt
+++ b/src/nl/hannahsten/texifyidea/util/labels/ProjectLabels.kt
@@ -6,7 +6,7 @@ import nl.hannahsten.texifyidea.index.BibtexEntryIndex
 import nl.hannahsten.texifyidea.index.LatexCommandsIndex
 import nl.hannahsten.texifyidea.index.LatexParameterLabeledCommandsIndex
 import nl.hannahsten.texifyidea.index.LatexParameterLabeledEnvironmentsIndex
-import nl.hannahsten.texifyidea.lang.CommandManager
+import nl.hannahsten.texifyidea.lang.alias.CommandManager
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 
 /**

--- a/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
@@ -3,7 +3,7 @@
 package nl.hannahsten.texifyidea.util.magic
 
 import com.intellij.openapi.project.Project
-import nl.hannahsten.texifyidea.lang.CommandManager
+import nl.hannahsten.texifyidea.lang.alias.CommandManager
 import nl.hannahsten.texifyidea.lang.commands.LatexBiblatexCommand.*
 import nl.hannahsten.texifyidea.lang.commands.LatexCommand
 import nl.hannahsten.texifyidea.lang.commands.LatexGenericMathCommand.*

--- a/src/nl/hannahsten/texifyidea/util/magic/EnvironmentMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/EnvironmentMagic.kt
@@ -1,12 +1,22 @@
 package nl.hannahsten.texifyidea.util.magic
 
+import com.intellij.openapi.project.Project
 import nl.hannahsten.texifyidea.lang.DefaultEnvironment.*
+import nl.hannahsten.texifyidea.lang.alias.EnvironmentManager
 
 object EnvironmentMagic {
 
     val listingEnvironments = hashSetOf(ITEMIZE, ENUMERATE, DESCRIPTION).map { it.env }
 
-    val tableEnvironments = hashSetOf(TABULAR, TABULAR_STAR, TABULARX, ARRAY, LONGTABLE, TABU, MATRIX, BMATRIX, PMATRIX, VMATRIX, VMATRIX_CAPITAL).map { it.env }
+    private val tableEnvironmentsWithoutCustomEnvironments = hashSetOf(TABULAR, TABULAR_STAR, TABULARX, ARRAY, LONGTABLE, TABU, MATRIX, BMATRIX, PMATRIX, VMATRIX, VMATRIX_CAPITAL).map { it.env }
+
+    /**
+     * Get all table environments in the project, including any user defined aliases.
+     */
+    fun getAllTableEnvironments(project: Project): Set<String> {
+        EnvironmentManager.updateAliases(tableEnvironmentsWithoutCustomEnvironments, project)
+        return EnvironmentManager.getAliases(tableEnvironmentsWithoutCustomEnvironments.first())
+    }
 
     /**
      * Map that maps all environments that are expected to have a label to the label prefix they have by convention.

--- a/src/nl/hannahsten/texifyidea/util/magic/EnvironmentMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/EnvironmentMagic.kt
@@ -8,7 +8,7 @@ object EnvironmentMagic {
 
     val listingEnvironments = hashSetOf(ITEMIZE, ENUMERATE, DESCRIPTION).map { it.env }
 
-    private val tableEnvironmentsWithoutCustomEnvironments = hashSetOf(TABULAR, TABULAR_STAR, TABULARX, ARRAY, LONGTABLE, TABU, MATRIX, BMATRIX, PMATRIX, VMATRIX, VMATRIX_CAPITAL).map { it.env }
+    private val tableEnvironmentsWithoutCustomEnvironments = hashSetOf(TABULAR, TABULAR_STAR, TABULARX, TABULARY, ARRAY, LONGTABLE, TABU, MATRIX, BMATRIX, PMATRIX, VMATRIX, VMATRIX_CAPITAL).map { it.env }
 
     /**
      * Get all table environments in the project, including any user defined aliases.

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexFigureNotReferencedInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexFigureNotReferencedInspectionTest.kt
@@ -2,7 +2,7 @@ package nl.hannahsten.texifyidea.inspections.latex.codestyle
 
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
-import nl.hannahsten.texifyidea.lang.CommandManager
+import nl.hannahsten.texifyidea.lang.alias.CommandManager
 
 class LatexFigureNotReferencedInspectionTest : TexifyInspectionTestBase(LatexFigureNotReferencedInspection()) {
 

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMissingLabelInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMissingLabelInspectionTest.kt
@@ -2,7 +2,7 @@ package nl.hannahsten.texifyidea.inspections.latex.codestyle
 
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
-import nl.hannahsten.texifyidea.lang.CommandManager
+import nl.hannahsten.texifyidea.lang.alias.CommandManager
 import nl.hannahsten.texifyidea.psi.LatexKeyvalPair
 import nl.hannahsten.texifyidea.util.childrenOfType
 

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexEscapeAmpersandInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexEscapeAmpersandInspectionTest.kt
@@ -32,6 +32,21 @@ internal class LatexEscapeAmpersandInspectionTest : TexifyInspectionTestBase(Lat
         myFixture.checkHighlighting(true, false, false, false)
     }
 
+    fun `test that ampersand in custom tabular environment does not trigger a warning`() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \newenvironment{kwak}{ \begin{tabular}{lc} }{ \end{tabular} }
+            \begin{document}
+                \begin{kwak}
+                    kwik & kwek \\
+                \end{kwak}
+            \end{document}
+            """.trimIndent()
+        )
+        myFixture.checkHighlighting(true, false, false, false)
+    }
+
     fun `test that ampersand in math environment does trigger a warning`() {
         myFixture.configureByText(
             LatexFileType,

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnresolvedReferenceInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnresolvedReferenceInspectionTest.kt
@@ -2,7 +2,7 @@ package nl.hannahsten.texifyidea.inspections.latex.probablebugs
 
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
-import nl.hannahsten.texifyidea.lang.CommandManager
+import nl.hannahsten.texifyidea.lang.alias.CommandManager
 import org.junit.Test
 
 class LatexUnresolvedReferenceInspectionTest : TexifyInspectionTestBase(LatexUnresolvedReferenceInspection()) {

--- a/test/nl/hannahsten/texifyidea/inspections/latex/redundancy/LatexDuplicateLabelInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/redundancy/LatexDuplicateLabelInspectionTest.kt
@@ -2,7 +2,7 @@ package nl.hannahsten.texifyidea.inspections.latex.redundancy
 
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
-import nl.hannahsten.texifyidea.lang.CommandManager
+import nl.hannahsten.texifyidea.lang.alias.CommandManager
 
 class LatexDuplicateLabelInspectionTest : TexifyInspectionTestBase(LatexDuplicateLabelInspection()) {
 

--- a/test/nl/hannahsten/texifyidea/lang/CommandManagerTest.kt
+++ b/test/nl/hannahsten/texifyidea/lang/CommandManagerTest.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.lang
 
+import nl.hannahsten.texifyidea.lang.alias.CommandManager
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test

--- a/test/nl/hannahsten/texifyidea/psi/LatexParameterTextUtilTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/LatexParameterTextUtilTest.kt
@@ -2,7 +2,7 @@ package nl.hannahsten.texifyidea.psi
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import nl.hannahsten.texifyidea.file.LatexFileType
-import nl.hannahsten.texifyidea.lang.CommandManager
+import nl.hannahsten.texifyidea.lang.alias.CommandManager
 
 class LatexParameterTextUtilTest : BasePlatformTestCase() {
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fixes #2162 
Fix #2223

#### Summary of additions and changes

* Add EnvironmentManager similar to CommandManager, migrate common code to AliasManager
* Moved the CommandManager class
* Register the tabular-like environments
* Added the `tabulary` environment to the default table environments

#### How to test this pull request
No inspection warning, and table formatting works:
```latex
\documentclass[11pt]{article}

\newenvironment{table2}
    { \begin{tabular}{ c c c } }
    { \end{tabular} }

\begin{document}
    \begin{table2}
        a      & b & c \\
        bbbbbb & c & d \\
    \end{table2}
\end{document}
```
