### PR TITLE
Improve parser performance

### DIFF
--- a/gen/nl/hannahsten/texifyidea/parser/LatexParser.java
+++ b/gen/nl/hannahsten/texifyidea/parser/LatexParser.java
@@ -333,18 +333,33 @@ public class LatexParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // keyval_content+
+  // (group | NORMAL_TEXT_WORD | STAR | AMPERSAND | QUOTATION_MARK | PIPE | EXCLAMATION_MARK | DASH)+
   public static boolean keyval_key(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "keyval_key")) return false;
     boolean r;
     Marker m = enter_section_(b, l, _NONE_, KEYVAL_KEY, "<keyval key>");
-    r = keyval_content(b, l + 1);
+    r = keyval_key_0(b, l + 1);
     while (r) {
       int c = current_position_(b);
-      if (!keyval_content(b, l + 1)) break;
+      if (!keyval_key_0(b, l + 1)) break;
       if (!empty_element_parsed_guard_(b, "keyval_key", c)) break;
     }
     exit_section_(b, l, m, r, false, null);
+    return r;
+  }
+
+  // group | NORMAL_TEXT_WORD | STAR | AMPERSAND | QUOTATION_MARK | PIPE | EXCLAMATION_MARK | DASH
+  private static boolean keyval_key_0(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "keyval_key_0")) return false;
+    boolean r;
+    r = group(b, l + 1);
+    if (!r) r = consumeToken(b, NORMAL_TEXT_WORD);
+    if (!r) r = consumeToken(b, STAR);
+    if (!r) r = consumeToken(b, AMPERSAND);
+    if (!r) r = consumeToken(b, QUOTATION_MARK);
+    if (!r) r = consumeToken(b, PIPE);
+    if (!r) r = consumeToken(b, EXCLAMATION_MARK);
+    if (!r) r = consumeToken(b, DASH);
     return r;
   }
 

--- a/gen/nl/hannahsten/texifyidea/psi/LatexCommands.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexCommands.java
@@ -1,14 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiNameIdentifierOwner;
+import com.intellij.psi.PsiReference;
 import com.intellij.psi.StubBasedPsiElement;
 import nl.hannahsten.texifyidea.index.stub.LatexCommandsStub;
-import com.intellij.psi.PsiReference;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.LinkedHashMap;
+import java.util.List;
 
 public interface LatexCommands extends PsiNameIdentifierOwner, LatexCommandWithParams, StubBasedPsiElement<LatexCommandsStub> {
 
@@ -18,7 +19,8 @@ public interface LatexCommands extends PsiNameIdentifierOwner, LatexCommandWithP
   @NotNull
   PsiElement getCommandToken();
 
-  @NotNull PsiReference[] getReferences();
+  @NotNull
+  PsiReference[] getReferences();
 
   PsiReference getReference();
 

--- a/gen/nl/hannahsten/texifyidea/psi/LatexEnvironment.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexEnvironment.java
@@ -1,13 +1,12 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
+import com.intellij.psi.LiteralTextEscaper;
 import com.intellij.psi.PsiLanguageInjectionHost;
 import com.intellij.psi.StubBasedPsiElement;
 import nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStub;
-import com.intellij.psi.LiteralTextEscaper;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public interface LatexEnvironment extends PsiLanguageInjectionHost, StubBasedPsiElement<LatexEnvironmentStub> {
 
@@ -28,6 +27,7 @@ public interface LatexEnvironment extends PsiLanguageInjectionHost, StubBasedPsi
 
   PsiLanguageInjectionHost updateText(@NotNull String text);
 
-  @NotNull LiteralTextEscaper<LatexEnvironment> createLiteralTextEscaper();
+  @NotNull
+  LiteralTextEscaper<LatexEnvironment> createLiteralTextEscaper();
 
 }

--- a/gen/nl/hannahsten/texifyidea/psi/LatexKeyvalKey.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexKeyvalKey.java
@@ -1,13 +1,14 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface LatexKeyvalKey extends PsiElement {
 
   @NotNull
-  List<LatexKeyvalContent> getKeyvalContentList();
+  List<LatexGroup> getGroupList();
 
 }

--- a/gen/nl/hannahsten/texifyidea/psi/LatexParameter.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexParameter.java
@@ -1,11 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiLanguageInjectionHost;
 import com.intellij.psi.LiteralTextEscaper;
+import com.intellij.psi.PsiLanguageInjectionHost;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public interface LatexParameter extends PsiLanguageInjectionHost {
 
@@ -25,6 +24,7 @@ public interface LatexParameter extends PsiLanguageInjectionHost {
 
   PsiLanguageInjectionHost updateText(@NotNull String text);
 
-  @NotNull LiteralTextEscaper<LatexParameter> createLiteralTextEscaper();
+  @NotNull
+  LiteralTextEscaper<LatexParameter> createLiteralTextEscaper();
 
 }

--- a/gen/nl/hannahsten/texifyidea/psi/LatexParameterGroupText.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexParameterGroupText.java
@@ -1,11 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface LatexParameterGroupText extends PsiElement {
+
+  @NotNull
+  List<LatexGroup> getGroupList();
 
   @NotNull
   List<LatexParameterText> getParameterTextList();

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexCommandsImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexCommandsImpl.java
@@ -1,20 +1,21 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.util.PsiTreeUtil;
-import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
-import nl.hannahsten.texifyidea.psi.LatexCommandsImplMixin;
-import nl.hannahsten.texifyidea.psi.*;
 import com.intellij.psi.PsiReference;
-import java.util.LinkedHashMap;
-import nl.hannahsten.texifyidea.index.stub.LatexCommandsStub;
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.util.PsiTreeUtil;
+import nl.hannahsten.texifyidea.index.stub.LatexCommandsStub;
+import nl.hannahsten.texifyidea.psi.*;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import static nl.hannahsten.texifyidea.psi.LatexTypes.COMMAND_TOKEN;
 
 public class LatexCommandsImpl extends LatexCommandsImplMixin implements LatexCommands {
 
@@ -53,7 +54,8 @@ public class LatexCommandsImpl extends LatexCommandsImplMixin implements LatexCo
   }
 
   @Override
-  public @NotNull PsiReference[] getReferences() {
+  @NotNull
+  public PsiReference[] getReferences() {
     return LatexPsiImplUtil.getReferences(this);
   }
 

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexEnvironmentImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexEnvironmentImpl.java
@@ -1,25 +1,23 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.util.PsiTreeUtil;
-import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
 import com.intellij.extapi.psi.StubBasedPsiElementBase;
-import nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStub;
-import nl.hannahsten.texifyidea.psi.*;
+import com.intellij.lang.ASTNode;
 import com.intellij.psi.LiteralTextEscaper;
+import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiLanguageInjectionHost;
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.util.PsiTreeUtil;
+import nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStub;
+import nl.hannahsten.texifyidea.psi.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class LatexEnvironmentImpl extends StubBasedPsiElementBase<LatexEnvironmentStub> implements LatexEnvironment {
 
-  public LatexEnvironmentImpl(@NotNull LatexEnvironmentStub stub, @NotNull IStubElementType<?, ?> nodeType) {
-    super(stub, nodeType);
+  public LatexEnvironmentImpl(@NotNull LatexEnvironmentStub stub, @NotNull IStubElementType<?, ?> type) {
+    super(stub, type);
   }
 
   public LatexEnvironmentImpl(@NotNull ASTNode node) {
@@ -79,7 +77,8 @@ public class LatexEnvironmentImpl extends StubBasedPsiElementBase<LatexEnvironme
   }
 
   @Override
-  public @NotNull LiteralTextEscaper<LatexEnvironment> createLiteralTextEscaper() {
+  @NotNull
+  public LiteralTextEscaper<LatexEnvironment> createLiteralTextEscaper() {
     return LatexPsiImplUtil.createLiteralTextEscaper(this);
   }
 

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexKeyvalKeyImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexKeyvalKeyImpl.java
@@ -1,15 +1,17 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
-import com.intellij.extapi.psi.ASTWrapperPsiElement;
-import nl.hannahsten.texifyidea.psi.*;
+import nl.hannahsten.texifyidea.psi.LatexGroup;
+import nl.hannahsten.texifyidea.psi.LatexKeyvalKey;
+import nl.hannahsten.texifyidea.psi.LatexPsiImplUtil;
+import nl.hannahsten.texifyidea.psi.LatexVisitor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public class LatexKeyvalKeyImpl extends ASTWrapperPsiElement implements LatexKeyvalKey {
 
@@ -29,8 +31,8 @@ public class LatexKeyvalKeyImpl extends ASTWrapperPsiElement implements LatexKey
 
   @Override
   @NotNull
-  public List<LatexKeyvalContent> getKeyvalContentList() {
-    return PsiTreeUtil.getChildrenOfTypeAsList(this, LatexKeyvalContent.class);
+  public List<LatexGroup> getGroupList() {
+    return PsiTreeUtil.getChildrenOfTypeAsList(this, LatexGroup.class);
   }
 
   @Override

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexMagicCommentImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexMagicCommentImpl.java
@@ -1,23 +1,23 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
+import com.intellij.extapi.psi.StubBasedPsiElementBase;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.util.PsiTreeUtil;
-import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
-import com.intellij.extapi.psi.StubBasedPsiElementBase;
-import nl.hannahsten.texifyidea.index.stub.LatexMagicCommentStub;
-import nl.hannahsten.texifyidea.psi.*;
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.tree.IElementType;
+import nl.hannahsten.texifyidea.index.stub.LatexMagicCommentStub;
+import nl.hannahsten.texifyidea.psi.LatexMagicComment;
+import nl.hannahsten.texifyidea.psi.LatexVisitor;
+import org.jetbrains.annotations.NotNull;
+
+import static nl.hannahsten.texifyidea.psi.LatexTypes.MAGIC_COMMENT_TOKEN;
 
 public class LatexMagicCommentImpl extends StubBasedPsiElementBase<LatexMagicCommentStub> implements LatexMagicComment {
 
-  public LatexMagicCommentImpl(@NotNull LatexMagicCommentStub stub, @NotNull IStubElementType<?, ?> nodeType) {
-    super(stub, nodeType);
+  public LatexMagicCommentImpl(@NotNull LatexMagicCommentStub stub, @NotNull IStubElementType<?, ?> type) {
+    super(stub, type);
   }
 
   public LatexMagicCommentImpl(@NotNull ASTNode node) {

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexParameterGroupTextImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexParameterGroupTextImpl.java
@@ -1,15 +1,17 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
-import com.intellij.extapi.psi.ASTWrapperPsiElement;
-import nl.hannahsten.texifyidea.psi.*;
+import nl.hannahsten.texifyidea.psi.LatexGroup;
+import nl.hannahsten.texifyidea.psi.LatexParameterGroupText;
+import nl.hannahsten.texifyidea.psi.LatexParameterText;
+import nl.hannahsten.texifyidea.psi.LatexVisitor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public class LatexParameterGroupTextImpl extends ASTWrapperPsiElement implements LatexParameterGroupText {
 
@@ -23,8 +25,14 @@ public class LatexParameterGroupTextImpl extends ASTWrapperPsiElement implements
 
   @Override
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof LatexVisitor) accept((LatexVisitor)visitor);
+    if (visitor instanceof LatexVisitor) accept((LatexVisitor) visitor);
     else super.accept(visitor);
+  }
+
+  @Override
+  @NotNull
+  public List<LatexGroup> getGroupList() {
+    return PsiTreeUtil.getChildrenOfTypeAsList(this, LatexGroup.class);
   }
 
   @Override

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexParameterImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexParameterImpl.java
@@ -1,17 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi.impl;
 
-import java.util.List;
-import org.jetbrains.annotations.*;
-import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.util.PsiTreeUtil;
-import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
-import nl.hannahsten.texifyidea.psi.*;
+import com.intellij.lang.ASTNode;
 import com.intellij.psi.LiteralTextEscaper;
+import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiLanguageInjectionHost;
+import com.intellij.psi.util.PsiTreeUtil;
+import nl.hannahsten.texifyidea.psi.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class LatexParameterImpl extends ASTWrapperPsiElement implements LatexParameter {
 
@@ -64,7 +62,8 @@ public class LatexParameterImpl extends ASTWrapperPsiElement implements LatexPar
   }
 
   @Override
-  public @NotNull LiteralTextEscaper<LatexParameter> createLiteralTextEscaper() {
+  @NotNull
+  public LiteralTextEscaper<LatexParameter> createLiteralTextEscaper() {
     return LatexPsiImplUtil.createLiteralTextEscaper(this);
   }
 

--- a/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
+++ b/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
@@ -134,7 +134,9 @@ angle_param_content ::= raw_text | magic_comment | comment | environment | pseud
 
 strict_keyval_pair ::= keyval_key EQUALS keyval_value?
 keyval_pair ::= keyval_key (EQUALS keyval_value?)?
-keyval_key ::= keyval_content+ {
+
+// Keys in a key/val list are typically no commands and don't need to be references
+keyval_key ::= (group | NORMAL_TEXT_WORD | STAR | AMPERSAND | QUOTATION_MARK | PIPE | EXCLAMATION_MARK | DASH)+ {
     methods=[toString]
 }
 keyval_value ::= keyval_content+ {

--- a/src/nl/hannahsten/texifyidea/psi/LatexCommandsImplUtil.kt
+++ b/src/nl/hannahsten/texifyidea/psi/LatexCommandsImplUtil.kt
@@ -9,19 +9,48 @@ import com.intellij.psi.PsiReference
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.util.nextLeaf
 import com.intellij.util.containers.toArray
-import nl.hannahsten.texifyidea.lang.alias.CommandManager
 import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.SUBFILES
-import nl.hannahsten.texifyidea.lang.commands.*
+import nl.hannahsten.texifyidea.lang.alias.CommandManager
+import nl.hannahsten.texifyidea.lang.commands.LatexCommand
+import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
+import nl.hannahsten.texifyidea.lang.commands.RequiredArgument
+import nl.hannahsten.texifyidea.lang.commands.RequiredFileArgument
 import nl.hannahsten.texifyidea.reference.CommandDefinitionReference
 import nl.hannahsten.texifyidea.reference.InputFileReference
 import nl.hannahsten.texifyidea.reference.LatexLabelReference
-import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.firstChildOfType
 import nl.hannahsten.texifyidea.util.labels.getLabelReferenceCommands
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.magic.PatternMagic
 import nl.hannahsten.texifyidea.util.magic.cmd
-import java.util.*
+import nl.hannahsten.texifyidea.util.requiredParameters
+import nl.hannahsten.texifyidea.util.shrink
 import java.util.regex.Pattern
+import kotlin.collections.ArrayList
+import kotlin.collections.LinkedHashMap
+import kotlin.collections.List
+import kotlin.collections.Map
+import kotlin.collections.MutableList
+import kotlin.collections.addAll
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.contains
+import kotlin.collections.emptyList
+import kotlin.collections.firstOrNull
+import kotlin.collections.flatMap
+import kotlin.collections.forEach
+import kotlin.collections.getOrDefault
+import kotlin.collections.indices
+import kotlin.collections.isNotEmpty
+import kotlin.collections.joinToString
+import kotlin.collections.lastOrNull
+import kotlin.collections.listOf
+import kotlin.collections.map
+import kotlin.collections.mapNotNull
+import kotlin.collections.mutableListOf
+import kotlin.collections.set
+import kotlin.collections.setOf
+import kotlin.collections.toTypedArray
 
 /**
  * Get the references for this command.
@@ -218,8 +247,21 @@ fun setName(element: LatexCommands, newName: String): PsiElement {
     return element
 }
 
-fun keyValContentToString(element: LatexKeyvalKey): String =
-    keyValContentToString(element.keyvalContentList)
+fun keyValKeyToString(element: LatexKeyvalKey): String {
+    // This is ugly, but element.children returns only composite children and other querying methods are recursive
+    val result = ArrayList<PsiElement>()
+    var psiChild = element.firstChild
+    while (psiChild != null) {
+        result.add(psiChild)
+        psiChild = psiChild.getNextSibling()
+    }
+    return result.joinToString(separator = "") {
+        when (it) {
+            is LatexGroup -> it.content?.text ?: ""
+            else -> it.text
+        }
+    }
+}
 
 fun keyValContentToString(list: List<LatexKeyvalContent>): String =
     list.joinToString(separator = "") {

--- a/src/nl/hannahsten/texifyidea/psi/LatexPsiImplUtil.java
+++ b/src/nl/hannahsten/texifyidea/psi/LatexPsiImplUtil.java
@@ -40,7 +40,7 @@ public class LatexPsiImplUtil {
     }
 
     public static String toString(@NotNull LatexKeyvalKey element) {
-        return LatexCommandsImplUtilKt.keyValContentToString(element);
+        return LatexCommandsImplUtilKt.keyValKeyToString(element);
     }
 
     public static String toString(@NotNull LatexKeyvalValue element) {


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2445

#### Summary of additions and changes
* Restrict the possible values for keys in key/val pairs

The changes are based on the assumption that keys in key/val pairs are never references because now they are no longer `parameter_text`. 