### PR TITLE
Index style files also for miktex on windows

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 group = "nl.hannahsten"
-version = "0.7.20"
+version = "0.7.21-alpha.3"
 
 repositories {
     mavenCentral()

--- a/src/nl/hannahsten/texifyidea/index/file/LatexIndexableSetContributor.kt
+++ b/src/nl/hannahsten/texifyidea/index/file/LatexIndexableSetContributor.kt
@@ -37,6 +37,7 @@ class LatexIndexableSetContributor : IndexableSetContributor() {
                 }
                 catch (e: ArchiverException) {
                     // Ignore permission errors, nothing we can do about that
+                    Log.debug("Exception when trying to extract MiKTeX source files: ${e.message}")
                     return mutableSetOf()
                 }
             }
@@ -67,12 +68,14 @@ class LatexIndexableSetContributor : IndexableSetContributor() {
             // If the user has e.g. a MiKTeX admin install, we do not have rights to extract zips
             if (!Files.isWritable(Path.of(root.path))) {
                 extractedFiles = true
+                Log.debug("MiKTeX installation path ${root.path} is not writable, cannot extract sources")
                 return false
             }
 
             // Try to create if not exists
             if (!destination.exists() && !destination.mkdir()) {
                 extractedFiles = true
+                Log.debug("Could not create destination directory ${destination.absolutePath}")
                 return false
             }
 

--- a/src/nl/hannahsten/texifyidea/settings/sdk/MiktexWindowsSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/MiktexWindowsSdk.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import nl.hannahsten.texifyidea.run.latex.LatexDistributionType
+import nl.hannahsten.texifyidea.util.Log
 import nl.hannahsten.texifyidea.util.runCommand
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion
 import java.nio.file.InvalidPathException
@@ -50,11 +51,24 @@ class MiktexWindowsSdk : LatexSdk("MiKTeX Windows SDK") {
     }
 
     override fun getDefaultSourcesPath(homePath: String): VirtualFile? {
+        val path = Paths.get(homePath, "source").toString()
         return try {
             // To save space, MiKTeX leaves source/latex empty by default, but does leave the zipped files in source/
-            LocalFileSystem.getInstance().findFileByPath(Paths.get(homePath, "source").toString())
+            LocalFileSystem.getInstance().findFileByPath(path)
         }
         catch (ignored: InvalidPathException) {
+            Log.debug("Invalid path $path when looking for LaTeX sources")
+            null
+        }
+    }
+
+    override fun getDefaultStyleFilesPath(homePath: String): VirtualFile? {
+        val path = Paths.get(homePath, "tex", "latex").toString()
+        return try {
+            LocalFileSystem.getInstance().findFileByPath(path)
+        }
+        catch (ignored: InvalidPathException) {
+            Log.debug("Invalid path $path when looking for LaTeX style files")
             null
         }
     }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2190 but now also for MiKTeX on Windows.

#### Summary of additions and changes

* Add style file root

#### How to test this pull request

https://plugins.jetbrains.com/files/9473/206710/TeXiFy-IDEA-0.7.21-alpha.3.zip

![image](https://user-images.githubusercontent.com/15669080/183739076-b3e4bd62-a26c-4d93-a864-1e5d65d51e8d.png)

It might be necessary to add the SDK.

