### PR TITLE
Also check MiKTeX version for unicode support

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspection.kt
@@ -69,10 +69,10 @@ class LatexUnicodeInspection : TexifyInspectionBase() {
         internal fun unicodeEnabled(file: PsiFile): Boolean {
             // TeX Live 2018 is UTF-8 by default and loads inputenc automatically
             val compilerCompat = file.project.selectedRunConfig()?.compiler
-            if (compilerCompat == LatexCompiler.LUALATEX
-                || compilerCompat == LatexCompiler.XELATEX
-                || TexliveSdk.version >= 2018
-                || MiktexWindowsSdk().getVersion(null) >= DefaultArtifactVersion("2.9.7350")
+            if (compilerCompat == LatexCompiler.LUALATEX ||
+                compilerCompat == LatexCompiler.XELATEX ||
+                TexliveSdk.version >= 2018 ||
+                MiktexWindowsSdk().getVersion(null) >= DefaultArtifactVersion("2.9.7350")
             ) {
                 return true
             }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspection.kt
@@ -22,12 +22,14 @@ import nl.hannahsten.texifyidea.lang.commands.LatexRegularCommand
 import nl.hannahsten.texifyidea.psi.LatexMathEnvironment
 import nl.hannahsten.texifyidea.psi.LatexNormalText
 import nl.hannahsten.texifyidea.run.compiler.LatexCompiler
+import nl.hannahsten.texifyidea.settings.sdk.MiktexWindowsSdk
 import nl.hannahsten.texifyidea.settings.sdk.TexliveSdk
 import nl.hannahsten.texifyidea.util.includedPackages
 import nl.hannahsten.texifyidea.util.insertUsepackage
 import nl.hannahsten.texifyidea.util.magic.PackageMagic
 import nl.hannahsten.texifyidea.util.magic.PatternMagic
 import nl.hannahsten.texifyidea.util.selectedRunConfig
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion
 import org.jetbrains.annotations.Nls
 import java.text.Normalizer
 import java.util.regex.Pattern
@@ -67,7 +69,11 @@ class LatexUnicodeInspection : TexifyInspectionBase() {
         internal fun unicodeEnabled(file: PsiFile): Boolean {
             // TeX Live 2018 is UTF-8 by default and loads inputenc automatically
             val compilerCompat = file.project.selectedRunConfig()?.compiler
-            if (compilerCompat == LatexCompiler.LUALATEX || compilerCompat == LatexCompiler.XELATEX || TexliveSdk.version >= 2018) {
+            if (compilerCompat == LatexCompiler.LUALATEX
+                || compilerCompat == LatexCompiler.XELATEX
+                || TexliveSdk.version >= 2018
+                || MiktexWindowsSdk().getVersion(null) >= DefaultArtifactVersion("2.9.7350")
+            ) {
                 return true
             }
 

--- a/src/nl/hannahsten/texifyidea/settings/sdk/MiktexWindowsSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/MiktexWindowsSdk.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import nl.hannahsten.texifyidea.run.latex.LatexDistributionType
 import nl.hannahsten.texifyidea.util.runCommand
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion
 import java.nio.file.InvalidPathException
 import java.nio.file.Paths
 
@@ -16,7 +17,7 @@ class MiktexWindowsSdk : LatexSdk("MiKTeX Windows SDK") {
     companion object {
 
         // Cache version
-        var version: String? = null
+        var version: DefaultArtifactVersion? = null
     }
 
     override fun getLatexDistributionType() = LatexDistributionType.MIKTEX
@@ -63,17 +64,18 @@ class MiktexWindowsSdk : LatexSdk("MiKTeX Windows SDK") {
         return LatexSdkUtil.isPdflatexPresent(directory, errorMessage, name, suppressNotification = suggestHomePaths().plus(suggestHomePath()))
     }
 
-    override fun getVersionString(sdk: Sdk): String? {
+    override fun getVersionString(sdk: Sdk): String {
         return getVersionString(sdk.homePath)
     }
 
-    override fun getVersionString(sdkHome: String?): String? {
-        version?.let { return version }
+    override fun getVersionString(sdkHome: String?) = "MiKTeX " + getVersion(sdkHome).toString()
 
+    fun getVersion(sdkHome: String?): DefaultArtifactVersion {
+        version?.let { return it }
         val executable = sdkHome?.let { getExecutableName("pdflatex", it) } ?: "pdflatex"
         val output = "$executable --version".runCommand() ?: ""
-        version = "\\(MiKTeX (\\d+.\\d+)\\)".toRegex().find(output)?.value
-
-        return version
+        val versionString = "\\(MiKTeX (\\d+.\\d+)\\)".toRegex().find(output)?.groups?.get(1)?.value ?: ""
+        version = DefaultArtifactVersion(versionString)
+        return version!!
     }
 }


### PR DESCRIPTION
I don't know exactly when unicode support was enabled by default, but it was supposedly in 2018 so I've guessed a MiKTeX version.