### PR TITLE
Normalize string when generating label names

### DIFF
--- a/src/nl/hannahsten/texifyidea/util/Strings.kt
+++ b/src/nl/hannahsten/texifyidea/util/Strings.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.util.TextRange
 import nl.hannahsten.texifyidea.util.magic.PatternMagic
 import org.intellij.lang.annotations.Language
 import java.io.File
+import java.text.Normalizer
 import java.util.*
 import kotlin.math.max
 import kotlin.math.min
@@ -174,9 +175,11 @@ fun String.formatAsFilePath(): String {
  * Formats the string as a valid LaTeX label name.
  */
 fun String.formatAsLabel(): String {
-    return replace(" ", "-")
-        .removeAll("%", "~", "#", "\\", ",")
-        .lowercase(Locale.getDefault())
+    return this.let { Normalizer.normalize(it, Normalizer.Form.NFKD) }
+            .replace(" ", "-")
+            .removeAll("%", "~", "#", "\\", ",")
+            .replace("[^\\x00-\\x7F]".toRegex(), "")
+            .lowercase(Locale.getDefault())
 }
 
 /**

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMissingLabelInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMissingLabelInspectionTest.kt
@@ -98,6 +98,16 @@ class LatexMissingLabelInspectionTest : TexifyInspectionTestBase(LatexMissingLab
         """.trimIndent()
     )
 
+    fun `test label name generation`() = testQuickFix(
+        before = """
+        \section{~Ação –função}
+        """.trimIndent(),
+        after = """
+        \section{~Ação –função}\label{sec:acao-funcao}
+        """.trimIndent(),
+        numberOfFixes = 2
+    )
+
     fun `test quick fix in figure`() = testQuickFix(
         before = """
         \begin{document}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2359

#### Summary of additions and changes

* Normalize label string

#### How to test this pull request

```latex
\section{~Ação –função}
```
