### PR TITLE
Add line break between bibtex entries

### DIFF
--- a/src/nl/hannahsten/texifyidea/formatting/BibtexSpacingRules.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/BibtexSpacingRules.kt
@@ -20,6 +20,7 @@ fun createBibtexSpacingBuilder(settings: CodeStyleSettings): TexSpacingBuilder {
             after(OPEN_PARENTHESIS).spaces(1)
             around(CONCATENATE).spaces(1)
             between(ENTRY_CONTENT, ENDTRY).spaces(1)
+            before(ENTRY).blankLines(1)
         }
 
         custom {


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix [TEX-155](https://texify-idea.myjetbrains.com/youtrack/issue/TEX-155)

#### Summary of additions and changes

* Add blank line

#### How to test this pull request

```latex
@book{knuth1990,
    author = {Knuth, Donald E.},
    title = {The {\TeX}book},
    year = {1990},
    isbn = {},
    publisher = {Addison\,\textendash\,Wesley}
}@article{greenwade1993,
    author = "George D. Greenwade",
    title = "The {C}omprehensive {T}ex {A}rchive {N}etwork ({CTAN})",
    year = "1993",
    journal = "TUGBoat",
    volume = "14",
    number = "3",
    pages = "342--351",
    note = mytext
}
```
After formatting, a blank line is added.