### PR TITLE
Mock runCommand() in tests to avoid access to local LaTeX installation

### DIFF
--- a/test/nl/hannahsten/texifyidea/gutter/LatexGutterTest.kt
+++ b/test/nl/hannahsten/texifyidea/gutter/LatexGutterTest.kt
@@ -5,9 +5,18 @@ import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.mockk.every
+import io.mockk.mockkStatic
+import nl.hannahsten.texifyidea.util.runCommandWithExitCode
 import org.junit.Test
 
 class LatexGutterTest : BasePlatformTestCase() {
+
+    override fun setUp() {
+        super.setUp()
+        mockkStatic(::runCommandWithExitCode)
+        every { runCommandWithExitCode(*anyVararg(), workingDirectory = any(), timeout = any(), returnExceptionMessage = any()) } returns Pair(null, 0)
+    }
 
     override fun getTestDataPath(): String {
         return "test/resources/gutter"

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexFigureNotReferencedInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexFigureNotReferencedInspectionTest.kt
@@ -1,10 +1,19 @@
 package nl.hannahsten.texifyidea.inspections.latex.codestyle
 
+import io.mockk.every
+import io.mockk.mockkStatic
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
 import nl.hannahsten.texifyidea.lang.alias.CommandManager
+import nl.hannahsten.texifyidea.util.runCommandWithExitCode
 
 class LatexFigureNotReferencedInspectionTest : TexifyInspectionTestBase(LatexFigureNotReferencedInspection()) {
+
+    override fun setUp() {
+        super.setUp()
+        mockkStatic(::runCommandWithExitCode)
+        every { runCommandWithExitCode(*anyVararg(), workingDirectory = any(), timeout = any(), returnExceptionMessage = any()) } returns Pair(null, 0)
+    }
 
     fun testFigureNotReferencedWarning() {
         myFixture.configureByText(

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexTooLargeSectionInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexTooLargeSectionInspectionTest.kt
@@ -1,8 +1,17 @@
 package nl.hannahsten.texifyidea.inspections.latex.codestyle
 
+import io.mockk.every
+import io.mockk.mockkStatic
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
+import nl.hannahsten.texifyidea.util.runCommandWithExitCode
 
 class LatexTooLargeSectionInspectionTest : TexifyInspectionTestBase(LatexTooLargeSectionInspection()) {
+
+    override fun setUp() {
+        super.setUp()
+        mockkStatic(::runCommandWithExitCode)
+        every { runCommandWithExitCode(*anyVararg(), workingDirectory = any(), timeout = any(), returnExceptionMessage = any()) } returns Pair(null, 0)
+    }
 
     override fun getTestDataPath(): String = "test/resources/inspections/latex/toolargesection"
 

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexUsePackageInPackageInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexUsePackageInPackageInspectionTest.kt
@@ -1,7 +1,10 @@
 package nl.hannahsten.texifyidea.inspections.latex.codestyle
 
+import io.mockk.every
+import io.mockk.mockkStatic
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
 import nl.hannahsten.texifyidea.inspections.latex.TexifyRegexInspectionTestBase
+import nl.hannahsten.texifyidea.util.runCommandWithExitCode
 
 class LatexUsePackageInPackageInspectionRegexTest : TexifyRegexInspectionTestBase(LatexUsePackageInPackageInspection()) {
 
@@ -19,6 +22,12 @@ class LatexUsePackageInPackageInspectionRegexTest : TexifyRegexInspectionTestBas
 }
 
 class LatexUsePackageInPackageInspectionQuickFixTest : TexifyInspectionTestBase(LatexUsePackageInPackageInspection()) {
+
+    override fun setUp() {
+        super.setUp()
+        mockkStatic(::runCommandWithExitCode)
+        every { runCommandWithExitCode(*anyVararg(), workingDirectory = any(), timeout = any(), returnExceptionMessage = any()) } returns Pair(null, 0)
+    }
 
     fun testRequiredArgumentQuickFix() = testQuickFix(
         before = """\usepackage{xcolor}""",

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspectionTest.kt
@@ -1,7 +1,10 @@
 package nl.hannahsten.texifyidea.inspections.latex.probablebugs
 
+import io.mockk.every
+import io.mockk.mockkStatic
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
+import nl.hannahsten.texifyidea.util.runCommandWithExitCode
 import org.junit.Test
 import java.io.File
 import java.nio.file.Path
@@ -15,6 +18,12 @@ class LatexFileNotFoundInspectionTest : TexifyInspectionTestBase(LatexFileNotFou
     init {
         val currentRelativePath: Path = Paths.get("")
         absoluteWorkingPath = currentRelativePath.toAbsolutePath().toString().replace(File.separatorChar, '/')
+    }
+
+    override fun setUp() {
+        super.setUp()
+        mockkStatic(::runCommandWithExitCode)
+        every { runCommandWithExitCode(*anyVararg(), workingDirectory = any(), timeout = any(), returnExceptionMessage = any()) } returns Pair(null, 0)
     }
 
     override fun getTestDataPath(): String {

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspectionTest.kt
@@ -1,7 +1,10 @@
 package nl.hannahsten.texifyidea.inspections.latex.probablebugs
 
+import io.mockk.every
+import io.mockk.mockkStatic
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
+import nl.hannahsten.texifyidea.util.runCommandWithExitCode
 
 class OutsideMathLatexUnicodeInspectionTest : LatexUnicodeInspectionTest() {
 
@@ -32,6 +35,12 @@ class OutsideMathLatexUnicodeInspectionTest : LatexUnicodeInspectionTest() {
 }
 
 class InsideMathLatexUnicodeInspectionTest : LatexUnicodeInspectionTest() {
+
+    override fun setUp() {
+        super.setUp()
+        mockkStatic(::runCommandWithExitCode)
+        every { runCommandWithExitCode(*anyVararg(), workingDirectory = any(), timeout = any(), returnExceptionMessage = any()) } returns Pair(null, 0)
+    }
 
     fun `test without support`() {
         setUnicodeSupport(false)

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnresolvedReferenceInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnresolvedReferenceInspectionTest.kt
@@ -1,11 +1,20 @@
 package nl.hannahsten.texifyidea.inspections.latex.probablebugs
 
+import io.mockk.every
+import io.mockk.mockkStatic
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
 import nl.hannahsten.texifyidea.lang.alias.CommandManager
+import nl.hannahsten.texifyidea.util.runCommandWithExitCode
 import org.junit.Test
 
 class LatexUnresolvedReferenceInspectionTest : TexifyInspectionTestBase(LatexUnresolvedReferenceInspection()) {
+
+    override fun setUp() {
+        super.setUp()
+        mockkStatic(::runCommandWithExitCode)
+        every { runCommandWithExitCode(*anyVararg(), workingDirectory = any(), timeout = any(), returnExceptionMessage = any()) } returns Pair(null, 0)
+    }
 
     override fun getTestDataPath(): String {
         return "test/resources/inspections/latex/unresolvedreference"

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/packages/LatexMissingImportInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/packages/LatexMissingImportInspectionTest.kt
@@ -1,9 +1,12 @@
 package nl.hannahsten.texifyidea.inspections.latex.probablebugs.packages
 
 import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl
+import io.mockk.every
+import io.mockk.mockkStatic
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
 import nl.hannahsten.texifyidea.testutils.writeCommand
+import nl.hannahsten.texifyidea.util.runCommandWithExitCode
 
 class LatexMissingImportInspectionTest : TexifyInspectionTestBase(LatexMissingImportInspection()) {
 
@@ -15,6 +18,8 @@ class LatexMissingImportInspectionTest : TexifyInspectionTestBase(LatexMissingIm
         super.setUp()
         myFixture.copyDirectoryToProject("", "")
         (myFixture as CodeInsightTestFixtureImpl).canChangeDocumentDuringHighlighting(true)
+        mockkStatic(::runCommandWithExitCode)
+        every { runCommandWithExitCode(*anyVararg(), workingDirectory = any(), timeout = any(), returnExceptionMessage = any()) } returns Pair(null, 0)
     }
 
     fun testWarning() {

--- a/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
@@ -1,9 +1,18 @@
 package nl.hannahsten.texifyidea.psi
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.mockk.every
+import io.mockk.mockkStatic
 import nl.hannahsten.texifyidea.file.LatexFileType
+import nl.hannahsten.texifyidea.util.runCommandWithExitCode
 
 class LatexParserTest : BasePlatformTestCase() {
+
+    override fun setUp() {
+        super.setUp()
+        mockkStatic(::runCommandWithExitCode)
+        every { runCommandWithExitCode(*anyVararg(), workingDirectory = any(), timeout = any(), returnExceptionMessage = any()) } returns Pair(null, 0)
+    }
 
     fun testSomeGeneralConstructs() {
         myFixture.configureByText(


### PR DESCRIPTION
@fberlakovich Please check if this helps in fixing the `java.lang.AssertionError: File accessed outside allowed roots`.
At least when I check the function return value, it doesn't refer to my local `inputenc.sty` anymore in LatexGutterTest, which mimics what happens in GitHub Actions.
I have no clue why you got the error but I don't, so I can't say for sure if this is enough.