### PR TITLE
Improve inspection performance when import package is used

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 group = "nl.hannahsten"
-version = "0.7.20-alpha.1"
+version = "0.7.20-alpha.3"
 
 repositories {
     mavenCentral()

--- a/src/nl/hannahsten/texifyidea/index/file/LatexExternalPackageInclusionCache.kt
+++ b/src/nl/hannahsten/texifyidea/index/file/LatexExternalPackageInclusionCache.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.index.file
 
+import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.util.indexing.FileBasedIndex
@@ -22,7 +23,7 @@ object LatexExternalPackageInclusionCache {
      */
     @Synchronized
     fun getAllPackageInclusions(project: Project): Map<LatexPackage, Set<LatexPackage>> {
-        if (cache.isNotEmpty()) return cache
+        if (cache.isNotEmpty() || DumbService.isDumb(project)) return cache
 
         val directChildren = mutableMapOf<LatexPackage, MutableSet<LatexPackage>>()
 

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexInclusionLoopInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexInclusionLoopInspection.kt
@@ -9,8 +9,6 @@ import nl.hannahsten.texifyidea.index.LatexIncludesIndex
 import nl.hannahsten.texifyidea.inspections.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.util.files.findIncludedFile
-import nl.hannahsten.texifyidea.util.files.searchFileByImportPaths
-import java.util.*
 
 /**
  * This inspection only detects inclusion loops involving two files.
@@ -38,27 +36,21 @@ open class LatexInclusionLoopInspection : TexifyInspectionBase() {
             // Find included files
             val declaredIn = command.containingFile
 
-            // Check if import package is used
-            val fileMaybe = searchFileByImportPaths(command)
-            if (fileMaybe != null) {
-                inclusions.getOrPut(declaredIn) { mutableSetOf() }.add(fileMaybe)
-            }
-            else {
-                for (referenced in declaredIn.findIncludedFile(command)) {
+            // Do not use ImportPackage#searchFileByImportPaths, because if we would do that for every command, that would be way too expensive.
+            for (referenced in declaredIn.findIncludedFile(command)) {
 
-                    inclusions.getOrPut(declaredIn) { mutableSetOf() }.add(referenced)
+                inclusions.getOrPut(declaredIn) { mutableSetOf() }.add(referenced)
 
-                    if (declaredIn == file && inclusions.getOrDefault(referenced, mutableSetOf()).contains(declaredIn)) {
-                        descriptors.add(
-                            manager.createProblemDescriptor(
-                                command,
-                                TextRange(0, command.textLength - 1),
-                                "File inclusion loop found for files ${referenced.name} and ${declaredIn.name}.",
-                                ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
-                                isOntheFly
-                            )
+                if (declaredIn == file && inclusions.getOrDefault(referenced, mutableSetOf()).contains(declaredIn)) {
+                    descriptors.add(
+                        manager.createProblemDescriptor(
+                            command,
+                            TextRange(0, command.textLength - 1),
+                            "File inclusion loop found for files ${referenced.name} and ${declaredIn.name}.",
+                            ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                            isOntheFly
                         )
-                    }
+                    )
                 }
             }
         }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2523
Fix #2537 Dumb mode in LatexPackageLocationCache

#### Summary of additions and changes

* LatexInclusionLoopInspection was using this expensive method for the import package, I just removed that part as that's not worth it
* Improve the check if the import package is used: move it before the expensive calls

#### How to test this pull request

Tested on project with 160 files and 50k lines of tex: inspections take one minute the first time (building fileset), then only two seconds afterwards.
