### PR TITLE
Fix inspection false positives related to \def redefinitions

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMightBreakTexifyInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMightBreakTexifyInspection.kt
@@ -45,7 +45,7 @@ class LatexMightBreakTexifyInspection : TexifyInspectionBase() {
                     descriptors.add(
                         manager.createProblemDescriptor(
                             command,
-                            "This might break TeXiFy functionality",
+                            "Redefining ${newCommand?.name ?: "this command"} might break TeXiFy functionality",
                             null as LocalQuickFix?,
                             ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
                             isOntheFly

--- a/src/nl/hannahsten/texifyidea/util/Psi.kt
+++ b/src/nl/hannahsten/texifyidea/util/Psi.kt
@@ -205,6 +205,7 @@ fun PsiElement.nextSiblingIgnoreWhitespace(): PsiElement? {
 
 /**
  * Finds the next sibling of the element that has the given type.
+ * If the element has the given type, it is returned directly.
  *
  * @return The first following sibling of the given type, or `null` when the sibling couldn't be found.
  */

--- a/src/nl/hannahsten/texifyidea/util/PsiCommands.kt
+++ b/src/nl/hannahsten/texifyidea/util/PsiCommands.kt
@@ -216,9 +216,9 @@ fun LatexCommands.forcedFirstRequiredParameterAsCommand(): LatexCommands? {
         return if (found.size == 1) found.first() else null
     }
 
-    val parent = PsiTreeUtil.getParentOfType(this, LatexNoMathContent::class.java)
-    val sibling = PsiTreeUtil.getNextSiblingOfType(parent, LatexNoMathContent::class.java)
-    return PsiTreeUtil.findChildOfType(sibling, LatexCommands::class.java)
+    // This is just a bit of guesswork about the parser structure.
+    // Probably, if we're looking at a \def\mycommand, if the sibling isn't it, probably the parent has a sibling.
+    return nextSibling?.nextSiblingOfType(LatexCommands::class) ?: parent?.nextSiblingIgnoreWhitespace()?.firstChildOfType(LatexCommands::class)
 }
 
 /**

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMightBreakTexifyInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMightBreakTexifyInspectionTest.kt
@@ -1,0 +1,26 @@
+package nl.hannahsten.texifyidea.inspections.latex.codestyle
+
+import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
+
+class LatexMightBreakTexifyInspectionTest : TexifyInspectionTestBase(LatexMightBreakTexifyInspection()) {
+
+    fun testTruePositive() = testHighlighting(
+        """
+            <error descr="Redefining \newcommand might break TeXiFy functionality">\def</error>\newcommand\noop
+            
+            <error descr="Redefining \documentclass might break TeXiFy functionality">\renewcommand{\documentclass}{\noclass}</error>
+        """.trimIndent()
+    )
+
+    fun testTrueNegative() = testHighlighting(
+        """
+            \def\venue{openair}
+            \ifthenelse {\equal{\venue}{openair}}{
+                \def\venueString{parking}
+            }{
+                \def\venueString{cultural centre}
+            }
+            \def\someCommand{xxx} 
+        """.trimIndent()
+    )
+}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2542

#### Summary of additions and changes

* The code for finding the command after a \def wasn't very up to date, this should be better now.
Also the CommandAlreadyDefinedInspection used the same code.
* Clearer inspection message

#### How to test this pull request

See tests and issue
