### PR TITLE
Fix stackoverflow when defining color series

### DIFF
--- a/src/nl/hannahsten/texifyidea/gutter/LatexElementColorProvider.kt
+++ b/src/nl/hannahsten/texifyidea/gutter/LatexElementColorProvider.kt
@@ -113,6 +113,12 @@ object LatexElementColorProvider : ElementColorProvider {
                             colorDefinitionCommand.getRequiredArgumentValueByName("spec-list")
                         )
                     }
+                    LatexColorDefinitionCommand.DEFINECOLORSERIES.command -> {
+                        getColorFromDefineColor(
+                            colorDefinitionCommand.getOptionalArgumentValueByName("b-model") ?: colorDefinitionCommand.getRequiredArgumentValueByName("core model"),
+                            colorDefinitionCommand.getRequiredArgumentValueByName("b-spec")
+                        )
+                    }
                     else -> getColorFromColorParameter(file, colorName)
                 }
             }

--- a/src/nl/hannahsten/texifyidea/util/PsiCommands.kt
+++ b/src/nl/hannahsten/texifyidea/util/PsiCommands.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import nl.hannahsten.texifyidea.lang.commands.LatexMathCommand
 import nl.hannahsten.texifyidea.lang.commands.LatexRegularCommand
+import nl.hannahsten.texifyidea.lang.commands.OptionalArgument
 import nl.hannahsten.texifyidea.lang.commands.RequiredArgument
 import nl.hannahsten.texifyidea.psi.*
 import nl.hannahsten.texifyidea.reference.InputFileReference
@@ -120,6 +121,26 @@ fun LatexCommands.getRequiredArgumentValueByName(argument: String): String? {
         }
     return if (requiredArgIndices.isNullOrEmpty() || requiredArgIndices.all { it == -1 }) null
     else requiredParameters.getOrNull(min(requiredArgIndices.first(), requiredParameters.size - 1))
+}
+
+/**
+ * Get the value of the named optional [argument] given in `this` command.
+ *
+ * @return null when the optional argument is not given.
+ */
+fun LatexCommands.getOptionalArgumentValueByName(argument: String): String? {
+    // Find all pre-defined commands that define `this` command.
+    val optionalArgIndices = LatexRegularCommand[
+            name?.substring(1)
+                ?: return null
+    ]
+        // Find the index of their optional argument named [argument].
+        ?.map {
+            it.arguments.filterIsInstance<OptionalArgument>()
+                .indexOfFirst { arg -> arg.name == argument }
+        }
+    return if (optionalArgIndices.isNullOrEmpty() || optionalArgIndices.all { it == -1 }) null
+    else optionalParameterMap.keys.toList().getOrNull(min(optionalArgIndices.first(), optionalParameterMap.keys.toList().size - 1))?.text
 }
 
 /**


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2305

#### Summary of additions and changes

* Avoid an SO by getting the color from the correct argument of the `\definecolorseries` command.

Does not take into account any other fancy color series stuff (see [TEX-150](https://texify-idea.myjetbrains.com/youtrack/issue/TEX-150)).

#### How to test this pull request

```latex
\usepackage{xcolor}
\definecolorseries{gfcolors}{hsb}{grad}[hsb]{.650,1,1}{.987,-.234,0}
```
Doesn't crash and does show the first color in the gutter icon.