### PR TITLE
Fix off-by-one error in Grazie text extractor

### DIFF
--- a/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
@@ -45,8 +45,17 @@ class GrazieInspectionTest : BasePlatformTestCase() {
 
     fun testInlineMath() {
         myFixture.configureByText(
-            LatexFileType, """Does Grazie detect ${'$'}m$ as a sentence?
-"""
+            LatexFileType, """Does Grazie detect ${'$'}m$ as a sentence?"""
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun testSentenceStart() {
+        myFixture.configureByText(
+            LatexFileType, """
+               \subsubsection{Something}
+                The hardware requirements 
+            """.trimIndent()
         )
         myFixture.checkHighlighting()
     }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2314

#### Summary of additions and changes

* I don't know if I broke something else, but tests pass. At least the conversion from inclusive end to exclusive end is making slightly more sense now.

#### How to test this pull request

```latex
% Preamble
\documentclass[11pt]{article}

% Document
\begin{document}
    \subsubsection{Something}
    The hardware requirements


\end{document}
```
