### PR TITLE
Fix missing labels in crash reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -40,3 +40,5 @@ assignees: ''
 ```
 
 ```
+
+<!-- If you see a minor issue related to commands or environments metadata, e.g. which commands are cite or verbatim commands, you are encouraged to try to add the missing information yourself, see https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Contributing-to-TeXiFy#editing-magic -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: TeXiFy IDEA wiki
     url: https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Features
     about: List of features and documentation of TeXiFy IDEA.
+  - name: Contributing to TeXiFy IDEA
+    url: https://github.com/Hannah-Sten/TeXiFy-IDEA/wiki/Contributing-to-TeXiFy
+    about: Help in contributing to the source of TeXiFy IDEA

--- a/.github/ISSUE_TEMPLATE/crash_report.md
+++ b/.github/ISSUE_TEMPLATE/crash_report.md
@@ -1,0 +1,16 @@
+---
+name: Crash report
+about: Create a report of crashes and exceptions that popped up
+title: ''
+labels: crash-report, untriaged
+assignees: ''
+
+---
+
+#### How to reproduce the exception
+
+#### The full stacktrace of the exception thrown
+```
+
+```
+

--- a/src/nl/hannahsten/texifyidea/LatexErrorReportSubmitter.kt
+++ b/src/nl/hannahsten/texifyidea/LatexErrorReportSubmitter.kt
@@ -90,7 +90,7 @@ class LatexErrorReportSubmitter : ErrorReportSubmitter() {
             builder.append(URLEncoder.encode("### TeXiFy IDEA version\n$currentVersion\n\n", ENCODING))
             builder.append(URLEncoder.encode("### Description\n", ENCODING))
             builder.append(URLEncoder.encode(additionalInfo ?: "\n", ENCODING))
-            builder.append(URLEncoder.encode("\n\n### Stacktrace\n```\n${body.take(7000)}\n```", ENCODING))
+            builder.append(URLEncoder.encode("\n\n### Stacktrace\n```\n${body.take(6000)}\n```", ENCODING))
         }
         catch (e: UnsupportedEncodingException) {
             consumer.consume(
@@ -103,7 +103,7 @@ class LatexErrorReportSubmitter : ErrorReportSubmitter() {
             return false
         }
 
-        BrowserUtil.browse(builder.toString().take(7000))
+        BrowserUtil.browse(builder.toString())
         consumer.consume(
             SubmittedReportInfo(
                 null,
@@ -116,7 +116,7 @@ class LatexErrorReportSubmitter : ErrorReportSubmitter() {
 
     companion object {
 
-        private const val ISSUE_URL = "https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/new?labels=crash-report&title="
+        private const val ISSUE_URL = "https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/new?labels=crash-report&template=crash_report.md&title="
 
         private const val JETBRAINS_API_URL = "https://plugins.jetbrains.com/plugins/list?pluginId=9473"
 


### PR DESCRIPTION
Still have to check whether this works with a dummy account, but I suspect that this fixes the missing labels since we moved to issue templates.