### PR TITLE
Project initialized check, FileNotFoundInspection and command definition reference inside definition

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspection.kt
@@ -43,7 +43,7 @@ open class LatexFileNotFoundInspection : TexifyInspectionBase() {
         // Loop through commands of file
         for (command in commands) {
             // Don't resolve references in command definitions, as in \cite{#1} the #1 is not a reference
-            if (command.parent.firstParentOfType(LatexCommands::class)?.name in CommandMagic.commandDefinitionsAndRedefinitions) {
+            if (command.parent.parentsOfType(LatexCommands::class).any { it.name in CommandMagic.commandDefinitionsAndRedefinitions }) {
                 continue
             }
 

--- a/src/nl/hannahsten/texifyidea/reference/CommandDefinitionReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/CommandDefinitionReference.kt
@@ -4,7 +4,9 @@ import com.intellij.psi.*
 import com.intellij.util.containers.toArray
 import nl.hannahsten.texifyidea.index.LatexDefinitionIndex
 import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.psi.LatexParameter
 import nl.hannahsten.texifyidea.util.childrenOfType
+import nl.hannahsten.texifyidea.util.firstParentOfType
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.parentsOfType
 import nl.hannahsten.texifyidea.util.projectSearchScope
@@ -24,8 +26,10 @@ class CommandDefinitionReference(element: LatexCommands) : PsiReferenceBase<Late
     override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
         val definitionsAndRedefinitions = CommandMagic.commandDefinitionsAndRedefinitions + CommandMagic.commandRedefinitions
 
-        // Don't resolve to a definition when you are in a \newcommand
-        if (element.parentsOfType<LatexCommands>().any { it.name in definitionsAndRedefinitions }) {
+        // Don't resolve to a definition when you are in a \newcommand,
+        // and if this element is the element that is being defined
+        if (element.parentsOfType<LatexCommands>().any { it.name in definitionsAndRedefinitions } &&
+            element.parent.firstParentOfType(LatexCommands::class)?.parameterList?.firstOrNull() == element.firstParentOfType(LatexParameter::class)) {
             return emptyArray()
         }
         else {

--- a/src/nl/hannahsten/texifyidea/util/Projects.kt
+++ b/src/nl/hannahsten/texifyidea/util/Projects.kt
@@ -54,6 +54,7 @@ fun Project.findAvailableDocumentClasses(): Set<String> {
  * Get all the virtual files that are in the project of a given file type.
  */
 fun Project.allFiles(type: FileType): Collection<VirtualFile> {
+    if (!isInitialized) return emptyList()
     return runReadAction {
         val scope = GlobalSearchScope.projectScope(this)
         return@runReadAction FileTypeIndex.getFiles(type, scope)

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspectionTest.kt
@@ -75,6 +75,13 @@ class LatexFileNotFoundInspectionTest : TexifyInspectionTestBase(LatexFileNotFou
         }
     }
 
+    @Test
+    fun testNoWarningInDefinition() {
+        myFixture.configureByText(LatexFileType, """\newcommand*{\gridelement}[1]{\subbottom[#1]{\includegraphics[width=2cm]{media/#1}}}""")
+
+        myFixture.checkHighlighting()
+    }
+
     // Test isn't working
 //    @Test
 //    fun testImportAbsolutePath() {

--- a/test/nl/hannahsten/texifyidea/reference/CommandDefinitionReferenceTest.kt
+++ b/test/nl/hannahsten/texifyidea/reference/CommandDefinitionReferenceTest.kt
@@ -10,4 +10,18 @@ class CommandDefinitionReferenceTest : BasePlatformTestCase() {
         myFixture.renameElementAtCaret("\\mooizo")
         myFixture.checkResult("""\newcommand{\mooizo}{} \mooizo""")
     }
+
+    fun testResolveInDefinition() {
+        myFixture.configureByText(LatexFileType, """
+            \newcommand{\MyCommand}{Hello World!}
+            \newcommand{\AnotherCommand}{\MyCommand<caret>}
+            \AnotherCommand
+            """.trimIndent())
+        myFixture.renameElementAtCaret("\\floep")
+        myFixture.checkResult("""
+            \newcommand{\floep}{Hello World!}
+            \newcommand{\AnotherCommand}{\floep<caret>}
+            \AnotherCommand
+            """.trimIndent())
+    }
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2235 Index access on uninitialized project
Fix #2238 false positive in FileNotFoundInspection
Fix #2225 resolve to command definition inside definition when not the first parameter
