### PR TITLE
Fixed some crashes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 group = "nl.hannahsten"
-version = "0.7.18"
+version = "0.7.19-alpha.1"
 
 repositories {
     mavenCentral()
@@ -150,7 +150,7 @@ intellij {
     pluginName.set("TeXiFy-IDEA")
 
     // indices plugin doesn't work in tests
-    plugins.set(listOf("tanvd.grazi", "java")) // , "com.firsttimeinforever.intellij.pdf.viewer.intellij-pdf-viewer:0.12.0-alpha.4@alpha")) // , "com.jetbrains.hackathon.indices.viewer:1.13")
+    plugins.set(listOf("tanvd.grazi", "java", "com.firsttimeinforever.intellij.pdf.viewer.intellij-pdf-viewer:0.14.0")) // , "com.jetbrains.hackathon.indices.viewer:1.13")
 
     // Use the since build number from plugin.xml
     updateSinceUntilBuild.set(false)

--- a/src/nl/hannahsten/texifyidea/LatexParserDefinition.kt
+++ b/src/nl/hannahsten/texifyidea/LatexParserDefinition.kt
@@ -52,7 +52,7 @@ class LatexParserDefinition : ParserDefinition {
         val FILE: IStubFileElementType<*> = object : IStubFileElementType<LatexFileStub>(
             Language.findInstance(LatexLanguage::class.java)
         ) {
-            override fun getStubVersion(): Int = 37
+            override fun getStubVersion(): Int = 38
         }
     }
 

--- a/src/nl/hannahsten/texifyidea/index/stub/LatexCommandsStubElementType.kt
+++ b/src/nl/hannahsten/texifyidea/index/stub/LatexCommandsStubElementType.kt
@@ -99,7 +99,7 @@ class LatexCommandsStubElementType(debugName: String) :
             val label = latexCommandsStub.optionalParams["label"]!!
             indexSinkOccurrence(indexSink, LatexParameterLabeledCommandsIndex, label)
         }
-        if (token in CommandMagic.glossaryEntry) {
+        if (token in CommandMagic.glossaryEntry && latexCommandsStub.requiredParams.isNotEmpty()) {
             indexSinkOccurrence(indexSink, LatexGlossaryEntryIndex, latexCommandsStub.requiredParams[0])
         }
     }

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
@@ -576,6 +576,7 @@ class LatexRunConfiguration constructor(
      */
     fun getMainFileContentRoot(): VirtualFile? {
         if (mainFile == null) return null
+        if (!project.isInitialized) return null
         return runReadAction {
             return@runReadAction ProjectRootManager.getInstance(project).fileIndex.getContentRootForFile(mainFile!!)
         }


### PR DESCRIPTION
Fix #2397 index access of uninitialized project 
Fix #2407, avoid IOOB while indexing glossary entries