### PR TITLE
Apply each fix once instead of twice when using the fix all action

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexEncloseWithLeftRightInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexEncloseWithLeftRightInspection.kt
@@ -197,11 +197,11 @@ open class LatexEncloseWithLeftRightInspection : TexifyLineOptionsInspection("Cu
     private open class InsertLeftRightFix(val openElement: SmartPsiElementPointer<PsiElement>, val closeElement: SmartPsiElementPointer<PsiElement>, val open: String) : LocalQuickFix {
 
         /**
-         * Keep track of whether or not this fix has been applied.
+         * Keep track of whether this fix has been applied.
          *
          * There are two descriptors per fix (one for the open bracket and one for the close bracket). Whenever the user
          * applies one of those fixes by hand, all is good. But when the user uses the "fix all" action, both fixes will
-         * applied. Which, when not keeping track of a fix being applied or not, means that the fix will be applied twice.
+         * be applied. Which, when not keeping track of a fix being applied or not, means that the fix will be applied twice.
          */
         private var applied = false
 
@@ -213,8 +213,13 @@ open class LatexEncloseWithLeftRightInspection : TexifyLineOptionsInspection("Cu
                 val openReplacement = psiHelper.createFromText("\\left$open").firstChild
                 val closeReplacement = psiHelper.createFromText("\\right${brackets[open]}").firstChild
 
-                openElement.element?.parent?.replace(openReplacement) ?: return
-                closeElement.element?.parent?.replace(closeReplacement) ?: return
+                // Get the elements from the psi pointers before replacing elements, because the pointers are not accurate
+                // anymore after changing the psi structure.
+                val openElement = openElement.element ?: return
+                val closeElement = closeElement.element ?: return
+
+                openElement.replace(openReplacement)
+                closeElement.replace(closeReplacement)
 
                 applied = true
             }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexEncloseWithLeftRightInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexEncloseWithLeftRightInspectionTest.kt
@@ -57,4 +57,25 @@ class LatexEncloseWithLeftRightInspectionTest : TexifyInspectionTestBase(LatexEn
             """.trimIndent()
         )
     }
+
+    fun testAllQuickFixesWithPictureArgument() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            ${'$'} (\frac {\cos(\frac{1}{2} \pi)}{2})${'$'}
+            """.trimIndent()
+        )
+
+        val quickFixes = myFixture.getAllQuickFixes()
+        assertEquals(4, quickFixes.size)
+        writeCommand(myFixture.project) {
+            quickFixes.forEach { it.invoke(myFixture.project, myFixture.editor, myFixture.file) }
+        }
+
+        myFixture.checkResult(
+            """
+            ${'$'} \left(\frac {\cos\left(\frac{1}{2} \pi\right)}{2}\right)${'$'}
+            """.trimIndent()
+        )
+    }
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexEncloseWithLeftRightInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexEncloseWithLeftRightInspectionTest.kt
@@ -36,4 +36,25 @@ class LatexEncloseWithLeftRightInspectionTest : TexifyInspectionTestBase(LatexEn
             """.trimIndent()
         )
     }
+
+    fun testAllQuickFixes() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            ${'$'} ((\frac 1 2))${'$'}
+            """.trimIndent()
+        )
+
+        val quickFixes = myFixture.getAllQuickFixes()
+        assertEquals(4, quickFixes.size)
+        writeCommand(myFixture.project) {
+            quickFixes.forEach { it.invoke(myFixture.project, myFixture.editor, myFixture.file) }
+        }
+
+        myFixture.checkResult(
+            """
+            ${'$'} \left(\left(\frac 1 2\right)\right)${'$'}
+            """.trimIndent()
+        )
+    }
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix [TEX-149](https://texify-idea.myjetbrains.com/youtrack/issue/TEX-149)

#### Summary of additions and changes

* We use two descriptors for one `\left(...\right)` fix. This works fine as long as the user only applies one of those quick fixes, but not when they apply both (via the "apply all quick fixes" action). In that case the fix of each descriptor will be applied, which here means that each fix will be applied twice (and brackets and `\left`, `\right` commands will appear in strange numbers and places). Fixed this by keeping track of whether or not a fix has been applied already, and applying a fix by doing replacements in the psi tree instead of replacing text ranges.

#### How to test this pull request

```latex
\[
    u_k = (s \cos(\frac{2k\pi}{5}), s \sin(\frac{2k\pi}{5}), t)
\]
```
Use the fix all intention to change all `(...)` pairs to `\left(...\right)`.