### PR TITLE
Add file completion for bibsource field

### DIFF
--- a/src/nl/hannahsten/texifyidea/completion/BibtexCompletionContributor.kt
+++ b/src/nl/hannahsten/texifyidea/completion/BibtexCompletionContributor.kt
@@ -4,11 +4,9 @@ import com.intellij.codeInsight.completion.CompletionContributor
 import com.intellij.codeInsight.completion.CompletionType
 import com.intellij.patterns.PlatformPatterns
 import nl.hannahsten.texifyidea.BibtexLanguage
+import nl.hannahsten.texifyidea.completion.pathcompletion.LatexFileProvider
 import nl.hannahsten.texifyidea.psi.*
-import nl.hannahsten.texifyidea.util.firstChildOfType
-import nl.hannahsten.texifyidea.util.hasParent
-import nl.hannahsten.texifyidea.util.parentOfType
-import nl.hannahsten.texifyidea.util.withPattern
+import nl.hannahsten.texifyidea.util.*
 import java.util.*
 
 /**
@@ -20,6 +18,7 @@ open class BibtexCompletionContributor : CompletionContributor() {
         registerTypeCompletion()
         registerKeyCompletion()
         registerStringCompletion()
+        registerFileCompletion()
     }
 
     /**
@@ -62,5 +61,18 @@ open class BibtexCompletionContributor : CompletionContributor() {
             .inside(BibtexContent::class.java)
             .withLanguage(BibtexLanguage),
         BibtexStringProvider
+    )
+
+    private fun registerFileCompletion() = extend(
+        CompletionType.BASIC,
+        PlatformPatterns.psiElement()
+            .inside(BibtexContent::class.java)
+            .withPattern("File completion pattern") { psiElement, _ ->
+                val key = psiElement.firstParentOfType(BibtexTag::class)?.firstChildOfType(BibtexKey::class) ?: return@withPattern false
+                // Currently, the bibsource field is used for file sources, but this is apparently not 'official'
+                key.text == "bibsource"
+            }
+            .withLanguage(BibtexLanguage),
+        LatexFileProvider()
     )
 }

--- a/src/nl/hannahsten/texifyidea/completion/BibtexCompletionContributor.kt
+++ b/src/nl/hannahsten/texifyidea/completion/BibtexCompletionContributor.kt
@@ -7,6 +7,7 @@ import nl.hannahsten.texifyidea.BibtexLanguage
 import nl.hannahsten.texifyidea.completion.pathcompletion.LatexFileProvider
 import nl.hannahsten.texifyidea.psi.*
 import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.magic.FileMagic
 import java.util.*
 
 /**
@@ -70,7 +71,7 @@ open class BibtexCompletionContributor : CompletionContributor() {
             .withPattern("File completion pattern") { psiElement, _ ->
                 val key = psiElement.firstParentOfType(BibtexTag::class)?.firstChildOfType(BibtexKey::class) ?: return@withPattern false
                 // Currently, the bibsource field is used for file sources, but this is apparently not 'official'
-                key.text == "bibsource"
+                key.text in FileMagic.bibtexFileKeys
             }
             .withLanguage(BibtexLanguage),
         LatexFileProvider()


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2353 

#### Summary of additions and changes

* Add file completion for the bibsource field
afaik this field is not in any 'official' entry type, but it's a convention by dblp which I agree to adopt. 

#### How to test this pull request

```latex
@inproceedings{DBLP:conf/mdm/ValdesGO16,
   author    = {Fabio Vald{\'{e}}s and
               Ralf Hartmut G{\"{u}}ting and
               Federico Ossi},
   title     = {Efficient Trajectory Analysis for Several Time-Dependent Attributes:
               {A} Case Study for Roe Deer},
   booktitle = {{IEEE} 17th International Conference on Mobile Data Management, {MDM}
   2016, Porto, Portugal, June 13-16, 2016},
   bibsource = {main.pdf}
}
```

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: