### PR TITLE
Trim whitespace when resolving file name

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 group = "nl.hannahsten"
-version = "0.7.20-alpha.1"
+version = "0.7.20-alpha.2"
 
 repositories {
     mavenCentral()

--- a/src/nl/hannahsten/texifyidea/action/preview/EquationPreviewToolWindow.kt
+++ b/src/nl/hannahsten/texifyidea/action/preview/EquationPreviewToolWindow.kt
@@ -10,8 +10,8 @@ class EquationPreviewToolWindow {
 
     private val previewForm = PreviewForm()
 
-    val content: JPanel
-        get() = previewForm.panel!!
+    val content: JPanel?
+        get() = previewForm.panel
 
     val form: PreviewForm
         get() = previewForm

--- a/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
@@ -109,7 +109,9 @@ class InputFileReference(
             }
         }
 
-        val processedKey = expandCommandsOnce(key, element.project, file = rootFiles.firstOrNull()?.psiFile(element.project)) ?: key
+        var processedKey = expandCommandsOnce(key, element.project, file = rootFiles.firstOrNull()?.psiFile(element.project)) ?: key
+        // Leading and trailing whitespaces seem to be ignored, at least it holds for \include-like commands
+        processedKey = processedKey.trim()
 
         var targetFile: VirtualFile? = null
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2518 whitespace around file name
Fix #2526 NPE EquationPreviewToolWindow
