### PR TITLE
Fix urls not showing in documentation for packages

### DIFF
--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexCommand.kt
@@ -45,9 +45,11 @@ interface LatexCommand : Described, Dependend {
         fun lookupInIndex(cmdWithoutSlash: String, project: Project): Set<LatexCommand> {
             // Don't try to access index when in dumb mode
             if (DumbService.isDumb(project)) return emptySet()
-
-            val cmds = mutableSetOf<LatexCommand>()
             val cmdWithSlash = "\\$cmdWithoutSlash"
+
+            // Make sure to look up the hardcoded commands, to have something in case nothing is found in the index
+            val cmds = lookup(cmdWithSlash)?.toMutableSet() ?: mutableSetOf()
+
             // Look up in index
             FileBasedIndex.getInstance().processValues(LatexExternalCommandIndex.id, cmdWithSlash, null, { file, value ->
                 val dependency = LatexPackage.create(file)


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2335

#### How to test this pull request

Ctrl+Q on \usepackage will now show the urls for the package documentation.

