### PR TITLE
Disable inline math completion in verbatim

### DIFF
--- a/resources/META-INF/extensions/editor/editor.xml
+++ b/resources/META-INF/extensions/editor/editor.xml
@@ -21,7 +21,7 @@
         <enterHandlerDelegate implementation="nl.hannahsten.texifyidea.editor.typedhandlers.LatexEnterInCommentHandler"/>
         <enterHandlerDelegate implementation="nl.hannahsten.texifyidea.completion.InsertBibtexTag"/>
         <codeInsight.parameterInfo language="Latex" implementationClass="nl.hannahsten.texifyidea.documentation.LatexParameterInfoHandler"/>
-        <typedHandler implementation="nl.hannahsten.texifyidea.highlighting.LatexTypedHandler"/>
+        <typedHandler implementation="nl.hannahsten.texifyidea.editor.typedhandlers.LatexTypedHandler"/>
         <lookup.charFilter implementation="nl.hannahsten.texifyidea.completion.LatexCharFilter" id="latex"/>
         <enterHandlerDelegate implementation="nl.hannahsten.texifyidea.editor.typedhandlers.LatexEnterInEnumerationHandler"/>
         <typedHandler implementation="nl.hannahsten.texifyidea.editor.ShiftTracker"/>

--- a/src/nl/hannahsten/texifyidea/editor/typedhandlers/InlineMathBackspaceHandler.kt
+++ b/src/nl/hannahsten/texifyidea/editor/typedhandlers/InlineMathBackspaceHandler.kt
@@ -1,24 +1,29 @@
 package nl.hannahsten.texifyidea.editor.typedhandlers
 
 import com.intellij.codeInsight.editorActions.BackspaceHandlerDelegate
+import com.intellij.grazie.utils.orFalse
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiUtilBase.getElementAtCaret
+import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
 import nl.hannahsten.texifyidea.util.caretOffset
 import nl.hannahsten.texifyidea.util.files.document
 import nl.hannahsten.texifyidea.util.files.isLatexFile
 import nl.hannahsten.texifyidea.util.get
+import nl.hannahsten.texifyidea.util.inVerbatim
 
 /**
  * In the situation $<caret>$, pressing backspace should delete both $.
+ * See [LatexTypedHandler] for how the second $ was inserted.
  *
  * @author Thomas
  */
 class InlineMathBackspaceHandler : BackspaceHandlerDelegate() {
 
     override fun beforeCharDeleted(c: Char, file: PsiFile, editor: Editor) {
-        if (c == '$' && file.isLatexFile()) {
+        if (c == '$' && file.isLatexFile() && !getElementAtCaret(editor)?.inVerbatim().orFalse()) {
             val offset = editor.caretOffset()
-            if (file.document()?.get(offset) == "$") {
+            if (file.document()?.get(offset) == LatexGenericRegularCommand.DOLLAR_SIGN.command) {
                 file.document()?.deleteString(offset, offset + 1)
             }
         }

--- a/src/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandler.kt
+++ b/src/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandler.kt
@@ -1,7 +1,8 @@
-package nl.hannahsten.texifyidea.highlighting
+package nl.hannahsten.texifyidea.editor.typedhandlers
 
 import com.intellij.codeInsight.CodeInsightSettings
 import com.intellij.codeInsight.editorActions.TypedHandlerDelegate
+import com.intellij.grazie.utils.orFalse
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.fileTypes.FileType
@@ -10,11 +11,14 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFile
 import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.PsiUtilBase.getElementAtCaret
 import nl.hannahsten.texifyidea.file.LatexFile
+import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
 import nl.hannahsten.texifyidea.psi.LatexInlineMath
 import nl.hannahsten.texifyidea.psi.LatexTypes
 import nl.hannahsten.texifyidea.settings.TexifySettings.Companion.getInstance
 import nl.hannahsten.texifyidea.util.files.isLatexFile
+import nl.hannahsten.texifyidea.util.inVerbatim
 
 /**
  * @author Sten Wessel
@@ -61,8 +65,9 @@ class LatexTypedHandler : TypedHandlerDelegate() {
     }
 
     override fun charTyped(c: Char, project: Project, editor: Editor, file: PsiFile): Result {
-        if (file is LatexFile) {
-            if (c == '$' && getInstance().automaticSecondInlineMathSymbol) {
+        if (file is LatexFile && !getElementAtCaret(editor)?.inVerbatim().orFalse()) {
+            val dollarSign = LatexGenericRegularCommand.DOLLAR_SIGN.command.toCharArray().first()
+            if (c == dollarSign && getInstance().automaticSecondInlineMathSymbol) {
                 val tokenType = getTypedTokenType(editor)
                 if (tokenType !== LatexTypes.COMMAND_TOKEN && tokenType !== LatexTypes.COMMENT_TOKEN && tokenType !== LatexTypes.INLINE_MATH_END) {
                     editor.document.insertString(

--- a/src/nl/hannahsten/texifyidea/highlighting/LatexPairedBraceMatcher.kt
+++ b/src/nl/hannahsten/texifyidea/highlighting/LatexPairedBraceMatcher.kt
@@ -15,7 +15,7 @@ class LatexPairedBraceMatcher : PairedBraceMatcher {
 
         private val bracePairs = arrayOf(
             BracePair(LatexTypes.DISPLAY_MATH_START, LatexTypes.DISPLAY_MATH_END, true),
-            BracePair(LatexTypes.INLINE_MATH_START, LatexTypes.INLINE_MATH_END, true),
+//            BracePair(LatexTypes.INLINE_MATH_START, LatexTypes.INLINE_MATH_END, true),
             BracePair(LatexTypes.BEGIN_TOKEN, LatexTypes.END_TOKEN, false),
             BracePair(LatexTypes.OPEN_PAREN, LatexTypes.CLOSE_PAREN, false),
             BracePair(LatexTypes.OPEN_BRACE, LatexTypes.CLOSE_BRACE, false),

--- a/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandlerTest.kt
+++ b/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandlerTest.kt
@@ -1,0 +1,49 @@
+package nl.hannahsten.texifyidea.editor.typedhandlers
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import nl.hannahsten.texifyidea.file.LatexFileType
+
+class LatexTypedHandlerTest : BasePlatformTestCase() {
+
+    fun testInlineMath() {
+        myFixture.configureByText(LatexFileType, "")
+        myFixture.type("$")
+        myFixture.checkResult("$$")
+    }
+
+    fun testInlineMath2() {
+        myFixture.configureByText(LatexFileType, "$\\xi<caret>$")
+        myFixture.type("$")
+        myFixture.checkResult("$\\xi$<caret>")
+    }
+
+    fun testVerbatim() {
+        myFixture.configureByText(LatexFileType, """
+            \begin{verbatim}
+                <caret>
+            \end{verbatim}
+        """.trimIndent())
+        myFixture.type("$")
+        myFixture.checkResult("""
+            \begin{verbatim}
+                $<caret>
+            \end{verbatim}
+        """.trimIndent())
+    }
+
+    fun testDisplayMath() {
+        myFixture.configureByText(LatexFileType, "")
+        myFixture.type("\\[")
+        myFixture.checkResult("\\[\\]")
+    }
+
+    fun testDisplayMath2() {
+        myFixture.configureByText(LatexFileType, "\\[<caret>\\]")
+        myFixture.type("\n")
+        myFixture.checkResult("""
+            \[
+                <caret>
+            \]
+        """.trimIndent())
+    }
+}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2322

#### Summary of additions and changes

* In verbatim, typing `$` will not insert a second `$` and also will not delete it - similar for `\[` and `\(`.
