### PR TITLE
Improve performance of inspections and formatting

### DIFF
--- a/src/nl/hannahsten/texifyidea/formatting/LatexSpacingRules.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexSpacingRules.kt
@@ -8,6 +8,7 @@ import nl.hannahsten.texifyidea.formatting.spacingrules.rightTableSpaceAlign
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexTypes.*
 import nl.hannahsten.texifyidea.settings.codestyle.LatexCodeStyleSettings
+import nl.hannahsten.texifyidea.util.firstChildOfType
 import nl.hannahsten.texifyidea.util.inDirectEnvironment
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.magic.EnvironmentMagic
@@ -56,7 +57,7 @@ fun createSpacingBuilder(settings: CodeStyleSettings): TexSpacingBuilder {
         custom {
             customRule { parent, _, right ->
                 // Lowercase to also catch \STATE from algorithmic
-                if (right.node?.psi?.text?.lowercase(Locale.getDefault()) in setOf(
+                if (right.node?.psi?.firstChildOfType(LatexCommands::class)?.name?.lowercase(Locale.getDefault()) in setOf(
                         "\\state",
                         "\\statex"
                     ) && parent.node?.psi?.inDirectEnvironment(EnvironmentMagic.algorithmEnvironments) == true) {
@@ -92,8 +93,13 @@ fun createSpacingBuilder(settings: CodeStyleSettings): TexSpacingBuilder {
             // Make sure the number of new lines before a sectioning command is as much as the user specified in the settings.
             // BUG OR FEATURE? Does not work for a command that immediately follows \begin{document}.
             customRule { _, _, right ->
+                // Because getting the full text from a node is relatively expensive, we first use a condition which is necessary (but not sufficient) as an early exit.
+                val commandName = right.node?.psi?.firstChildOfType(LatexCommands::class)?.name
+                if (commandName !in LatexCodeStyleSettings.blankLinesOptions.values) return@customRule null
+
+                val rightText = right.node?.text
                 LatexCodeStyleSettings.blankLinesOptions.forEach {
-                    if (right.node?.text?.matches(Regex("\\" + "${it.value}\\{.*\\}")) == true &&
+                    if (rightText?.matches(Regex("\\\\${it.value.trimStart('\\')}\\{.*}")) == true &&
                         !CommandMagic.definitions.contains(right.node?.psi?.parentOfType(LatexCommands::class)?.name)) {
                         return@customRule createSpacing(
                             minSpaces = 0,

--- a/src/nl/hannahsten/texifyidea/inspections/grazie/LatexTextExtractor.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/grazie/LatexTextExtractor.kt
@@ -38,6 +38,9 @@ class LatexTextExtractor : TextExtractor() {
      * Note: IntRange has an inclusive end.
      */
     private fun getStealthyRanges(root: PsiElement): List<IntRange> {
+        // Getting text takes time, so we only do it once
+        val rootText = root.text
+
         // Only keep normaltext, assuming other things (like inline math) need to be ignored.
         val ranges = root.childrenOfType(LatexNormalText::class)
             .asSequence()
@@ -47,7 +50,7 @@ class LatexTextExtractor : TextExtractor() {
             .flatMap {
                 // I have no idea what happens here. I don't think Grazie uses the same indices and text as root.text, because it doesn't behave consistently when I move around indices, so it may appear we are ignoring too much or too little while in practice the inspections may work.
                 var start = it.textRange.startOffset - root.startOffset
-                if (start > 0 && root.text[start - 1] != '\n' && root.text[start - 1] != ' ') {
+                if (start > 0 && rootText[start - 1] != '\n' && rootText[start - 1] != ' ') {
                     // Support sentence ends with inline math
                     start -= 1
                 }
@@ -65,7 +68,7 @@ class LatexTextExtractor : TextExtractor() {
             // To get the ranges that we need to ignore
             // -1 because IntRange has inclusive end, but we want to exclude all letters _excluding_ the letter where the normal text started
             .chunked(2) { IntRange(it[0], it[1] - 1) }
-            .filter { it.first < it.last && it.first >= 0 && it.last < root.text.length }
+            .filter { it.first < it.last && it.first >= 0 && it.last < rootText.length }
             .toMutableSet()
 
         // There is still a bit of a problem, because when stitching together the NormalTexts, whitespace is lost

--- a/src/nl/hannahsten/texifyidea/lang/alias/AliasManager.kt
+++ b/src/nl/hannahsten/texifyidea/lang/alias/AliasManager.kt
@@ -135,11 +135,11 @@ abstract class AliasManager {
 
         // If the command name itself is not directly in the given set, check if it is perhaps an alias of a command in the set
         // Uses projectScope now, may be improved to filesetscope
-        val indexedCommandDefinitions = LatexDefinitionIndex.getItems(project)
+        val indexedCommandDefinitions = LatexDefinitionIndex.getItems(project).toSet()
 
         // Check if something has changed (the number of indexed command might be the same while the content is different), and if so, update the aliases.
         // Also do this the first time something is registered, because then we have to update aliases as well
-        val hasNotChanged = this.indexedCommandDefinitions.containsAll(indexedCommandDefinitions) && indexedCommandDefinitions.containsAll(this.indexedCommandDefinitions)
+        val hasNotChanged = this.indexedCommandDefinitions == indexedCommandDefinitions
         if (!hasNotChanged || wasRegistered) {
             // Update everything, since it is difficult to know beforehand what aliases could be added or not
             // Alternatively we could save a numberOfIndexedCommandDefinitions per alias set, and only update the

--- a/test/nl/hannahsten/texifyidea/formatting/LatexFormattingTest.kt
+++ b/test/nl/hannahsten/texifyidea/formatting/LatexFormattingTest.kt
@@ -237,6 +237,18 @@ fun Int?.ifPositiveAddTwo(): Int =
         """.trimIndent()
     }
 
+    fun `test newlines before sectioning commands`() {
+        """
+            Text.
+            \section{New section}
+        """.trimIndent() `should be reformatted to` """
+            Text.
+            
+            
+            \section{New section}
+        """.trimIndent()
+    }
+
     fun `test indentation of environments`() {
         val text = """
             \begin{document}


### PR DESCRIPTION
This PR was tested on a 8000-line LaTeX file, the inspections were around 50x faster.

The second commit improves formatter performance (pressing enter)