### PR TITLE
Support \def to \newcommand quickfix with braced definition

### DIFF
--- a/src/nl/hannahsten/texifyidea/structure/latex/BibitemPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/BibitemPresentation.kt
@@ -19,11 +19,7 @@ class BibitemPresentation(labelCommand: LatexCommands) : ItemPresentation {
         }
 
         // Get label name.
-        val required = labelCommand.requiredParameters
-        if (required.isEmpty()) {
-            throw IllegalArgumentException("\\bibitem has no label name")
-        }
-        this.bibitemName = required[0]
+        this.bibitemName = labelCommand.requiredParameters.firstOrNull() ?: ""
 
         // Location string.
         val manager = FileDocumentManager.getInstance()

--- a/src/nl/hannahsten/texifyidea/util/Psi.kt
+++ b/src/nl/hannahsten/texifyidea/util/Psi.kt
@@ -25,7 +25,7 @@ fun PsiElement.endOffset(): Int = textOffset + textLength
  * @see [PsiTreeUtil.getChildrenOfType]
  */
 fun <T : PsiElement> PsiElement.childrenOfType(clazz: KClass<T>): Collection<T> {
-    if (project.isDisposed) return emptyList()
+    if (project.isDisposed || !this.isValid) return emptyList()
     return PsiTreeUtil.findChildrenOfType(this, clazz.java)
 }
 

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codematurity/LatexDiscouragedUseOfDefInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codematurity/LatexDiscouragedUseOfDefInspectionTest.kt
@@ -15,6 +15,19 @@ class LatexDiscouragedUseOfDefInspectionTest : TexifyInspectionTestBase(LatexDis
             quickFixName = "Convert to \\newcommand"
     )
 
+    fun `test quick fix def to newcommand 2`() = testNamedQuickFix(
+            before = """
+                \def \indentpar {\hangindent=1cm \hangafter=0}
+                \setlength{\parskip}{0.5em}
+            """.trimIndent(),
+            after = """
+                \newcommand{\indentpar}{\hangindent=1cm \hangafter=0}
+                \setlength{\parskip}{0.5em}
+            """.trimIndent(),
+            numberOfFixes = 2,
+            quickFixName = "Convert to \\newcommand"
+    )
+
     fun `test quick fix def to renewcommand`() = testNamedQuickFix(
             before = """\def\a1""",
             after = """\renewcommand{\a}{1}""",


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2370
Fix #2376 \bibitem without parameters in structure view
Fix #2380 invalid psi element access

#### Summary of additions and changes

* Add support for quickfixing `\def \command {definition with braces}`
There are of course many pathological examples in which this is going to fail because we're not parsing this correctly, so this PR just fixes this one issue.

#### How to test this pull request

```latex
\def\a1
\def \indentpar {\hangindent=1cm \hangafter=0}
\setlength{\parskip}{0.5em}
```
