### PR TITLE
Change the port of the server for Mendeley authentication

### DIFF
--- a/src/nl/hannahsten/texifyidea/action/library/mendeley/AddMendeleyAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/library/mendeley/AddMendeleyAction.kt
@@ -1,6 +1,7 @@
 package nl.hannahsten.texifyidea.action.library.mendeley
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.ui.jcef.JBCefBrowser
 import nl.hannahsten.texifyidea.action.library.AddLibraryAction
 import nl.hannahsten.texifyidea.psi.BibtexEntry
@@ -43,6 +44,11 @@ class AddMendeleyAction : AddLibraryAction<MendeleyLibrary, AddMendeleyAction.Ad
 
         override fun createCenterPanel(): JComponent {
             return browser.component
+        }
+
+        override fun doValidate(): ValidationInfo? {
+            return if (MendeleyAuthenticator.isUserAuthenticationFinished) null
+            else ValidationInfo("You are not yet logged in to Mendeley")
         }
     }
 }

--- a/src/nl/hannahsten/texifyidea/action/library/mendeley/AddMendeleyAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/library/mendeley/AddMendeleyAction.kt
@@ -35,10 +35,17 @@ class AddMendeleyAction : AddLibraryAction<MendeleyLibrary, AddMendeleyAction.Ad
         val project: Project,
     ) : AddLibDialogWrapper(MendeleyLibrary.NAME) {
 
-        private val browser = JBCefBrowser(MendeleyAuthenticator.authorizationUrl)
+        private val browser = try { JBCefBrowser(MendeleyAuthenticator.authorizationUrl) }
+        catch (e: Exception) {
+            throw Exception("Could not create Mendeley log in browser", e)
+        }
 
         init {
-            init()
+            try {
+                init()
+            } catch (e: Exception) {
+                throw Exception("Something went wrong in init{} block", e)
+            }
         }
 
         override fun createCenterPanel(): JComponent {

--- a/src/nl/hannahsten/texifyidea/action/library/mendeley/AddMendeleyAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/library/mendeley/AddMendeleyAction.kt
@@ -35,17 +35,10 @@ class AddMendeleyAction : AddLibraryAction<MendeleyLibrary, AddMendeleyAction.Ad
         val project: Project,
     ) : AddLibDialogWrapper(MendeleyLibrary.NAME) {
 
-        private val browser = try { JBCefBrowser(MendeleyAuthenticator.authorizationUrl) }
-        catch (e: Exception) {
-            throw Exception("Could not create Mendeley log in browser", e)
-        }
+        private val browser = JBCefBrowser(MendeleyAuthenticator.authorizationUrl)
 
         init {
-            try {
-                init()
-            } catch (e: Exception) {
-                throw Exception("Something went wrong in init{} block", e)
-            }
+            init()
         }
 
         override fun createCenterPanel(): JComponent {

--- a/src/nl/hannahsten/texifyidea/remotelibraries/mendeley/MendeleyAuthenticator.kt
+++ b/src/nl/hannahsten/texifyidea/remotelibraries/mendeley/MendeleyAuthenticator.kt
@@ -35,7 +35,10 @@ object MendeleyAuthenticator {
         createAuthenticationServer()
     }
 
-    private const val port = 8080
+    /**
+     * The port is fixed by Mendeley, so we choose a port that hopefully no one has anything running on.
+     */
+    private const val port = 59473
 
     private const val redirectPath = "/"
 
@@ -81,7 +84,8 @@ object MendeleyAuthenticator {
                     }
                 }
             }.start(false)
-        } catch (e: Exception) {
+        }
+        catch (e: Exception) {
             throw Exception("Something went wrong when initializing the Jetty Server", e)
         }
     }

--- a/src/nl/hannahsten/texifyidea/remotelibraries/mendeley/MendeleyAuthenticator.kt
+++ b/src/nl/hannahsten/texifyidea/remotelibraries/mendeley/MendeleyAuthenticator.kt
@@ -21,6 +21,8 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import nl.hannahsten.texifyidea.util.CredentialAttributes.Mendeley.refreshTokenAttributes
 import nl.hannahsten.texifyidea.util.CredentialAttributes.Mendeley.tokenAttributes
+import java.util.*
+import kotlin.properties.Delegates
 
 /**
  * Authorization via OAuth:
@@ -65,6 +67,8 @@ object MendeleyAuthenticator {
      */
     private lateinit var authenticationServer: JettyApplicationEngine
 
+    var isUserAuthenticationFinished = false
+
     /**
      * Authentication code that can be exchanged for an access token.
      */
@@ -76,10 +80,12 @@ object MendeleyAuthenticator {
      */
     private fun createAuthenticationServer() {
         try {
+            isUserAuthenticationFinished = false
             authenticationServer = embeddedServer(Jetty, port = port) {
                 routing {
                     get("/") {
                         this.call.respondText("You are now logged in to Mendeley. Click OK to continue.")
+                        isUserAuthenticationFinished = true
                         authenticationCode = call.parameters["code"]
                     }
                 }

--- a/src/nl/hannahsten/texifyidea/remotelibraries/mendeley/MendeleyAuthenticator.kt
+++ b/src/nl/hannahsten/texifyidea/remotelibraries/mendeley/MendeleyAuthenticator.kt
@@ -21,8 +21,6 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import nl.hannahsten.texifyidea.util.CredentialAttributes.Mendeley.refreshTokenAttributes
 import nl.hannahsten.texifyidea.util.CredentialAttributes.Mendeley.tokenAttributes
-import java.util.*
-import kotlin.properties.Delegates
 
 /**
  * Authorization via OAuth:

--- a/src/nl/hannahsten/texifyidea/remotelibraries/mendeley/MendeleyAuthenticator.kt
+++ b/src/nl/hannahsten/texifyidea/remotelibraries/mendeley/MendeleyAuthenticator.kt
@@ -72,14 +72,18 @@ object MendeleyAuthenticator {
      * gets the authorization code from the response.
      */
     private fun createAuthenticationServer() {
-        authenticationServer = embeddedServer(Jetty, port = port) {
-            routing {
-                get("/") {
-                    this.call.respondText("You are now logged in to Mendeley. Click OK to continue.")
-                    authenticationCode = call.parameters["code"]
+        try {
+            authenticationServer = embeddedServer(Jetty, port = port) {
+                routing {
+                    get("/") {
+                        this.call.respondText("You are now logged in to Mendeley. Click OK to continue.")
+                        authenticationCode = call.parameters["code"]
+                    }
                 }
-            }
-        }.start(false)
+            }.start(false)
+        } catch (e: Exception) {
+            throw Exception("Something went wrong when initializing the Jetty Server", e)
+        }
     }
 
     /**

--- a/src/nl/hannahsten/texifyidea/remotelibraries/mendeley/MendeleyCredentials.kt
+++ b/src/nl/hannahsten/texifyidea/remotelibraries/mendeley/MendeleyCredentials.kt
@@ -5,10 +5,10 @@ object MendeleyCredentials {
     /**
      * TeXiFy id to communicate with Mendeley.
      */
-    const val id = "13058"
+    const val id = "13334"
 
     /**
      * TeXiFy secret to communicate with Mendeley.
      */
-    const val secret = "\u0084BA\\U\u0086sTWx`MpuMT"
+    const val secret = "xBa\u0083o\u0082VvmSx`qes?"
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2595
Fix #2599

#### Summary of additions and changes

* Our Mendeley server (stupidly) used port 8080. When something was already running on that port the authentication server could not start and thus users could not login. I would have preferred to let Jetty automatically select a free port ([this is possible](https://youtrack.jetbrains.com/issue/KTOR-686)), but Mendeley requires us to configure a redirect url which must include the port when running on localhost.
* Added a warning when trying to OK the Mendeley login dialog while you are not logged in yet, see https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2599#issuecomment-1214429173

#### How to test this pull request

* Try to add Mendeley while you don't have something running on port 59473 :)
* "Accidentally" hit enter. It should be a bit less annoying than it was.