### PR TITLE
Exclude more stub indexes from indexing package files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 group = "nl.hannahsten"
-version = "0.7.19-alpha.1"
+version = "0.7.19-alpha.3"
 
 repositories {
     mavenCentral()
@@ -150,7 +150,7 @@ intellij {
     pluginName.set("TeXiFy-IDEA")
 
     // indices plugin doesn't work in tests
-    plugins.set(listOf("tanvd.grazi", "java", "com.firsttimeinforever.intellij.pdf.viewer.intellij-pdf-viewer:0.14.0")) // , "com.jetbrains.hackathon.indices.viewer:1.13")
+    plugins.set(listOf("tanvd.grazi", "java", "com.firsttimeinforever.intellij.pdf.viewer.intellij-pdf-viewer:0.14.0", "com.jetbrains.hackathon.indices.viewer:1.20"))
 
     // Use the since build number from plugin.xml
     updateSinceUntilBuild.set(false)
@@ -209,4 +209,8 @@ tasks.jacocoTestReport {
 
 ktlint {
     verbose.set(true)
+}
+
+tasks.jar {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/src/nl/hannahsten/texifyidea/formatting/spacingrules/TableAlignRule.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/spacingrules/TableAlignRule.kt
@@ -20,13 +20,13 @@ const val LINE_LENGTH = 80
  */
 fun rightTableSpaceAlign(latexCommonSettings: CommonCodeStyleSettings, parent: ASTBlock, left: ASTBlock): Spacing? {
 
-    if (parent.node?.psi?.firstParentOfType(LatexEnvironmentContent::class)
-            ?.firstParentOfType(LatexEnvironment::class)?.environmentName !in EnvironmentMagic.getAllTableEnvironments(parent.node?.psi?.project ?: ProjectManager.getInstance().defaultProject)
-    ) return null
-
     // Only add spaces after &, unless escaped
     if (left.node?.text?.endsWith("&") == false) return null
     if (left.node?.text?.endsWith("\\&") == true) return null
+
+    if (parent.node?.psi?.firstParentOfType(LatexEnvironmentContent::class)
+            ?.firstParentOfType(LatexEnvironment::class)?.environmentName !in EnvironmentMagic.getAllTableEnvironments(parent.node?.psi?.project ?: ProjectManager.getInstance().defaultProject)
+    ) return null
 
     return createSpacing(
         minSpaces = 1,

--- a/src/nl/hannahsten/texifyidea/index/file/LatexIndexableSetContributor.kt
+++ b/src/nl/hannahsten/texifyidea/index/file/LatexIndexableSetContributor.kt
@@ -44,7 +44,7 @@ class LatexIndexableSetContributor : IndexableSetContributor() {
         // Add style files (used in e.g. LatexExternalPackageInclusionIndex)
         // Unfortunately, since .sty is a LaTeX file type, these will all be parsed, which will take an enormous amount of time.
         // Note that using project-independent getAdditionalRootsToIndex does not fix this
-//        roots.addAll(LatexSdkUtil.getSdkStyleFileRoots(project)) // todo this causes parsing of all files which gets stuck
+        roots.addAll(LatexSdkUtil.getSdkStyleFileRoots(project))
 
         return roots
     }

--- a/src/nl/hannahsten/texifyidea/index/file/LatexIndexableSetContributor.kt
+++ b/src/nl/hannahsten/texifyidea/index/file/LatexIndexableSetContributor.kt
@@ -42,7 +42,9 @@ class LatexIndexableSetContributor : IndexableSetContributor() {
         }
 
         // Add style files (used in e.g. LatexExternalPackageInclusionIndex)
-        roots.addAll(LatexSdkUtil.getSdkStyleFileRoots(project))
+        // Unfortunately, since .sty is a LaTeX file type, these will all be parsed, which will take an enormous amount of time.
+        // Note that using project-independent getAdditionalRootsToIndex does not fix this
+//        roots.addAll(LatexSdkUtil.getSdkStyleFileRoots(project)) // todo this causes parsing of all files which gets stuck
 
         return roots
     }

--- a/src/nl/hannahsten/texifyidea/index/stub/LatexCommandsStubElementType.kt
+++ b/src/nl/hannahsten/texifyidea/index/stub/LatexCommandsStubElementType.kt
@@ -87,7 +87,7 @@ class LatexCommandsStubElementType(debugName: String) :
         val pathOfCurrentlyIndexedFile = (latexCommandsStub.psi?.containingFile?.viewProvider?.virtualFile as? LightVirtualFile)?.originalFile?.path
 
         // If any of the sdk source roots is part of the currently indexed path, don't index the file
-        if (getAdditionalProjectRoots(latexCommandsStub.psi?.project).any { pathOfCurrentlyIndexedFile?.contains(it) == true}) {
+        if (getAdditionalProjectRoots(latexCommandsStub.psi?.project).any { pathOfCurrentlyIndexedFile?.contains(it) == true }) {
             return
         }
 

--- a/src/nl/hannahsten/texifyidea/index/stub/LatexCommandsStubElementType.kt
+++ b/src/nl/hannahsten/texifyidea/index/stub/LatexCommandsStubElementType.kt
@@ -84,10 +84,10 @@ class LatexCommandsStubElementType(debugName: String) :
         // Therefore, we check if the indexing of this file was caused by being in an extra project root or not
         // It seems we cannot make a distinction that we do want to index with LatexExternalCommandIndex but not this index
         // Unfortunately, this seems to make indexing five times slower
-        val pathOfCurrentlyIndexedFile = (latexCommandsStub.psi?.containingFile?.viewProvider?.virtualFile as? LightVirtualFile)?.originalFile?.path ?: return
+        val pathOfCurrentlyIndexedFile = (latexCommandsStub.psi?.containingFile?.viewProvider?.virtualFile as? LightVirtualFile)?.originalFile?.path
 
-        // If none of the project roots is part of the currently indexed path, don't index the file
-        if (getAdditionalProjectRoots(latexCommandsStub.psi?.project).any { pathOfCurrentlyIndexedFile.contains(it) }) {
+        // If any of the sdk source roots is part of the currently indexed path, don't index the file
+        if (getAdditionalProjectRoots(latexCommandsStub.psi?.project).any { pathOfCurrentlyIndexedFile?.contains(it) == true}) {
             return
         }
 

--- a/src/nl/hannahsten/texifyidea/reference/LatexLabelReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/LatexLabelReference.kt
@@ -29,7 +29,8 @@ class LatexLabelReference(element: LatexCommands, range: TextRange?) : PsiRefere
 
     override fun getVariants(): Array<Any> {
         val file = myElement!!.containingFile.originalFile
-        val command = myElement.commandToken.text
+        @Suppress("USELESS_CAST") // Smart cast to 'LatexCommands' is deprecated, because 'myElement' is a property declared in base class from different module
+        val command = (myElement as LatexCommands).commandToken.text
 
         // add bibreferences to autocompletion for \cite-style commands
         if (CommandMagic.bibliographyReference.contains(command)) {

--- a/src/nl/hannahsten/texifyidea/util/Packages.kt
+++ b/src/nl/hannahsten/texifyidea/util/Packages.kt
@@ -216,7 +216,7 @@ object PackageUtils {
         initial: T
     ): T {
         for (cmd in commands) {
-            if (cmd.commandToken.text !in packageCommands) {
+            if (cmd.name !in packageCommands) {
                 continue
             }
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2433

#### Summary of additions and changes

* Exclude some more stub indexes from indexing package files, which greatly reduces index size and improves performance

This does not fix the root of the problem, which is that package file shouldn't be indexed at all.
