### PR TITLE
Add undefined commands inspection

### DIFF
--- a/resources/META-INF/extensions/inspections/latex/probablebugs/probablebugs.xml
+++ b/resources/META-INF/extensions/inspections/latex/probablebugs/probablebugs.xml
@@ -72,6 +72,10 @@
                          groupPath="LaTeX" groupName="Probable bugs" displayName="Relative path to parent is not allowed when using BIBINPUTS"
                          enabledByDefault="true"
                          level="ERROR" />
+        <localInspection language="Latex" implementationClass="nl.hannahsten.texifyidea.inspections.latex.probablebugs.LatexUndefinedCommandInspection"
+                         groupPath="LaTeX" groupName="Probable bugs" displayName="Command is not defined"
+                         enabledByDefault="false"
+                         level="ERROR" />
     </extensions>
 
     <xi:include href="/META-INF/extensions/inspections/latex/probablebugs/packages.xml" xpointer="xpointer(/idea-plugin/*)"/>

--- a/resources/META-INF/extensions/inspections/latex/probablebugs/probablebugs.xml
+++ b/resources/META-INF/extensions/inspections/latex/probablebugs/probablebugs.xml
@@ -72,7 +72,7 @@
                          groupPath="LaTeX" groupName="Probable bugs" displayName="Relative path to parent is not allowed when using BIBINPUTS"
                          enabledByDefault="true"
                          level="ERROR" />
-        <localInspection language="Latex" implementationClass="nl.hannahsten.texifyidea.inspections.latex.probablebugs.LatexUndefinedCommandInspection"
+        <localInspection language="Latex" implementationClass="nl.hannahsten.texifyidea.inspections.latex.probablebugs.packages.LatexUndefinedCommandInspection"
                          groupPath="LaTeX" groupName="Probable bugs" displayName="Command is not defined"
                          enabledByDefault="false"
                          level="ERROR" />

--- a/resources/inspectionDescriptions/LatexUndefinedCommand.html
+++ b/resources/inspectionDescriptions/LatexUndefinedCommand.html
@@ -1,0 +1,5 @@
+<html>
+    <body>
+        The command was not found in LaTeX or any included package.
+    </body>
+</html>

--- a/src/nl/hannahsten/texifyidea/completion/LatexCommandsAndEnvironmentsCompletionProvider.kt
+++ b/src/nl/hannahsten/texifyidea/completion/LatexCommandsAndEnvironmentsCompletionProvider.kt
@@ -237,7 +237,7 @@ class LatexCommandsAndEnvironmentsCompletionProvider internal constructor(privat
     }
 
     private fun getTypeText(commands: LatexCommands): String {
-        if (commands.commandToken.text in CommandMagic.commandDefinitions) {
+        if (commands.commandToken.text in CommandMagic.commandDefinitionsAndRedefinitions) {
             return ""
         }
         val firstNext = commands.nextCommand() ?: return ""

--- a/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexFigureNotReferencedInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexFigureNotReferencedInspection.kt
@@ -48,7 +48,7 @@ open class LatexFigureNotReferencedInspection : TexifyInspectionBase() {
         val referenceCommands = file.project.getLabelReferenceCommands()
         for (command in file.commandsInFileSet()) {
             // Don't resolve references in command definitions
-            if (command.parent.firstParentOfType(LatexCommands::class)?.name in CommandMagic.commandDefinitions ||
+            if (command.parent.firstParentOfType(LatexCommands::class)?.name in CommandMagic.commandDefinitionsAndRedefinitions ||
                 referenceCommands.contains(command.name)
             ) {
                 command.referencedLabelNames.forEach { figureLabels.remove(it) }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspection.kt
@@ -43,7 +43,7 @@ open class LatexFileNotFoundInspection : TexifyInspectionBase() {
         // Loop through commands of file
         for (command in commands) {
             // Don't resolve references in command definitions, as in \cite{#1} the #1 is not a reference
-            if (command.parent.firstParentOfType(LatexCommands::class)?.name in CommandMagic.commandDefinitions) {
+            if (command.parent.firstParentOfType(LatexCommands::class)?.name in CommandMagic.commandDefinitionsAndRedefinitions) {
                 continue
             }
 

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUndefinedCommandInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUndefinedCommandInspection.kt
@@ -1,0 +1,62 @@
+package nl.hannahsten.texifyidea.inspections.latex.probablebugs
+
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.psi.PsiFile
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.util.indexing.FileBasedIndex
+import nl.hannahsten.texifyidea.index.file.LatexExternalCommandIndex
+import nl.hannahsten.texifyidea.inspections.InsightGroup
+import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
+import nl.hannahsten.texifyidea.lang.LatexPackage
+import nl.hannahsten.texifyidea.lang.commands.LatexRegularCommand
+import nl.hannahsten.texifyidea.util.definedCommandName
+import nl.hannahsten.texifyidea.util.files.commandsInFile
+import nl.hannahsten.texifyidea.util.files.commandsInFileSet
+import nl.hannahsten.texifyidea.util.files.definitionsInFileSet
+import nl.hannahsten.texifyidea.util.includedPackages
+import nl.hannahsten.texifyidea.util.magic.CommandMagic
+
+/**
+ * Warn when the user uses a command that is not defined in any included packages or LaTeX base.
+ *
+ * @author Thomas
+ */
+class LatexUndefinedCommandInspection : TexifyInspectionBase() {
+
+    override val inspectionGroup = InsightGroup.LATEX
+
+    override val inspectionId = "UndefinedCommand"
+
+    override fun getDisplayName() = "Undefined command"
+
+    override fun inspectFile(file: PsiFile, manager: InspectionManager, isOntheFly: Boolean): List<ProblemDescriptor> {
+        val includedPackages = file.includedPackages().toSet().plus(LatexPackage.DEFAULT)
+        val commandsInFile = file.commandsInFile()
+        val commandNamesInFile = commandsInFile.map { it.name }
+        // The number of indexed commands can be quite large (50k+) so we filter the large set based on the small one (in this file).
+        val indexedCommands = FileBasedIndex.getInstance().getAllKeys(LatexExternalCommandIndex.id, file.project)
+            .filter { it in commandNamesInFile }
+            .associateWith { command ->
+                val containingPackages = FileBasedIndex.getInstance().getContainingFiles(LatexExternalCommandIndex.id, command, GlobalSearchScope.everythingScope(file.project))
+                    .map { LatexPackage.create(it) }
+                    .toSet()
+                containingPackages
+            }
+        val magicCommands = LatexRegularCommand.ALL.associate { Pair(it.command, setOf(it.dependency)) }
+        val userDefinedCommands = file.definitionsInFileSet().filter { it.name in CommandMagic.commandDefinitions }
+            .map { it.definedCommandName() }
+            .associateWith { setOf(LatexPackage.DEFAULT) }
+
+        // Join all the maps
+        val allKnownCommands = (indexedCommands.keys + magicCommands.keys + userDefinedCommands.keys).associateWith {
+            indexedCommands.getOrDefault(it, setOf()) + magicCommands.getOrDefault(it, setOf()) + userDefinedCommands.getOrDefault(it, setOf())
+        }
+
+        return commandsInFile.filter { allKnownCommands.getOrDefault(it.name, emptyList()).intersect(includedPackages).isEmpty() }
+            .map { manager.createProblemDescriptor(it, it.textRange, "", ProblemHighlightType.GENERIC_ERROR_OR_WARNING, isOntheFly) }
+    }
+
+    // todo quickfix
+}

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnresolvedReferenceInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnresolvedReferenceInspection.kt
@@ -41,7 +41,7 @@ open class LatexUnresolvedReferenceInspection : TexifyInspectionBase() {
             }
 
             // Don't resolve references in command definitions, as in \cite{#1} the #1 is not a reference
-            if (command.parent.firstParentOfType(LatexCommands::class)?.name in CommandMagic.commandDefinitions) {
+            if (command.parent.firstParentOfType(LatexCommands::class)?.name in CommandMagic.commandDefinitionsAndRedefinitions) {
                 continue
             }
 

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/packages/LatexUndefinedCommandInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/packages/LatexUndefinedCommandInspection.kt
@@ -79,6 +79,5 @@ class LatexUndefinedCommandInspection : TexifyInspectionBase() {
         override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
             descriptor.psiElement.containingFile.insertUsepackage(dependency)
         }
-
     }
 }

--- a/src/nl/hannahsten/texifyidea/reference/CommandDefinitionReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/CommandDefinitionReference.kt
@@ -22,7 +22,7 @@ class CommandDefinitionReference(element: LatexCommands) : PsiReferenceBase<Late
 
     // Find all command definitions and redefinitions which define the current element
     override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
-        val definitionsAndRedefinitions = CommandMagic.commandDefinitions + CommandMagic.commandRedefinitions
+        val definitionsAndRedefinitions = CommandMagic.commandDefinitionsAndRedefinitions + CommandMagic.commandRedefinitions
 
         // Don't resolve to a definition when you are in a \newcommand
         if (element.parentsOfType<LatexCommands>().any { it.name in definitionsAndRedefinitions }) {

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexStructureViewElement.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexStructureViewElement.kt
@@ -126,7 +126,7 @@ class LatexStructureViewElement(private val element: PsiElement) : StructureView
         }
 
         // Add command definitions.
-        CommandMagic.commandDefinitions.forEach {
+        CommandMagic.commandDefinitionsAndRedefinitions.forEach {
             addFromCommand(treeElements, commands, it)
         }
 

--- a/src/nl/hannahsten/texifyidea/util/Commands.kt
+++ b/src/nl/hannahsten/texifyidea/util/Commands.kt
@@ -24,7 +24,7 @@ import java.util.stream.Collectors
  */
 fun Project.findCommandDefinitions(): Collection<LatexCommands> {
     return LatexDefinitionIndex.getItems(this).filter {
-        it.name in CommandMagic.commandDefinitions
+        it.name in CommandMagic.commandDefinitionsAndRedefinitions
     }
 }
 
@@ -48,7 +48,7 @@ fun expandCommandsOnce(inputText: String, project: Project, file: PsiFile?): Str
 
     for (command in commandsInText) {
         // Expand the command once, and replace the command with the expanded text
-        val commandExpansion = LatexCommandsIndex.getCommandsByNames(file ?: return null, *CommandMagic.commandDefinitions.toTypedArray())
+        val commandExpansion = LatexCommandsIndex.getCommandsByNames(file ?: return null, *CommandMagic.commandDefinitionsAndRedefinitions.toTypedArray())
                 .firstOrNull { it.getRequiredArgumentValueByName("cmd") == command.text }
                 ?.getRequiredArgumentValueByName("def")
         text = text.replace(command.text, commandExpansion ?: command.text)

--- a/src/nl/hannahsten/texifyidea/util/PsiCommands.kt
+++ b/src/nl/hannahsten/texifyidea/util/PsiCommands.kt
@@ -43,7 +43,7 @@ fun LatexCommands?.usesColor() = this != null && this.name?.substring(1) in Colo
  *         `null` or otherwise.
  */
 fun LatexCommands?.isDefinitionOrRedefinition() = this != null &&
-        (this.name in CommandMagic.commandDefinitions || this.name in CommandMagic.commandRedefinitions ||
+        (this.name in CommandMagic.commandDefinitionsAndRedefinitions || this.name in CommandMagic.commandRedefinitions ||
                 this.name in CommandMagic.environmentDefinitions || this.name in CommandMagic.environmentRedefinitions)
 
 /**
@@ -51,7 +51,7 @@ fun LatexCommands?.isDefinitionOrRedefinition() = this != null &&
  *
  * @return `true` if the command is a command definition, `false` when the command is `null` or otherwise.
  */
-fun LatexCommands?.isCommandDefinition(): Boolean = this != null && name in CommandMagic.commandDefinitions
+fun LatexCommands?.isCommandDefinition(): Boolean = this != null && name in CommandMagic.commandDefinitionsAndRedefinitions
 
 /**
  * Checks whether the given LaTeX commands is an environment definition or not.

--- a/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
@@ -197,14 +197,14 @@ fun PsiFile.scanRoots(path: String, extensions: Set<String>? = null): PsiFile? {
 fun PsiFile.document(): Document? = PsiDocumentManager.getInstance(project).getDocument(this)
 
 /**
- * @param name
+ * @param commandName
  *          The name of the command including a backslash, or `null` for all commands.
  *
  * @see [LatexCommandsIndex.getItems]
  */
 @JvmOverloads
-fun PsiFile.commandsInFile(name: String? = null): Collection<LatexCommands> {
-    return name?.let {
+fun PsiFile.commandsInFile(commandName: String? = null): Collection<LatexCommands> {
+    return commandName?.let {
         LatexCommandsIndex.getCommandsByName(it, this)
     } ?: LatexCommandsIndex.getItems(this)
 }

--- a/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
@@ -187,24 +187,30 @@ object CommandMagic {
     )
 
     /**
+     * Commands that define other command but don't complain if it is already defined.
+     */
+    val flexibleCommandDefinitions = setOf(
+        PROVIDECOMMAND, // Does nothing if command exists
+        PROVIDECOMMAND_STAR,
+        PROVIDEDOCUMENTCOMMAND, // Does nothing if command exists
+        DECLAREDOCUMENTCOMMAND,
+        DEF,
+        LET,
+    ).map { it.cmd }
+
+    /**
      * All commands that define or redefine other commands, whether it exists or not.
      */
-    val commandRedefinitions = hashSetOf(
+    val commandRedefinitions = setOf(
             RENEWCOMMAND,
             RENEWCOMMAND_STAR,
-            PROVIDECOMMAND, // Does nothing if command exists
-            PROVIDECOMMAND_STAR,
-            PROVIDEDOCUMENTCOMMAND, // Does nothing if command exists
-            DECLAREDOCUMENTCOMMAND,
-            DEF,
-            LET,
             CATCODE, // Not really redefining commands, but characters
-    ).map { it.cmd }
+    ).map { it.cmd } + flexibleCommandDefinitions
 
     /**
      * All commands that define or redefine regular commands.
      */
-    val regularCommandDefinitions = regularStrictCommandDefinitions + commandRedefinitions
+    val regularCommandDefinitionsAndRedefinitions = regularStrictCommandDefinitions + commandRedefinitions
 
     /**
      * All commands that define commands that should be used exclusively
@@ -218,9 +224,14 @@ object CommandMagic {
     )
 
     /**
-     * All commands that define new commands.
+     * All commands that can define regular commands.
      */
-    val commandDefinitions = regularCommandDefinitions + mathCommandDefinitions
+    val commandDefinitions = regularStrictCommandDefinitions + mathCommandDefinitions + flexibleCommandDefinitions
+
+    /**
+     * All commands that (re)define new commands.
+     */
+    val commandDefinitionsAndRedefinitions = regularCommandDefinitionsAndRedefinitions + mathCommandDefinitions
 
     /**
      * All commands that define new documentclasses.
@@ -251,7 +262,7 @@ object CommandMagic {
     /**
      * All commands that define stuff like classes, environments, and definitions.
      */
-    val definitions = commandDefinitions + classDefinitions + packageDefinitions + environmentDefinitions
+    val definitions = commandDefinitionsAndRedefinitions + classDefinitions + packageDefinitions + environmentDefinitions
 
     /**
      * Commands for which TeXiFy-IDEA has essential custom behaviour and which should not be redefined.

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUndefinedCommandInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUndefinedCommandInspectionTest.kt
@@ -2,11 +2,12 @@ package nl.hannahsten.texifyidea.inspections.latex.probablebugs
 
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
+import nl.hannahsten.texifyidea.inspections.latex.probablebugs.packages.LatexUndefinedCommandInspection
 
 class LatexUndefinedCommandInspectionTest : TexifyInspectionTestBase(LatexUndefinedCommandInspection()) {
 
     fun testUndefinedCommand() {
-        myFixture.configureByText(LatexFileType, """\blub""")
+        myFixture.configureByText(LatexFileType, """<error descr="Command \blub is not defined">\blub</error>""")
         myFixture.checkHighlighting()
     }
 
@@ -18,5 +19,4 @@ class LatexUndefinedCommandInspectionTest : TexifyInspectionTestBase(LatexUndefi
         """.trimIndent())
         myFixture.checkHighlighting()
     }
-
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUndefinedCommandInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUndefinedCommandInspectionTest.kt
@@ -1,0 +1,22 @@
+package nl.hannahsten.texifyidea.inspections.latex.probablebugs
+
+import nl.hannahsten.texifyidea.file.LatexFileType
+import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
+
+class LatexUndefinedCommandInspectionTest : TexifyInspectionTestBase(LatexUndefinedCommandInspection()) {
+
+    fun testUndefinedCommand() {
+        myFixture.configureByText(LatexFileType, """\blub""")
+        myFixture.checkHighlighting()
+    }
+
+    fun testDefinedCommand() {
+        myFixture.configureByText(LatexFileType, """
+            \documentclass{article}
+            \newcommand{\floep}{\grq}
+            \floep
+        """.trimIndent())
+        myFixture.checkHighlighting()
+    }
+
+}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2201

#### Summary of additions and changes

We already have the missing import inspection, but it only works on commands that are already hardcoded in TeXiFy. There is a good reason it doesn't error on the other unknown commands: many of the valid commands are not yet indexed.
This PR adds an inspection which does just that, and which is then of course disabled by default.
It is mainly useful for finding issues with the external commands data indexer, at the moment. (e.g. #2190)

#### How to test this pull request

Example command that is in index but not hardcoded: `\branch` from koma-script.

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: