### PR TITLE
Support non-IntelliJ IDEs also for package-file based indexes

### DIFF
--- a/src/nl/hannahsten/texifyidea/index/file/LatexIndexableSetContributor.kt
+++ b/src/nl/hannahsten/texifyidea/index/file/LatexIndexableSetContributor.kt
@@ -27,7 +27,7 @@ class LatexIndexableSetContributor : IndexableSetContributor() {
         }
 
         // Add source files
-        val roots = LatexSdkUtil.getSdkSourceRoots(project).toMutableSet()
+        val roots = LatexSdkUtil.getSdkSourceRoots(project) { sdk, homePath -> sdk.getDefaultSourcesPath(homePath) }.toMutableSet()
         // Check if we possibly need to extract files first
         for (root in roots) {
             if (root.path.contains("MiKTeX", ignoreCase = true) && !extractedFiles) {
@@ -44,7 +44,7 @@ class LatexIndexableSetContributor : IndexableSetContributor() {
         // Add style files (used in e.g. LatexExternalPackageInclusionIndex)
         // Unfortunately, since .sty is a LaTeX file type, these will all be parsed, which will take an enormous amount of time.
         // Note that using project-independent getAdditionalRootsToIndex does not fix this
-        roots.addAll(LatexSdkUtil.getSdkStyleFileRoots(project))
+        roots.addAll(LatexSdkUtil.getSdkSourceRoots(project) { sdkType, homePath -> sdkType.getDefaultStyleFilesPath(homePath) })
 
         return roots
     }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2387

#### Summary of additions and changes

* For some reason, only dtx file source paths were attempted to be found when no SDKs are configured, now this also holds for sty file sources.
