### PR TITLE
Use live template for labels in itemize enter handler

### DIFF
--- a/src/nl/hannahsten/texifyidea/editor/typedhandlers/LatexEnterInEnumerationHandler.kt
+++ b/src/nl/hannahsten/texifyidea/editor/typedhandlers/LatexEnterInEnumerationHandler.kt
@@ -47,7 +47,7 @@ class LatexEnterInEnumerationHandler : EnterHandlerDelegate {
         if (hasValidContext(element)) {
             val previousMarker = getPreviousMarker(element!!)
             if (previousMarker == null) {
-                editor.insertAtCaretAndMove( "\\item ")
+                editor.insertAtCaretAndMove("\\item ")
             }
             else {
                 // Use live template, so that the user can choose to replace the label and press enter to jump out of the optional argument
@@ -58,7 +58,7 @@ class LatexEnterInEnumerationHandler : EnterHandlerDelegate {
         }
         else {
             if (ControlTracker.isControlPressed) {
-                editor.insertAtCaretAndMove( "")
+                editor.insertAtCaretAndMove("")
             }
         }
 

--- a/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexEnterInEnumerationHandlerTest.kt
+++ b/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexEnterInEnumerationHandlerTest.kt
@@ -40,7 +40,7 @@ class LatexEnterInEnumerationHandlerTest : BasePlatformTestCase() {
                     \item[foobar:]
                     \item[barfoo:]
                 \end{labeling} 
-                \item[whoo] <caret>
+                \item[whoo] 
             \end{enumerate}
         """.trimIndent())
     }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2231

#### Summary of additions and changes

* Use live template to place caret in optional param of next \item, with as suggested text the previous item label.

#### How to test this pull request

```latex
\documentclass{article}
\begin{document}
\begin{description}
  \item[Label A] A description of Label A
\end{description}
\end{document}
```