### PR TITLE
Add `blockarray` and `block` environments

### DIFF
--- a/src/nl/hannahsten/texifyidea/lang/DefaultEnvironment.kt
+++ b/src/nl/hannahsten/texifyidea/lang/DefaultEnvironment.kt
@@ -130,6 +130,8 @@ enum class DefaultEnvironment(
     // other
     ALGORITHM("algorithm"),
     ALGORITHMIC("algorithmic", dependency = ALGORITHMICX),
+    BLOCKARRAY(environmentName = "blockarray", context = Context.MATH, dependency = LatexPackage.BLKARRAY),
+    BLOCK(environmentName = "block", context = Context.MATH, dependency = LatexPackage.BLKARRAY),
     GMATRIX(environmentName = "gmatrix", context = Context.MATH, dependency = GAUSS),
     COMMENT(environmentName = "comment", context = Context.COMMENT, dependency = LatexPackage.COMMENT),
     LISTINGS(environmentName = "lstlisting", dependency = LatexPackage.LISTINGS),

--- a/src/nl/hannahsten/texifyidea/lang/LatexPackage.kt
+++ b/src/nl/hannahsten/texifyidea/lang/LatexPackage.kt
@@ -32,6 +32,7 @@ open class LatexPackage @JvmOverloads constructor(
         val AMSSYMB = LatexPackage("amssymb")
         val BIBLATEX = LatexPackage("biblatex")
         val BLINDTEXT = LatexPackage("blindtext")
+        val BLKARRAY = LatexPackage("blkarray")
         val BM = LatexPackage("bm")
         val BOOKTABS = LatexPackage("booktabs")
         val CHAPTERBIB = LatexPackage("chapterbib")

--- a/src/nl/hannahsten/texifyidea/util/magic/EnvironmentMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/EnvironmentMagic.kt
@@ -8,7 +8,7 @@ object EnvironmentMagic {
 
     val listingEnvironments = hashSetOf(ITEMIZE, ENUMERATE, DESCRIPTION).map { it.env }
 
-    private val tableEnvironmentsWithoutCustomEnvironments = hashSetOf(TABULAR, TABULAR_STAR, TABULARX, TABULARY, ARRAY, LONGTABLE, TABU, MATRIX, BMATRIX, PMATRIX, VMATRIX, VMATRIX_CAPITAL, WIDETABULAR).map { it.env }
+    private val tableEnvironmentsWithoutCustomEnvironments = hashSetOf(TABULAR, TABULAR_STAR, TABULARX, TABULARY, ARRAY, LONGTABLE, TABU, MATRIX, BMATRIX, PMATRIX, VMATRIX, VMATRIX_CAPITAL, WIDETABULAR, BLOCKARRAY, BLOCK).map { it.env }
 
     /**
      * Get all table environments in the project, including any user defined aliases.


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Similar to PR #2245

#### Summary of additions and changes

Add the `blockarray` and `block` environments provided by the  `blkarray` package.

#### Problem

Inspection was triggered suggesting to escape ampersands and underscores within `blockarray` and `block` contexts.

#### How to test this pull request

```latex
\begin{equation*}
    \B{A} =
    \begin{blockarray}{ccccc}
        & 1 & 2 & & m \\
      \begin{block}{c(cccc)}
        1 & a_{1,1} & a_{1,2} & \cdots & a_{1,m} \\
        2 & a_{2,1} & a_{2,2} & \cdots & a_{2,m} \\
        & \vdots  & \vdots  & \ddots & \vdots \\
        n & a_{n,1} & a_{n,2} & \cdots & a_{n,m} \\
      \end{block}
    \end{blockarray}
\end{equation*}
```

At least the inspection to replace `&` with `\&` should not be triggered.

#### Disclaimer

I have 0 experience with this project and with Kotlin/Java in general and don't have the setup to build/test this fix. I tried to deduce which files/lines to add/edit from a similar PR #2245. It seemed rather straightforward. I hope I didn't mess up completely.

I could not figure out whether the changes have any effect on the underscore inspection problem. If not and someone can point me in the right direction, I could attempt to fix that too.