### PR TITLE
add support for glossary entries loaded via loadglsentries command

### DIFF
--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexGlossariesCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexGlossariesCommand.kt
@@ -49,7 +49,15 @@ enum class LatexGlossariesCommand(
     GLS("gls", "label".asRequired(), dependency = LatexPackage.GLOSSARIES),
     GLSUPPER("Gls", "label".asRequired(), dependency = LatexPackage.GLOSSARIES),
     GLSPLURAL("glspl", "label".asRequired(), dependency = LatexPackage.GLOSSARIES),
-    GLSPLURALUPPER("Glspl", "label".asRequired(), dependency = LatexPackage.GLOSSARIES);
+    GLSPLURALUPPER("Glspl", "label".asRequired(), dependency = LatexPackage.GLOSSARIES),
+
+    LOADGLSENTRIES(
+        "loadglsentries", RequiredFileArgument(
+            "glossariesfile",
+            isAbsolutePathSupported = true,
+            commaSeparatesArguments = false
+        ), dependency = LatexPackage.GLOSSARIES
+    );
 
     companion object {
 

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexRegularCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexRegularCommand.kt
@@ -20,9 +20,10 @@ object LatexRegularCommand {
     val IFS: Set<LatexCommand> = LatexIfCommand.values().toSet()
     val LISTINGS: Set<LatexCommand> = LatexListingCommand.values().toSet()
     val LOREM_IPSUM: Set<LatexCommand> = LatexLoremIpsumCommand.values().toSet()
+    val GLOSSARY: Set<LatexCommand> = LatexGlossariesCommand.values().toSet()
 
     val ALL: Set<LatexCommand> = GENERIC + TEXTCOMP + EURO + TEXT_SYMBOLS + NEW_DEFINITIONS + MATHTOOLS +
-            XCOLOR + XPARSE + NATBIB + BIBLATEX + SIUNITX + ALGORITHMICX + IFS + LISTINGS + LOREM_IPSUM
+            XCOLOR + XPARSE + NATBIB + BIBLATEX + SIUNITX + ALGORITHMICX + IFS + LISTINGS + LOREM_IPSUM + GLOSSARY
 
     private val lookup = HashMap<String, MutableSet<LatexCommand>>()
     private val lookupDisplay = HashMap<String, MutableSet<LatexCommand>>()

--- a/test/nl/hannahsten/texifyidea/completion/LatexGlossaryCompletionTest.kt
+++ b/test/nl/hannahsten/texifyidea/completion/LatexGlossaryCompletionTest.kt
@@ -71,4 +71,18 @@ class LatexGlossaryCompletionTest : BasePlatformTestCase() {
         testGlossaryReferenceCompletion("glspl")
         testGlossaryReferenceCompletion("Gls")
     }
+
+    @Test
+    fun testExternalGlossaryCompletion() {
+        // given
+        myFixture.configureByFiles("LoadExternalGlossary.tex", "glossar.tex")
+
+        // when
+        val result = myFixture.complete(CompletionType.BASIC)
+
+        // then
+        assertEquals(2, result.size)
+        assertTrue(result.any { l -> l.lookupString == "aslr" })
+        assertTrue(result.any { l -> l.lookupString == "maths" })
+    }
 }

--- a/test/resources/completion/glossary/LoadExternalGlossary.tex
+++ b/test/resources/completion/glossary/LoadExternalGlossary.tex
@@ -1,0 +1,22 @@
+%! Author = felixl
+%! Date = 04/08/2022
+
+% Preamble
+\documentclass[11pt]{article}
+
+% Packages
+\usepackage{glossaries}
+\loadglsentries{glossar.tex}
+
+\newglossaryentry{maths}
+{
+    name=mathematics,
+    description={Mathematics is what mathematicians do}
+}
+
+% Document
+\begin{document}
+
+    \gls{<caret>}
+
+\end{document}

--- a/test/resources/completion/glossary/glossar.tex
+++ b/test/resources/completion/glossary/glossar.tex
@@ -1,0 +1,1 @@
+\newacronym{aslr}{ASLR}{Address Space Layout Randomization}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2563 

#### Summary of additions and changes

* Add support for the \loadglsentries command

#### How to test this pull request

See the included testcase
