### PR TITLE
Folding builders do not access index anymore

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ tasks.compileKotlin {
 
     kotlinOptions {
         jvmTarget = "11"
-        freeCompilerArgs = listOf("-Xjvm-default=enable")
+        freeCompilerArgs = listOf("-Xjvm-default=all")
     }
 }
 
@@ -63,7 +63,7 @@ tasks.compileTestKotlin {
 
     kotlinOptions {
         jvmTarget = "11"
-        freeCompilerArgs = listOf("-Xjvm-default=enable")
+        freeCompilerArgs = listOf("-Xjvm-default=all")
     }
 }
 

--- a/src/nl/hannahsten/texifyidea/editor/folding/LatexImportFoldingBuilder.kt
+++ b/src/nl/hannahsten/texifyidea/editor/folding/LatexImportFoldingBuilder.kt
@@ -7,10 +7,10 @@ import com.intellij.openapi.editor.Document
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
-import nl.hannahsten.texifyidea.index.LatexIncludesIndex
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexNoMathContent
 import nl.hannahsten.texifyidea.psi.PsiContainer
+import nl.hannahsten.texifyidea.util.allCommands
 import nl.hannahsten.texifyidea.util.firstChildOfType
 import nl.hannahsten.texifyidea.util.magic.PatternMagic
 import nl.hannahsten.texifyidea.util.parentOfType
@@ -36,7 +36,7 @@ open class LatexImportFoldingBuilder : FoldingBuilderEx() {
     override fun buildFoldRegions(root: PsiElement, document: Document, quick: Boolean): Array<FoldingDescriptor> {
         val descriptors = ArrayList<FoldingDescriptor>()
         val covered = HashSet<LatexCommands>()
-        val commands = LatexIncludesIndex.getCommandsByNames(root.containingFile, *includesArray)
+        val commands = root.allCommands().filter { it.name in includesArray }
 
         for (command in commands) {
             // Do not cover commands twice.

--- a/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
@@ -205,8 +205,8 @@ fun PsiFile.document(): Document? = PsiDocumentManager.getInstance(project).getD
 @JvmOverloads
 fun PsiFile.commandsInFile(commandName: String? = null): Collection<LatexCommands> {
     return commandName?.let {
-        LatexCommandsIndex.getCommandsByName(it, this)
-    } ?: LatexCommandsIndex.getItems(this)
+        this.allCommands().filter { it.name == commandName }
+    } ?: this.allCommands()
 }
 
 /**


### PR DESCRIPTION
After #2232 I received some errors from `SlowOperations#assertSlowOperationsAreAllowed`, but they came only from the folding builders that accessed the index. I ensured they do not do that anymore, and now the error seems gone.
It remains to be seen whether there is any performance impact.