### PR TITLE
Improve speed of caching mechanism for package location cache

### DIFF
--- a/resources/META-INF/extensions/startup.xml
+++ b/resources/META-INF/extensions/startup.xml
@@ -3,5 +3,6 @@
         <postStartupActivity implementation="nl.hannahsten.texifyidea.startup.StartEvinceInverseSearchListener"/>
         <postStartupActivity implementation="nl.hannahsten.texifyidea.startup.AnalyzeMenuRegistration"/>
         <postStartupActivity implementation="nl.hannahsten.texifyidea.startup.TexLivePackageListInitializer"/>
+        <postStartupActivity implementation="nl.hannahsten.texifyidea.startup.LatexPackageLocationCacheInitializer"/>
     </extensions>
 </idea-plugin>

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspection.kt
@@ -65,7 +65,7 @@ open class LatexFileNotFoundInspection : TexifyInspectionBase() {
         // CTAN packages are no targets of the InputFileReference, so we check them here and don't show a warning if a CTAN package is included
         if (extensions.contains("sty")) {
             val ctanPackages = PackageUtils.CTAN_PACKAGE_NAMES.map { it.lowercase(Locale.getDefault()) }
-            if (reference.key in ctanPackages) return
+            if (reference.key.lowercase(Locale.getDefault()) in ctanPackages) return
         }
 
         val fixes = mutableListOf<LocalQuickFix>()

--- a/src/nl/hannahsten/texifyidea/startup/LatexPackageLocationCacheInitializer.kt
+++ b/src/nl/hannahsten/texifyidea/startup/LatexPackageLocationCacheInitializer.kt
@@ -1,0 +1,20 @@
+package nl.hannahsten.texifyidea.startup
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.StartupActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import nl.hannahsten.texifyidea.util.files.LatexPackageLocationCache
+
+/**
+ * Initialize package location cache, because filling it takes a long time, we do not want to do that only at the moment we need it (when resolving references).
+ */
+class LatexPackageLocationCacheInitializer : StartupActivity {
+    override fun runActivity(project: Project) {
+        // Not sure on which thread this is run, run in background to be sure
+        CoroutineScope(Dispatchers.Default).launch {
+            LatexPackageLocationCache.fillCacheWithKpsewhich(project)
+        }
+    }
+}

--- a/src/nl/hannahsten/texifyidea/startup/LatexPackageLocationCacheInitializer.kt
+++ b/src/nl/hannahsten/texifyidea/startup/LatexPackageLocationCacheInitializer.kt
@@ -11,6 +11,7 @@ import nl.hannahsten.texifyidea.util.files.LatexPackageLocationCache
  * Initialize package location cache, because filling it takes a long time, we do not want to do that only at the moment we need it (when resolving references).
  */
 class LatexPackageLocationCacheInitializer : StartupActivity {
+
     override fun runActivity(project: Project) {
         // Not sure on which thread this is run, run in background to be sure
         CoroutineScope(Dispatchers.Default).launch {

--- a/src/nl/hannahsten/texifyidea/util/Packages.kt
+++ b/src/nl/hannahsten/texifyidea/util/Packages.kt
@@ -28,10 +28,10 @@ object PackageUtils {
      */
     val CTAN_PACKAGE_NAMES: List<String> = javaClass
         .getResourceAsStream("/nl/hannahsten/texifyidea/packages/package.list")
-        .bufferedReader()
-        .readLine()
-        .split(";")
-        .toList()
+        ?.bufferedReader()
+        ?.readLine()
+        ?.split(";")
+        ?.toList() ?: emptyList()
 
     /**
      * Inserts a usepackage statement for the given package in a certain file.

--- a/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
@@ -1,20 +1,40 @@
 package nl.hannahsten.texifyidea.util.files
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
 import nl.hannahsten.texifyidea.settings.sdk.LatexSdkUtil
 import nl.hannahsten.texifyidea.settings.sdk.TectonicSdk
-import nl.hannahsten.texifyidea.util.PackageUtils.CTAN_PACKAGE_NAMES
 import nl.hannahsten.texifyidea.util.runCommand
-import java.io.IOException
+import java.io.File
 
 /**
  * Cache locations of LaTeX packages in memory, because especially on Windows they can be expensive to retrieve
- * (requires a run of kpsewhich).
- * Can also be used for tex/bib files and whatever can be used with kpsewhich.
+ * (requires a run of kpsewhich), which takes too long to do on every character typed by the user.
+ * Can also be used for tex/bib files and whatever can be used with kpsewhich (probably any file that is in its search path).
  */
 object LatexPackageLocationCache {
 
-    private val cache = mutableMapOf<String, String?>()
+    /** Map filename with extension to full path. */
+    private var cache: MutableMap<String, String?>? = null
+
+    /**
+     * Fill cache with all paths of all files in the LaTeX installation.
+     * Note: this can take a long time.
+     */
+    fun fillCacheWithKpsewhich(project: Project) {
+        // We will get all search paths that kpsewhich has, expand them and find all files
+        // Source: https://www.tug.org/texinfohtml/kpathsea.html#Casefolding-search
+        // We cannot just fill the cache on the fly, because then we will also run kpsewhich when the user is still typing a package name, so we will run it once for every letter typed and this is already too expensive.
+        // We cannot rely on ls-R databases because they are not always populated, and running mktexlsr may run into permission issues.
+        val executableName = LatexSdkUtil.getExecutableName("kpsewhich", project)
+        val searchPaths = runCommand(executableName, "-show-path=tex")
+        cache = runCommand(executableName, "-expand-path=\"$searchPaths\"")?.split(File.pathSeparator)
+            ?.flatMap { LocalFileSystem.getInstance().findFileByPath(it)?.children?.toList() ?: emptyList() }
+            ?.filter { !it.isDirectory }
+            ?.toSet()
+            ?.associate { it.name to it.path }
+            ?.toMutableMap() ?: mutableMapOf()
+    }
 
     /**
      * Get the full path to the location of the package with the given name, or null in case there was any problem.
@@ -25,37 +45,19 @@ object LatexPackageLocationCache {
      * @param name Package name with extension.
      */
     fun getPackageLocation(name: String, project: Project): String? {
-        // Because this method may be called on partial package names (e.g. when the user is still typing it), we first check if the package even exists before doing expensive sytem calls to find the location.
-        if (name !in CTAN_PACKAGE_NAMES) return null
-
-        if (cache.containsKey(name).not()) {
-            // Tectonic does not have kpsewhich, but works a little differently
-            val projectSdk = LatexSdkUtil.getLatexProjectSdk(project)
-            val path = if (projectSdk?.sdkType is TectonicSdk) {
-                (projectSdk.sdkType as TectonicSdk).getPackageLocation(name, projectSdk.homePath)
-            }
-            else {
-                runKpsewhich(name, project)
-            }
-            cache[name] = path
-            if (path?.isBlank() == true) return null
-            return path
+        if (cache == null) {
+            fillCacheWithKpsewhich(project)
         }
 
-        return cache[name]
-    }
-
-    private fun runKpsewhich(arg: String, project: Project): String? = try {
-        val command = if (LatexSdkUtil.isMiktexAvailable) {
-            // Don't install the package if not present
-            "miktex-kpsewhich --miktex-disable-installer $arg"
+        // Tectonic does not have kpsewhich, but works a little differently
+        val projectSdk = LatexSdkUtil.getLatexProjectSdk(project)
+        val path = if (projectSdk?.sdkType is TectonicSdk) {
+            (projectSdk.sdkType as TectonicSdk).getPackageLocation(name, projectSdk.homePath)
         }
         else {
-            "${LatexSdkUtil.getExecutableName("kpsewhich", project)} $arg"
+            cache?.get(name)
         }
-        command.runCommand()
-    }
-    catch (e: IOException) {
-        null
+        if (path?.isBlank() == true) return null
+        return path
     }
 }

--- a/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
@@ -3,6 +3,7 @@ package nl.hannahsten.texifyidea.util.files
 import com.intellij.openapi.project.Project
 import nl.hannahsten.texifyidea.settings.sdk.LatexSdkUtil
 import nl.hannahsten.texifyidea.settings.sdk.TectonicSdk
+import nl.hannahsten.texifyidea.util.PackageUtils.CTAN_PACKAGE_NAMES
 import nl.hannahsten.texifyidea.util.runCommand
 import java.io.IOException
 
@@ -24,6 +25,9 @@ object LatexPackageLocationCache {
      * @param name Package name with extension.
      */
     fun getPackageLocation(name: String, project: Project): String? {
+        // Because this method may be called on partial package names (e.g. when the user is still typing it), we first check if the package even exists before doing expensive sytem calls to find the location.
+        if (name !in CTAN_PACKAGE_NAMES) return null
+
         if (cache.containsKey(name).not()) {
             // Tectonic does not have kpsewhich, but works a little differently
             val projectSdk = LatexSdkUtil.getLatexProjectSdk(project)

--- a/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
@@ -28,7 +28,7 @@ object LatexPackageLocationCache {
         // We cannot rely on ls-R databases because they are not always populated, and running mktexlsr may run into permission issues.
         val executableName = LatexSdkUtil.getExecutableName("kpsewhich", project)
         val searchPaths = runCommand(executableName, "-show-path=tex")
-        cache = runCommand(executableName, "-expand-path=\"$searchPaths\"")?.split(File.pathSeparator)
+        cache = runCommand(executableName, "-expand-path", searchPaths ?: ".:")?.split(File.pathSeparator)
             ?.flatMap { LocalFileSystem.getInstance().findFileByPath(it)?.children?.toList() ?: emptyList() }
             ?.filter { !it.isDirectory }
             ?.toSet()


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2307

Instead of caching lazily and executing system commands for every (partial) package name, we now fill the cache up front.
We cannot fill lazily in background because we might need the result immediately (resolving reference by user).

