### PR TITLE
Add command line arguments for makeindex run config

### DIFF
--- a/src/nl/hannahsten/texifyidea/run/makeindex/MakeindexCommandLineState.kt
+++ b/src/nl/hannahsten/texifyidea/run/makeindex/MakeindexCommandLineState.kt
@@ -8,6 +8,7 @@ import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.util.execution.ParametersListUtil
 import nl.hannahsten.texifyidea.run.compiler.MakeindexProgram
 import nl.hannahsten.texifyidea.util.appendExtension
 
@@ -19,7 +20,8 @@ class MakeindexCommandLineState(
     private val mainFile: VirtualFile?,
     private val workingDirectory: VirtualFile?,
     private val makeindexOptions: Map<String, String>,
-    private val indexProgram: MakeindexProgram
+    private val indexProgram: MakeindexProgram,
+    private val commandLineArguments: String?,
 ) : CommandLineState(environment) {
 
     @Throws(ExecutionException::class)
@@ -33,7 +35,10 @@ class MakeindexCommandLineState(
         // texindy requires the file extension
         val indexFilename = if (indexProgram != MakeindexProgram.XINDY) indexBasename else indexBasename.appendExtension("idx")
 
-        val command = listOf(indexProgram.executableName, indexFilename)
+        val command = ParametersListUtil.parse(commandLineArguments ?: "").apply {
+            add(0, indexProgram.executableName)
+            add(indexFilename)
+        }
         val commandLine = GeneralCommandLine(command).withWorkDirectory(workingDirectory?.path)
 
         val handler: ProcessHandler = KillableProcessHandler(commandLine)

--- a/src/nl/hannahsten/texifyidea/run/makeindex/MakeindexRunConfiguration.kt
+++ b/src/nl/hannahsten/texifyidea/run/makeindex/MakeindexRunConfiguration.kt
@@ -26,17 +26,19 @@ class MakeindexRunConfiguration(
         private const val PARENT_ELEMENT = "texify-makeindex"
         private const val PROGRAM = "program"
         private const val MAIN_FILE = "main-file"
+        private const val COMMAND_LINE_ARGS = "command-line-args"
         private const val WORK_DIR = "work-dir"
     }
 
     // The following variables are saved in the MakeindexSettingsEditor
     var makeindexProgram: MakeindexProgram = MakeindexProgram.MAKEINDEX
     var mainFile: VirtualFile? = null
+    var commandLineArguments: String? = null
     var workingDirectory: VirtualFile? = null
 
     override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState {
         val makeindexOptions = getMakeindexOptions(mainFile, project)
-        return MakeindexCommandLineState(environment, mainFile, workingDirectory, makeindexOptions, makeindexProgram)
+        return MakeindexCommandLineState(environment, mainFile, workingDirectory, makeindexOptions, makeindexProgram, commandLineArguments)
     }
 
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> = MakeindexSettingsEditor(project)
@@ -68,6 +70,19 @@ class MakeindexRunConfiguration(
             null
         }
 
+        val commandLineArgsText = try {
+            parent.getChildText(COMMAND_LINE_ARGS)
+        }
+        catch (e: NullPointerException) {
+            null
+        }
+        commandLineArguments = if (!commandLineArgsText.isNullOrBlank()) {
+            commandLineArgsText
+        }
+        else {
+            null
+        }
+
         val workDirPath = try {
             parent.getChildText(WORK_DIR)
         }
@@ -90,6 +105,7 @@ class MakeindexRunConfiguration(
 
         parent.addContent(Element(PROGRAM).apply { text = makeindexProgram.name })
         parent.addContent(Element(MAIN_FILE).apply { text = mainFile?.path ?: "" })
+        parent.addContent(Element(COMMAND_LINE_ARGS).apply { text = commandLineArguments ?: "" })
         parent.addContent(Element(WORK_DIR).apply { text = workingDirectory?.path ?: "" })
     }
 

--- a/src/nl/hannahsten/texifyidea/run/makeindex/MakeindexSettingsEditor.kt
+++ b/src/nl/hannahsten/texifyidea/run/makeindex/MakeindexSettingsEditor.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.ui.*
 import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.ui.RawCommandLineEditor
 import nl.hannahsten.texifyidea.run.compiler.MakeindexProgram
 import javax.swing.JComponent
 import javax.swing.JPanel
@@ -19,6 +20,7 @@ class MakeindexSettingsEditor(private val project: Project) : SettingsEditor<Mak
     private lateinit var panel: JPanel
     private lateinit var makeindexProgram: LabeledComponent<ComboBox<MakeindexProgram>>
     private lateinit var mainFile: LabeledComponent<TextFieldWithBrowseButton>
+    private lateinit var commandLineArguments: LabeledComponent<RawCommandLineEditor>
     private lateinit var workingDirectory: LabeledComponent<TextFieldWithBrowseButton>
 
     override fun createEditor(): JComponent {
@@ -30,6 +32,7 @@ class MakeindexSettingsEditor(private val project: Project) : SettingsEditor<Mak
     override fun resetEditorFrom(runConfig: MakeindexRunConfiguration) {
         makeindexProgram.component.selectedItem = runConfig.makeindexProgram
         mainFile.component.text = runConfig.mainFile?.path ?: ""
+        commandLineArguments.component.text = runConfig.commandLineArguments
         workingDirectory.component.text = runConfig.workingDirectory?.path ?: ""
     }
 
@@ -37,6 +40,7 @@ class MakeindexSettingsEditor(private val project: Project) : SettingsEditor<Mak
     override fun applyEditorTo(runConfig: MakeindexRunConfiguration) {
         runConfig.makeindexProgram = makeindexProgram.component.selectedItem as MakeindexProgram
         runConfig.mainFile = LocalFileSystem.getInstance().findFileByPath(mainFile.component.text)
+        runConfig.commandLineArguments = commandLineArguments.component.text
         runConfig.workingDirectory = LocalFileSystem.getInstance().findFileByPath(workingDirectory.component.text)
     }
 
@@ -60,6 +64,9 @@ class MakeindexSettingsEditor(private val project: Project) : SettingsEditor<Mak
             }
             mainFile = LabeledComponent.create(mainFileField, "Main file which uses an index")
             add(mainFile)
+
+            commandLineArguments = LabeledComponent.create(RawCommandLineEditor(), "Custom arguments")
+            add(commandLineArguments)
 
             // Working directory
             val workDirField = TextFieldWithBrowseButton().apply {


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2342

#### Summary of additions and changes

* Quick fix to have command line arguments in the stable version of the run configs