### PR TITLE
Re-enable ktlint indent rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,5 @@
 [*.{kt,kts}]
-# Enable indent once ktlint supports continuation indent again.
-disabled_rules = final-newline,no-wildcard-imports,parameter-list-wrapping,import-ordering,keyword-spacing,indent
+disabled_rules = final-newline,no-wildcard-imports,parameter-list-wrapping,import-ordering,keyword-spacing
 insert_final_newline = false
 
 ij_kotlin_else_on_new_line = true

--- a/src/nl/hannahsten/texifyidea/LatexErrorReportSubmitter.kt
+++ b/src/nl/hannahsten/texifyidea/LatexErrorReportSubmitter.kt
@@ -52,8 +52,8 @@ class LatexErrorReportSubmitter : ErrorReportSubmitter() {
                 .showInCenterOf(parentComponent)
 
             val message = "Please update your current version ($currentVersion) of TeXiFy to the latest version (${latestVersion.version}) before submitting,\n" +
-                    "to check if the error is already fixed. Go to Settings > Plugins to update.\n" +
-                    if (currentIdeaVersion < requiredIdeaVersion) "You first need to update your current IDE version ($currentIdeaVersion) to $requiredIdeaVersion or newer.\n" else ""
+                "to check if the error is already fixed. Go to Settings > Plugins to update.\n" +
+                if (currentIdeaVersion < requiredIdeaVersion) "You first need to update your current IDE version ($currentIdeaVersion) to $requiredIdeaVersion or newer.\n" else ""
 
             val result = MessageDialogBuilder.okCancel("Update TeXiFy", message)
                 .yesText("Cancel Submit") // Sort of the wrong way around, but it suggests to cancel this way

--- a/src/nl/hannahsten/texifyidea/TexifyIcons.kt
+++ b/src/nl/hannahsten/texifyidea/TexifyIcons.kt
@@ -14,446 +14,446 @@ object TexifyIcons {
      * Copyright (c) 2017 Hannah Schellekens
      */
     val LATEX_FILE_BIG = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/latex-file-big.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/latex-file-big.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017-2021 Hannah Schellekens
      */
     val LATEX_FILE = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/latex-file.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/latex-file.svg", TexifyIcons::class.java
     ) or IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/latex-file-alt.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/latex-file-alt.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val LATEX_FILE_SMALLER = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/latex-file_smaller.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/latex-file_smaller.svg", TexifyIcons::class.java
     ) or IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/latex-file-alt_smaller.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/latex-file-alt_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2019 Hannah Schellekens
      */
     val TIKZ_FILE = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/tikz-file.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/tikz-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val TIKZ_FILE_SMALLER = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/tikz-file_smaller.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/tikz-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val PDF_FILE = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/pdf-file.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/pdf-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val PDF_FILE_SMALLER = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/pdf-file_smaller.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/pdf-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DVI_FILE = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/dvi-file.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/dvi-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val DVI_FILE_SMALLER = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/dvi-file_smaller.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/dvi-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val BIBLIOGRAPHY_FILE = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/bibliography-file.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/bibliography-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val BIBLIOGRAPHY_FILE_SMALLER = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/bibliography-file_smaller.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/bibliography-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val CLASS_FILE = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/class-file.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/class-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val CLASS_FILE_SMALLER = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/class-file_smaller.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/class-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOCUMENTED_LATEX_SOURCE = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/doc-latex-file.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/doc-latex-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val DOCUMENTED_LATEX_SOURCE_SMALLER = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/doc-latex-file_smaller.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/doc-latex-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val STYLE_FILE = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/style-file.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/style-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val STYLE_FILE_SMALLER = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/style-file_smaller.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/style-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val FILE = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/file.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val FILE_SMALLER = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/file_smaller.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val TEMP_FILE = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/temp.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/temp.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val SYNCTEX_FILE = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/synctex-file.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/synctex-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val SYNCTEX_FILE_SMALLER = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/synctex-file_smaller.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/synctex-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val AUX_FILE = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/aux-file.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/aux-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val TABLE_OF_CONTENTS_FILE = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/toc-file.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/toc-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val BBL_FILE = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/bbl-file.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/bbl-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val TEXT_FILE = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/text-file.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/text-file.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val TEXT_FILE_SMALLER = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/text-file_smaller.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/text-file_smaller.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val BUILD = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/build.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/build.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val BUILD_BIB = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/bib-build.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/bib-build.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val LATEX_MODULE = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/latex-module.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/latex-module.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_LATEX = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/dot-tex.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/dot-tex.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_COMMAND = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/dot-cmd.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/dot-cmd.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_LABEL = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/dot-lbl.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/dot-lbl.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_BIB = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/dot-bib.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/dot-bib.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_INCLUDE = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/dot-incl.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/dot-incl.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_ENVIRONMENT = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/dot-env.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/dot-env.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2018 Hannah Schellekens
      */
     val DOT_CLASS = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/dot-cls.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/dot-cls.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_NUMBER = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/dot-num.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/dot-num.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_CHAPTER = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/dot-chap.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/dot-chap.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_PART = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/dot-part.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/dot-part.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_SECTION = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/dot-sec.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/dot-sec.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_SUBSECTION = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/dot-subsec.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/dot-subsec.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_SUBSUBSECTION = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/dot-subsubsec.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/dot-subsubsec.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_PARAGRAPH = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/dot-par.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/dot-par.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val DOT_SUBPARAGRAPH = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/dot-subpar.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/dot-subpar.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val FONT_BOLD = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/font-bold.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/font-bold.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val FONT_ITALICS = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/font-italics.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/font-italics.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val FONT_UNDERLINE = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/font-underline.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/font-underline.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val FONT_OVERLINE = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/font-overline.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/font-overline.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val FONT_SMALLCAPS = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/font-smallcaps.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/font-smallcaps.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val FONT_TYPEWRITER = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/font-mono.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/font-mono.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val FONT_STRIKETHROUGH = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/font-strike.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/font-strike.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val FONT_SLANTED = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/font-slanted.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/font-slanted.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val SUMATRA = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/sumatra.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/sumatra.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val WORD_COUNT = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/word-count.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/word-count.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val TOGGLE_STAR = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/toggle-star.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/toggle-star.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val STATS = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/stats.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/stats.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2017 Hannah Schellekens
      */
     val RIGHT = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/right.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/right.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2018 Hannah Schellekens
      */
     val EQUATION_PREVIEW = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/equation-preview.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/equation-preview.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2019 Hannah Schellekens
      */
     val TIKZ_PREVIEW = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/tikz-preview.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/tikz-preview.svg", TexifyIcons::class.java
     )
 
     /**
      * Copyright (c) 2021 Hannah Schellekens
      */
     val SYMBOLS = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/symbols.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/symbols.svg", TexifyIcons::class.java
     )
 
     // From IntelliJ
     val STRING = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/string.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/string.svg", TexifyIcons::class.java
     )
 
     // From IntelliJ (modified)
     val KEY_REQUIRED = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/key-required.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/key-required.svg", TexifyIcons::class.java
     )
 
     // From IntelliJ (modified)
     val KEY_USER_DEFINED = IconLoader.getIcon(
-            "/nl/hannahsten/texifyidea/icons/key-user.svg", TexifyIcons::class.java
+        "/nl/hannahsten/texifyidea/icons/key-user.svg", TexifyIcons::class.java
     )
 
     /**

--- a/src/nl/hannahsten/texifyidea/action/DeleteGeneratedFiles.kt
+++ b/src/nl/hannahsten/texifyidea/action/DeleteGeneratedFiles.kt
@@ -41,7 +41,7 @@ class DeleteGeneratedFiles : AnAction() {
 
         val result = showOkCancelDialog(
             "Delete Auxiliary and Output Files",
-        "Do you really want to delete all files in LaTeX output directories, " +
+            "Do you really want to delete all files in LaTeX output directories, " +
                 "and all auxiliary and generated files? \n" +
                 "All files in the following output directories will be deleted: \n" +
                 customOutput.mapNotNull { it?.path }.joinToString { "  $it\n" } +

--- a/src/nl/hannahsten/texifyidea/action/analysis/WordCountAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/analysis/WordCountAction.kt
@@ -138,10 +138,10 @@ open class WordCountAction : AnAction(
             .filter { it.name.endsWith(".tex", ignoreCase = true) }
         val allNormalText = fileSet.flatMap { it.childrenOfType(LatexNormalText::class) }
         val parameterText = fileSet.flatMap { it.childrenOfType(LatexParameterText::class) }
-                .filter {
-                    val commandText = it.command?.text ?: return@filter false
-                    return@filter commandText !in IGNORE_COMMANDS
-                }
+            .filter {
+                val commandText = it.command?.text ?: return@filter false
+                return@filter commandText !in IGNORE_COMMANDS
+            }
 
         val bibliographies = baseFile.childrenOfType(LatexEnvironment::class)
             .filter {

--- a/src/nl/hannahsten/texifyidea/action/debug/GenerateSymbolImagesAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/debug/GenerateSymbolImagesAction.kt
@@ -12,16 +12,16 @@ import nl.hannahsten.texifyidea.util.toastInfo
  * @author Hannah Schellekens
  */
 open class GenerateSymbolImagesAction : AnAction(
-        "Generate Symbol Images",
-        "(Development) Generates the symbol images for the symbol view",
-        null
+    "Generate Symbol Images",
+    "(Development) Generates the symbol images for the symbol view",
+    null
 ) {
 
     override fun actionPerformed(event: AnActionEvent) {
         val project = event.getData(PlatformDataKeys.PROJECT) ?: return
 
         val fileDescriptor = FileChooserDescriptor(false, true, false, false, false, false)
-                .withTitle("Select symbols folder...")
+            .withTitle("Select symbols folder...")
 
         FileChooser.chooseFile(fileDescriptor, project, null) {
             generateSymbolImages(it.path)

--- a/src/nl/hannahsten/texifyidea/action/wizard/graphic/InsertGraphicData.kt
+++ b/src/nl/hannahsten/texifyidea/action/wizard/graphic/InsertGraphicData.kt
@@ -7,19 +7,19 @@ import nl.hannahsten.texifyidea.lang.graphic.FigureLocation
  * @author Hannah Schellekens
  */
 data class InsertGraphicData(
-        val filePath: String,
-        val relativePath: Boolean,
-        val options: String,
-        val center: Boolean,
-        val placeInFigure: Boolean,
-        /** `null` when [placeInFigure] is `false`, not `null` otherwise */
-        val captionLocation: CaptionLocation? = null,
-        /** `null` when [placeInFigure] is `false`, not `null` otherwise */
-        val caption: String? = null,
-        /** `null` when [placeInFigure] is `false`, not `null` otherwise */
-        val shortCaption: String? = null,
-        /** `null` when [placeInFigure] is `false`, not `null` otherwise */
-        val label: String? = null,
-        /** `null` when [placeInFigure] is `false`, not `null` otherwise */
-        val positions: List<FigureLocation>? = null
+    val filePath: String,
+    val relativePath: Boolean,
+    val options: String,
+    val center: Boolean,
+    val placeInFigure: Boolean,
+    /** `null` when [placeInFigure] is `false`, not `null` otherwise */
+    val captionLocation: CaptionLocation? = null,
+    /** `null` when [placeInFigure] is `false`, not `null` otherwise */
+    val caption: String? = null,
+    /** `null` when [placeInFigure] is `false`, not `null` otherwise */
+    val shortCaption: String? = null,
+    /** `null` when [placeInFigure] is `false`, not `null` otherwise */
+    val label: String? = null,
+    /** `null` when [placeInFigure] is `false`, not `null` otherwise */
+    val positions: List<FigureLocation>? = null
 )

--- a/src/nl/hannahsten/texifyidea/action/wizard/graphic/InsertGraphicWizardDialogWrapper.kt
+++ b/src/nl/hannahsten/texifyidea/action/wizard/graphic/InsertGraphicWizardDialogWrapper.kt
@@ -12,19 +12,17 @@ import com.intellij.ui.components.fields.ExpandableTextField
 import com.intellij.ui.components.panels.HorizontalLayout
 import nl.hannahsten.texifyidea.lang.graphic.CaptionLocation
 import nl.hannahsten.texifyidea.lang.graphic.FigureLocation
-import nl.hannahsten.texifyidea.util.*
 import nl.hannahsten.texifyidea.util.addKeyReleasedListener
+import nl.hannahsten.texifyidea.util.addLabeledComponent
 import nl.hannahsten.texifyidea.util.addTextChangeListener
 import nl.hannahsten.texifyidea.util.magic.FileMagic
 import nl.hannahsten.texifyidea.util.setInputFilter
-import nl.hannahsten.texifyidea.util.*
 import java.awt.Dimension
 import java.util.*
 import javax.swing.Box
 import javax.swing.BoxLayout
 import javax.swing.JPanel
 import javax.swing.JTextField
-import kotlin.collections.LinkedHashMap
 
 /**
  * @author Hannah Schellekens
@@ -36,11 +34,13 @@ open class InsertGraphicWizardDialogWrapper(val initialFilePath: String = "") : 
      */
     private val txtGraphicFile = TextFieldWithBrowseButton().apply {
         text = initialFilePath
-        addBrowseFolderListener(TextBrowseFolderListener(
+        addBrowseFolderListener(
+            TextBrowseFolderListener(
                 FileChooserDescriptor(true, false, false, false, false, false)
-                        .withFileFilter { vf -> vf.extension?.lowercase(Locale.getDefault()) in FileMagic.graphicFileExtensions }
-                        .withTitle("Select graphics file...")
-        ))
+                    .withFileFilter { vf -> vf.extension?.lowercase(Locale.getDefault()) in FileMagic.graphicFileExtensions }
+                    .withTitle("Select graphics file...")
+            )
+        )
     }
 
     /**
@@ -135,23 +135,23 @@ open class InsertGraphicWizardDialogWrapper(val initialFilePath: String = "") : 
      * The check boxes for the figure locations.
      */
     private val checkPosition = FigureLocation.values().asSequence()
-            .map { location ->
-                location.symbol to JBCheckBox(location.description).apply {
-                    addActionListener { event ->
-                        val source = event.source as? JBCheckBox ?: error("Not a JBCheckBox!")
-                        // Add symbol if selected.
-                        if (source.isSelected && txtPosition.text.contains(location.symbol).not()) {
-                            txtPosition.text = txtPosition.text + location.symbol
-                        }
-                        // Remove if deselected.
-                        else {
-                            txtPosition.text = txtPosition.text.replace(location.symbol, "")
-                        }
+        .map { location ->
+            location.symbol to JBCheckBox(location.description).apply {
+                addActionListener { event ->
+                    val source = event.source as? JBCheckBox ?: error("Not a JBCheckBox!")
+                    // Add symbol if selected.
+                    if (source.isSelected && txtPosition.text.contains(location.symbol).not()) {
+                        txtPosition.text = txtPosition.text + location.symbol
+                    }
+                    // Remove if deselected.
+                    else {
+                        txtPosition.text = txtPosition.text.replace(location.symbol, "")
                     }
                 }
             }
-            // Use linked hash map to preserve order.
-            .toMap(LinkedHashMap())
+        }
+        // Use linked hash map to preserve order.
+        .toMap(LinkedHashMap())
 
     init {
         super.init()
@@ -162,18 +162,18 @@ open class InsertGraphicWizardDialogWrapper(val initialFilePath: String = "") : 
      * Get the data that has been entered into the UI.
      */
     fun extractData() = InsertGraphicData(
-            filePath = txtGraphicFile.text.trim(),
-            relativePath = checkRelativePath.isSelected,
-            options = txtCustomOptions.text.trim(),
-            center = checkCenterHorizontally.isSelected,
-            placeInFigure = checkPlaceInFigure.isSelected,
-            captionLocation = whenFigure { cboxCaptionLocation.selectedItem as CaptionLocation },
-            caption = whenFigure { txtLongCaption.text.trim() },
-            shortCaption = whenFigure { txtShortCaption.text.trim() },
-            label = whenFigure { txtLabel.text.trim() },
-            positions = whenFigure {
-                txtPosition.text.trim().mapNotNull { FigureLocation.bySymbol(it.toString()) }
-            }
+        filePath = txtGraphicFile.text.trim(),
+        relativePath = checkRelativePath.isSelected,
+        options = txtCustomOptions.text.trim(),
+        center = checkCenterHorizontally.isSelected,
+        placeInFigure = checkPlaceInFigure.isSelected,
+        captionLocation = whenFigure { cboxCaptionLocation.selectedItem as CaptionLocation },
+        caption = whenFigure { txtLongCaption.text.trim() },
+        shortCaption = whenFigure { txtShortCaption.text.trim() },
+        label = whenFigure { txtLabel.text.trim() },
+        positions = whenFigure {
+            txtPosition.text.trim().mapNotNull { FigureLocation.bySymbol(it.toString()) }
+        }
     )
 
     /**
@@ -264,7 +264,7 @@ open class InsertGraphicWizardDialogWrapper(val initialFilePath: String = "") : 
         // Update
         if (txtCustomOptions.text.contains("$fieldName=")) {
             txtCustomOptions.text = txtCustomOptions.text
-                    .replace(Regex("$fieldName=[^,]*"), Regex.escapeReplacement("$fieldName=$text"))
+                .replace(Regex("$fieldName=[^,]*"), Regex.escapeReplacement("$fieldName=$text"))
         }
         // Nothing yet, set width property.
         else if (txtCustomOptions.text.isBlank()) {

--- a/src/nl/hannahsten/texifyidea/action/wizard/ipsum/InsertDummyTextAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/wizard/ipsum/InsertDummyTextAction.kt
@@ -64,8 +64,10 @@ open class InsertDummyTextAction : AnAction() {
 
         // When itemize/enumerate/description is selected the level can be selected as well when larger than 1.
         val type = data.blindtextType
-        if ((type == DummyTextData.BlindtextType.ITEMIZE || type == DummyTextData.BlindtextType.ENUMERATE ||
-                    type == DummyTextData.BlindtextType.DESCRIPTION) && data.blindtextLevel > 1
+        if ((
+            type == DummyTextData.BlindtextType.ITEMIZE || type == DummyTextData.BlindtextType.ENUMERATE ||
+                type == DummyTextData.BlindtextType.DESCRIPTION
+            ) && data.blindtextLevel > 1
         ) {
             val command = "\\" + type.commandNoSlash.replace("list", "listlist[${data.blindtextLevel}]")
             insertAtCaretAndMove(command)

--- a/src/nl/hannahsten/texifyidea/action/wizard/ipsum/InsertDummyTextDialogWrapper.kt
+++ b/src/nl/hannahsten/texifyidea/action/wizard/ipsum/InsertDummyTextDialogWrapper.kt
@@ -191,8 +191,8 @@ open class InsertDummyTextDialogWrapper : DialogWrapper(true) {
 
     private fun updateUi() {
         intBlindLevel.isEnabled = cboxBlindType.item == DummyTextData.BlindtextType.ITEMIZE ||
-                cboxBlindType.item == DummyTextData.BlindtextType.DESCRIPTION ||
-                cboxBlindType.item == DummyTextData.BlindtextType.ENUMERATE
+            cboxBlindType.item == DummyTextData.BlindtextType.DESCRIPTION ||
+            cboxBlindType.item == DummyTextData.BlindtextType.ENUMERATE
 
         intBlindRepetitions.isEnabled = cboxBlindType.item == DummyTextData.BlindtextType.PARAGRAPH
         intBlindParagraphs.isEnabled = cboxBlindType.item == DummyTextData.BlindtextType.PARAGRAPH

--- a/src/nl/hannahsten/texifyidea/action/wizard/table/LatexTableWizardAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/wizard/table/LatexTableWizardAction.kt
@@ -45,11 +45,11 @@ class LatexTableWizardAction : AnAction() {
 
             // Insert the booktabs package.
             WriteCommandAction.runWriteCommandAction(
-                    project,
-                    "Insert Table",
-                    "LaTeX",
-                    Runnable { file.psiFile(project)?.insertUsepackage(LatexPackage.BOOKTABS) },
-                    file.psiFile(project)
+                project,
+                "Insert Table",
+                "LaTeX",
+                Runnable { file.psiFile(project)?.insertUsepackage(LatexPackage.BOOKTABS) },
+                file.psiFile(project)
             )
         }
     }
@@ -85,17 +85,17 @@ class LatexTableWizardAction : AnAction() {
         fun processTableContent(indent: String): String {
             return with(tableInformation) {
                 val headers = tableModel.getColumnNames()
-                        .joinToString(
-                                prefix = "$indent\\toprule\n$indent",
-                                separator = " & ",
-                                postfix = " \\\\\n$indent\\midrule\n"
-                        ) { "\\textbf{$it}" }
+                    .joinToString(
+                        prefix = "$indent\\toprule\n$indent",
+                        separator = " & ",
+                        postfix = " \\\\\n$indent\\midrule\n"
+                    ) { "\\textbf{$it}" }
 
                 val rows = tableModel.dataVector.joinToString(separator = "\n", postfix = "\n$indent\\bottomrule\n") { row ->
                     (row as Vector<*>).joinToString(
-                            prefix = indent,
-                            separator = " & ",
-                            postfix = " \\\\"
+                        prefix = indent,
+                        separator = " & ",
+                        postfix = " \\\\"
                     ) {
                         // Enclose with $ if the type of this column is math.
                         val index = row.indexOf(it)
@@ -111,18 +111,18 @@ class LatexTableWizardAction : AnAction() {
         // (this includes the caption and label).
         return with(tableInformation) {
             val openTableCommand = "\\begin{table}\n" +
-                    "$lineIndent$tabIndent\\centering\n" +
-                    // Everything within the table command gets an extra indent.
-                    "$lineIndent$tabIndent\\begin{tabular}{${columnTypes.toLatexColumnFormatters()}}\n"
+                "$lineIndent$tabIndent\\centering\n" +
+                // Everything within the table command gets an extra indent.
+                "$lineIndent$tabIndent\\begin{tabular}{${columnTypes.toLatexColumnFormatters()}}\n"
 
             // The content has to be indented once more.
             val content = processTableContent(indent = lineIndent + tabIndent + tabIndent)
 
             val closeTableCommand = "$lineIndent$tabIndent\\end{tabular}\n" +
-                    "$lineIndent$tabIndent\\caption{$caption}\n" +
-                    "$lineIndent$tabIndent\\label{$label}\n" +
-                    "$lineIndent\\end{table}\n" +
-                    lineIndent // Indentation on the last line so we can continue typing there.
+                "$lineIndent$tabIndent\\caption{$caption}\n" +
+                "$lineIndent$tabIndent\\label{$label}\n" +
+                "$lineIndent\\end{table}\n" +
+                lineIndent // Indentation on the last line so we can continue typing there.
 
             openTableCommand + content + closeTableCommand
         }

--- a/src/nl/hannahsten/texifyidea/action/wizard/table/TableCreationDialogWrapper.kt
+++ b/src/nl/hannahsten/texifyidea/action/wizard/table/TableCreationDialogWrapper.kt
@@ -28,8 +28,8 @@ import javax.swing.*
  * @author Abby Berkers
  */
 open class TableCreationDialogWrapper(
-        initialColumnTypes: List<ColumnType>? = null,
-        initialTableModel: TableCreationTableModel? = null
+    initialColumnTypes: List<ColumnType>? = null,
+    initialTableModel: TableCreationTableModel? = null
 ) : DialogWrapper(true) {
 
     /**
@@ -113,33 +113,38 @@ open class TableCreationDialogWrapper(
         add(createTablePanelContainer(), BorderLayout.CENTER)
 
         // Create labels.
-        add(JPanel(VerticalLayout(8)).apply {
-            addLabeledComponent(txtCaption, "Caption:", labelWidth = 64, leftPadding = 0)
-            addLabeledComponent(txtReference, "Label:", labelWidth = 64, leftPadding = 0)
-        }, BorderLayout.SOUTH)
+        add(
+            JPanel(VerticalLayout(8)).apply {
+                addLabeledComponent(txtCaption, "Caption:", labelWidth = 64, leftPadding = 0)
+                addLabeledComponent(txtReference, "Label:", labelWidth = 64, leftPadding = 0)
+            },
+            BorderLayout.SOUTH
+        )
     }
 
     /**
      * Generates table and the toolbaar buttons.
      */
     private fun createToolbarDecorator() = ToolbarDecorator.createDecorator(table)
-            .setAddAction {
-                TableCreationEditColumnDialog(
-                        { title, columnType, _ -> addTableColumn(title, columnType) },
-                        tableModel.columnCount
-                )
-            }
-            .setAddActionName("Add Column")
-            .setAddIcon(addText(IconUtil.getAddIcon(), "C"))
-            .addExtraAction(getRemoveColumnActionButton())
-            .addExtraAction(getEditColumnActionButton())
-            .addExtraAction(getAddRowActionButton())
-            .addExtraAction(getRemoveRowActionButton().apply {
+        .setAddAction {
+            TableCreationEditColumnDialog(
+                { title, columnType, _ -> addTableColumn(title, columnType) },
+                tableModel.columnCount
+            )
+        }
+        .setAddActionName("Add Column")
+        .setAddIcon(addText(IconUtil.getAddIcon(), "C"))
+        .addExtraAction(getRemoveColumnActionButton())
+        .addExtraAction(getEditColumnActionButton())
+        .addExtraAction(getAddRowActionButton())
+        .addExtraAction(
+            getRemoveRowActionButton().apply {
                 shortcut = ShortcutSet {
                     arrayOf(KeyboardShortcut(KeyStroke.getKeyStroke("DELETE"), null))
                 }
-            })
-            .createPanel()
+            }
+        )
+        .createPanel()
 
     /**
      * Panel containing the table and its controls.
@@ -191,7 +196,7 @@ open class TableCreationDialogWrapper(
 
                 // When we're in the last column of the last row, add a new row before calling the usual action.
                 if (table.selectionModel.leadSelectionIndex == table.rowCount - 1 &&
-                        table.columnModel.selectionModel.leadSelectionIndex == table.columnCount - 1
+                    table.columnModel.selectionModel.leadSelectionIndex == table.columnCount - 1
                 ) {
                     tableModel.addEmptyRow()
                 }
@@ -241,10 +246,10 @@ open class TableCreationDialogWrapper(
      */
     override fun doValidate(): ValidationInfo? {
         tableInformation = TableInformation(
-                tableModel,
-                columnTypes,
-                txtCaption.text.trim(),
-                txtReference.text.trim()
+            tableModel,
+            columnTypes,
+            txtCaption.text.trim(),
+            txtReference.text.trim()
         )
         return null
     }
@@ -257,10 +262,10 @@ open class TableCreationDialogWrapper(
             override fun actionPerformed(e: AnActionEvent) {
                 if (table.selectedColumn >= 0) {
                     TableCreationEditColumnDialog(
-                            { title, columnType, columnIndex -> editTableColumn(title, columnType, columnIndex) },
-                            table.selectedColumn,
-                            table.getColumnName(table.selectedColumn),
-                            columnTypes[table.selectedColumn]
+                        { title, columnType, columnIndex -> editTableColumn(title, columnType, columnIndex) },
+                        table.selectedColumn,
+                        table.getColumnName(table.selectedColumn),
+                        columnTypes[table.selectedColumn]
                     )
                 }
             }

--- a/src/nl/hannahsten/texifyidea/action/wizard/table/TableCreationEditColumnDialog.kt
+++ b/src/nl/hannahsten/texifyidea/action/wizard/table/TableCreationEditColumnDialog.kt
@@ -15,26 +15,26 @@ import javax.swing.JPanel
  */
 class TableCreationEditColumnDialog(
 
-        /**
-         * The function to execute when clicking the OK button.
-         */
-        private val onOkFunction: (title: String, columnType: ColumnType, columnIndex: Int) -> Unit,
+    /**
+     * The function to execute when clicking the OK button.
+     */
+    private val onOkFunction: (title: String, columnType: ColumnType, columnIndex: Int) -> Unit,
 
-        /**
-         * The index of the column being edited.
-         */
-        private val editingColumn: Int,
+    /**
+     * The index of the column being edited.
+     */
+    private val editingColumn: Int,
 
-        /**
-         * The name of the column that is being edited. Default is the empty string, the title of a column that does
-         * not yet exist.
-         */
-        private val columnName: String = "",
+    /**
+     * The name of the column that is being edited. Default is the empty string, the title of a column that does
+     * not yet exist.
+     */
+    private val columnName: String = "",
 
-        /**
-         * The [ColumnType] of the column that is being edited. Default is a text column.
-         */
-        private val columnType: ColumnType = ColumnType.TEXT_COLUMN
+    /**
+     * The [ColumnType] of the column that is being edited. Default is a text column.
+     */
+    private val columnType: ColumnType = ColumnType.TEXT_COLUMN
 ) {
 
     init {

--- a/src/nl/hannahsten/texifyidea/action/wizard/table/TableInformation.kt
+++ b/src/nl/hannahsten/texifyidea/action/wizard/table/TableInformation.kt
@@ -7,24 +7,24 @@ package nl.hannahsten.texifyidea.action.wizard.table
  */
 data class TableInformation(
 
-        /**
-         * Contains all information about the contents of the table.
-         * That is, the column names and the table entries.
-         */
-        val tableModel: TableCreationTableModel,
+    /**
+     * Contains all information about the contents of the table.
+     * That is, the column names and the table entries.
+     */
+    val tableModel: TableCreationTableModel,
 
-        /**
-         * Contains the type of each column.
-         */
-        val columnTypes: List<ColumnType>,
+    /**
+     * Contains the type of each column.
+     */
+    val columnTypes: List<ColumnType>,
 
-        /**
-         * Contains the caption to go along with the table.
-         */
-        val caption: String,
+    /**
+     * Contains the caption to go along with the table.
+     */
+    val caption: String,
 
-        /**
-         * Contains the label that is to be used to reference the table.
-         */
-        val label: String
+    /**
+     * Contains the label that is to be used to reference the table.
+     */
+    val label: String
 )

--- a/src/nl/hannahsten/texifyidea/completion/LatexBibliographyReferenceProvider.kt
+++ b/src/nl/hannahsten/texifyidea/completion/LatexBibliographyReferenceProvider.kt
@@ -27,12 +27,12 @@ object LatexBibliographyReferenceProvider : CompletionProvider<CompletionParamet
             .filter { it.id !in localEntries.filterIsInstance<BibtexEntry>().map { bib -> bib.id } }
 
         val lookupItems = localEntries.mapNotNull { bibtexEntry ->
-                when (bibtexEntry) {
-                    is BibtexEntry -> createLookupElementFromBibtexEntry(bibtexEntry)
-                    is LatexCommands -> createLookupElementFromLatexCommand(bibtexEntry)
-                    else -> null
-                }
+            when (bibtexEntry) {
+                is BibtexEntry -> createLookupElementFromBibtexEntry(bibtexEntry)
+                is LatexCommands -> createLookupElementFromLatexCommand(bibtexEntry)
+                else -> null
             }
+        }
 
         val lookupItemsFromRemote = remoteEntries.map { createLookupElementFromBibtexEntry(it, true) }
 

--- a/src/nl/hannahsten/texifyidea/completion/LatexCommandsAndEnvironmentsCompletionProvider.kt
+++ b/src/nl/hannahsten/texifyidea/completion/LatexCommandsAndEnvironmentsCompletionProvider.kt
@@ -269,10 +269,10 @@ class LatexCommandsAndEnvironmentsCompletionProvider internal constructor(privat
                 }
 
                 (if (optional.size == 2) "[args]" else "") +
-                        if (requiredParameterCount == 1) "{param}"
-                        // Number the required parameters so a toSet call won't merge them. This way the
-                        // user can keep them apart as well.
-                        else (1..requiredParameterCount).joinToString("") { "{param$it}" }
+                    if (requiredParameterCount == 1) "{param}"
+                    // Number the required parameters so a toSet call won't merge them. This way the
+                    // user can keep them apart as well.
+                    else (1..requiredParameterCount).joinToString("") { "{param$it}" }
             }
 
             "\\DeclarePairedDelimiter" -> "{param}"

--- a/src/nl/hannahsten/texifyidea/completion/LatexEnvironmentProvider.kt
+++ b/src/nl/hannahsten/texifyidea/completion/LatexEnvironmentProvider.kt
@@ -26,7 +26,8 @@ object LatexEnvironmentProvider {
 
         val usesTexlive = LatexCommandsAndEnvironmentsCompletionProvider.isTexliveAvailable
         val packagesInProject = if (!usesTexlive) emptyList() else includedPackages(LatexIncludesIndex.getItems(project), project).plus(
-            LatexPackage.DEFAULT)
+            LatexPackage.DEFAULT
+        )
 
         result.addAllElements(
             FileBasedIndex.getInstance().getAllKeys(LatexExternalEnvironmentIndex.id, project)
@@ -34,8 +35,8 @@ object LatexEnvironmentProvider {
                     Environment.lookupInIndex(envText, project)
                         .filter { if (usesTexlive) it.dependency in packagesInProject else true }
                         .map { env ->
-                        createEnvironmentLookupElement(env)
-                    }
+                            createEnvironmentLookupElement(env)
+                        }
                 }
         )
     }

--- a/src/nl/hannahsten/texifyidea/editor/ImagePasteProvider.kt
+++ b/src/nl/hannahsten/texifyidea/editor/ImagePasteProvider.kt
@@ -55,7 +55,7 @@ open class ImagePasteProvider : PasteProvider {
 
         val transferable = dataContext.getData(PasteAction.TRANSFERABLE_PROVIDER)?.produce() ?: return false
         return SaveImageFromClipboardDialog.supportsImage(transferable) ||
-                transferable.isDataFlavorSupported(DataFlavor.javaFileListFlavor)
+            transferable.isDataFlavorSupported(DataFlavor.javaFileListFlavor)
     }
 
     override fun isPasteEnabled(dataContext: DataContext) = isPastePossible(dataContext)

--- a/src/nl/hannahsten/texifyidea/editor/TablePasteProvider.kt
+++ b/src/nl/hannahsten/texifyidea/editor/TablePasteProvider.kt
@@ -86,8 +86,8 @@ open class TablePasteProvider : PasteProvider {
         }
 
         return TableCreationDialogWrapper(
-                columnTypes,
-                TableCreationTableModel(content, header)
+            columnTypes,
+            TableCreationTableModel(content, header)
         )
     }
 
@@ -113,8 +113,8 @@ open class TablePasteProvider : PasteProvider {
         }
 
         return prefix
-                .append(text())
-                .append(suffix.toString())
-                .toString()
+            .append(text())
+            .append(suffix.toString())
+            .toString()
     }
 }

--- a/src/nl/hannahsten/texifyidea/file/SaveImageFromClipboardDialog.kt
+++ b/src/nl/hannahsten/texifyidea/file/SaveImageFromClipboardDialog.kt
@@ -32,22 +32,22 @@ import javax.swing.border.EmptyBorder
  */
 class SaveImageFromClipboardDialog(
 
-        /**
-         * The current project.
-         */
-        val project: Project,
+    /**
+     * The current project.
+     */
+    val project: Project,
 
-        /**
-         * The transferable data from the clipboard.
-         * Must support the image data flavor [DataFlavor.imageFlavor].
-         */
-        private val transferable: Transferable,
+    /**
+     * The transferable data from the clipboard.
+     * Must support the image data flavor [DataFlavor.imageFlavor].
+     */
+    private val transferable: Transferable,
 
-        /**
-         * The function to execute when the dialog is succesfully closed.
-         * Does not execute when cancelled.
-         */
-        onOkFunction: (SaveImageFromClipboardDialog) -> Unit
+    /**
+     * The function to execute when the dialog is succesfully closed.
+     * Does not execute when cancelled.
+     */
+    onOkFunction: (SaveImageFromClipboardDialog) -> Unit
 ) : DialogWrapper(true) {
 
     companion object {
@@ -233,13 +233,16 @@ class SaveImageFromClipboardDialog(
     /**
      * Adds the panel that shows information about the pasted image.
      */
-    private fun JPanel.addImageMetaPanel() = add(JPanel(BorderLayout(16, 16)).apply {
-        border = EmptyBorder(16, 16, 16, 16)
+    private fun JPanel.addImageMetaPanel() = add(
+        JPanel(BorderLayout(16, 16)).apply {
+            border = EmptyBorder(16, 16, 16, 16)
 
-        add(imgPreview, BorderLayout.WEST)
+            add(imgPreview, BorderLayout.WEST)
 
-        // Info labels.
-        add(JBLabel("""<html>
+            // Info labels.
+            add(
+                JBLabel(
+                    """<html>
             <table>
                 <tr>
                     <td><b>Size:</b> </td>
@@ -254,8 +257,11 @@ class SaveImageFromClipboardDialog(
                     <td>${imageName ?: "unknown"}</td>
                 </tr>
             </table>
-        </html>"""))
-    })
+        </html>"""
+                )
+            )
+        }
+    )
 
     /**
      * Adds the user input controls to enter the image information.

--- a/src/nl/hannahsten/texifyidea/formatting/LatexBlock.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexBlock.kt
@@ -141,17 +141,21 @@ class LatexBlock(
 
     override fun getIndent(): Indent? {
         val shouldIndentDocumentEnvironment = CodeStyle.getCustomSettings(node.psi.containingFile, LatexCodeStyleSettings::class.java).INDENT_DOCUMENT_ENVIRONMENT
-        val shouldIndentEnvironment = myNode.elementType === LatexTypes.ENVIRONMENT_CONTENT && ((myNode.psi as LatexEnvironmentContent)
-            .firstParentOfType(LatexEnvironment::class)
-            ?.firstChildOfType(LatexBeginCommand::class)
-            ?.firstChildOfType(LatexParameterText::class)?.text != "document" || shouldIndentDocumentEnvironment)
+        val shouldIndentEnvironment = myNode.elementType === LatexTypes.ENVIRONMENT_CONTENT && (
+            (myNode.psi as LatexEnvironmentContent)
+                .firstParentOfType(LatexEnvironment::class)
+                ?.firstChildOfType(LatexBeginCommand::class)
+                ?.firstChildOfType(LatexParameterText::class)?.text != "document" || shouldIndentDocumentEnvironment
+            )
 
         if (shouldIndentEnvironment || myNode.elementType === LatexTypes.PSEUDOCODE_BLOCK_CONTENT ||
             // Fix for leading comments inside an environment, because somehow they are not placed inside environments.
             // Note that this does not help to insert the indentation, but at least the indent is not removed
             // when formatting.
-            (myNode.elementType === LatexTypes.COMMENT_TOKEN &&
-                myNode.treeParent?.elementType === LatexTypes.ENVIRONMENT)
+            (
+                myNode.elementType === LatexTypes.COMMENT_TOKEN &&
+                    myNode.treeParent?.elementType === LatexTypes.ENVIRONMENT
+                )
         ) {
             return Indent.getNormalIndent(true)
         }
@@ -169,10 +173,14 @@ class LatexBlock(
             myNode.elementType === LatexTypes.OPTIONAL_PARAM_CONTENT ||
             myNode.elementType === LatexTypes.STRICT_KEYVAL_PAIR ||
             myNode.elementType === LatexTypes.KEYVAL_PAIR ||
-            (myNode.elementType !== LatexTypes.CLOSE_BRACE &&
-                    myNode.treeParent?.elementType === LatexTypes.GROUP) ||
-            (myNode.elementType !== LatexTypes.CLOSE_BRACE &&
-                    myNode.treeParent?.elementType === LatexTypes.PARAMETER_GROUP)
+            (
+                myNode.elementType !== LatexTypes.CLOSE_BRACE &&
+                    myNode.treeParent?.elementType === LatexTypes.GROUP
+                ) ||
+            (
+                myNode.elementType !== LatexTypes.CLOSE_BRACE &&
+                    myNode.treeParent?.elementType === LatexTypes.PARAMETER_GROUP
+                )
         ) {
             return Indent.getNormalIndent(false)
         }

--- a/src/nl/hannahsten/texifyidea/formatting/LatexSpacingRules.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexSpacingRules.kt
@@ -60,7 +60,8 @@ fun createSpacingBuilder(settings: CodeStyleSettings): TexSpacingBuilder {
                 if (right.node?.psi?.firstChildOfType(LatexCommands::class)?.name?.lowercase(Locale.getDefault()) in setOf(
                         "\\state",
                         "\\statex"
-                    ) && parent.node?.psi?.inDirectEnvironment(EnvironmentMagic.algorithmEnvironments) == true) {
+                    ) && parent.node?.psi?.inDirectEnvironment(EnvironmentMagic.algorithmEnvironments) == true
+                ) {
                     return@customRule Spacing.createSpacing(0, 1, 1, latexCommonSettings.KEEP_LINE_BREAKS, latexCommonSettings.KEEP_BLANK_LINES_IN_CODE)
                 }
 
@@ -100,7 +101,8 @@ fun createSpacingBuilder(settings: CodeStyleSettings): TexSpacingBuilder {
                 val rightText = right.node?.text
                 LatexCodeStyleSettings.blankLinesOptions.forEach {
                     if (rightText?.matches(Regex("\\\\${it.value.trimStart('\\')}\\{.*}")) == true &&
-                        !CommandMagic.definitions.contains(right.node?.psi?.parentOfType(LatexCommands::class)?.name)) {
+                        !CommandMagic.definitions.contains(right.node?.psi?.parentOfType(LatexCommands::class)?.name)
+                    ) {
                         return@customRule createSpacing(
                             minSpaces = 0,
                             maxSpaces = Int.MAX_VALUE,

--- a/src/nl/hannahsten/texifyidea/formatting/spacingrules/TableAlignRule.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/spacingrules/TableAlignRule.kt
@@ -25,7 +25,7 @@ fun rightTableSpaceAlign(latexCommonSettings: CommonCodeStyleSettings, parent: A
     if (left.node?.text?.endsWith("\\&") == true) return null
 
     if (parent.node?.psi?.firstParentOfType(LatexEnvironmentContent::class)
-            ?.firstParentOfType(LatexEnvironment::class)?.environmentName !in EnvironmentMagic.getAllTableEnvironments(parent.node?.psi?.project ?: ProjectManager.getInstance().defaultProject)
+        ?.firstParentOfType(LatexEnvironment::class)?.environmentName !in EnvironmentMagic.getAllTableEnvironments(parent.node?.psi?.project ?: ProjectManager.getInstance().defaultProject)
     ) return null
 
     return createSpacing(
@@ -246,10 +246,14 @@ private fun getSpacesForRightBlock(
             if (absoluteIndices[level] == rightElementOffset) {
                 // For very long lines, it's a lot more readable to start & on a new line instead of inserting a whole bunch of spaces
                 // Make sure not to only put the \\ on a new line
-                val didPreviousCellGetNewline = if (level == 0) true else (relativeIndices.getOrNull(i)?.getOrNull(level - 1)
-                    ?: 0) > LINE_LENGTH
-                if ((relativeIndices.getOrNull(i)?.getOrNull(level)
-                        ?: 0) > LINE_LENGTH && (didPreviousCellGetNewline || level < absoluteIndices.size - 1)
+                val didPreviousCellGetNewline = if (level == 0) true else (
+                    relativeIndices.getOrNull(i)?.getOrNull(level - 1)
+                        ?: 0
+                    ) > LINE_LENGTH
+                if ((
+                    relativeIndices.getOrNull(i)?.getOrNull(level)
+                        ?: 0
+                    ) > LINE_LENGTH && (didPreviousCellGetNewline || level < absoluteIndices.size - 1)
                 ) return -1
                 return spacesPerCell.getOrNull(min(i, spacesPerCell.size - 1))?.getOrNull(level)
             }

--- a/src/nl/hannahsten/texifyidea/gutter/LatexElementColorProvider.kt
+++ b/src/nl/hannahsten/texifyidea/gutter/LatexElementColorProvider.kt
@@ -99,7 +99,8 @@ object LatexElementColorProvider : ElementColorProvider {
             // first parameter of a color definition command. If not, we can not find the
             // color (and return null in the end).
             if (colorName.contains('!') || colorDefiningCommands.map { it.getRequiredArgumentValueByName("name") }
-                    .contains(colorName)) {
+                .contains(colorName)
+            ) {
 
                 val colorDefinitionCommand =
                     colorDefiningCommands.find { it.getRequiredArgumentValueByName("name") == colorName }
@@ -221,8 +222,11 @@ object LatexElementColorProvider : ElementColorProvider {
     private fun fromHsbString(hsbText: String): Color {
         val hsb = hsbText.split(",").map { it.trim() }
         return hsb.map { it.toFloat().projectOnto(0..1) }
-            .let { Color.getHSBColor(
-                it[0], it[1], it[2]) }
+            .let {
+                Color.getHSBColor(
+                    it[0], it[1], it[2]
+                )
+            }
     }
 
     /**

--- a/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
+++ b/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
@@ -22,8 +22,8 @@ import javax.swing.Icon
 class LatexNavigationGutter : RelatedItemLineMarkerProvider() {
 
     override fun collectNavigationMarkers(
-            element: PsiElement,
-            result: MutableCollection<in RelatedItemLineMarkerInfo<*>>
+        element: PsiElement,
+        result: MutableCollection<in RelatedItemLineMarkerInfo<*>>
     ) {
 
         // Gutters should only be used with leaf elements.
@@ -62,11 +62,11 @@ class LatexNavigationGutter : RelatedItemLineMarkerProvider() {
 
         try {
             val builder = NavigationGutterIconBuilder
-                    .create(icon)
-                    .setTargets(files)
-                    .setPopupTitle("Navigate to Referenced File")
-                    .setTooltipText("Go to referenced file")
-                    .setCellRenderer { GotoFileCellRenderer(0) }
+                .create(icon)
+                .setTargets(files)
+                .setPopupTitle("Navigate to Referenced File")
+                .setTooltipText("Go to referenced file")
+                .setCellRenderer { GotoFileCellRenderer(0) }
 
             result.add(builder.createLineMarkerInfo(element))
         }

--- a/src/nl/hannahsten/texifyidea/index/file/LatexExternalPackageInclusionCache.kt
+++ b/src/nl/hannahsten/texifyidea/index/file/LatexExternalPackageInclusionCache.kt
@@ -29,11 +29,14 @@ object LatexExternalPackageInclusionCache {
 
         // Get direct children from the index
         FileBasedIndex.getInstance().getAllKeys(LatexExternalPackageInclusionIndex.id, project).forEach { indexKey ->
-            FileBasedIndex.getInstance().processValues(LatexExternalPackageInclusionIndex.id, indexKey, null, { file, _ ->
-                val key = LatexPackage(file.name.removeFileExtension())
-                directChildren[key] = directChildren.getOrDefault(key, mutableSetOf()).also { it.add(LatexPackage((indexKey))) }
-                true
-            }, GlobalSearchScope.everythingScope(project))
+            FileBasedIndex.getInstance().processValues(
+                LatexExternalPackageInclusionIndex.id, indexKey, null, { file, _ ->
+                    val key = LatexPackage(file.name.removeFileExtension())
+                    directChildren[key] = directChildren.getOrDefault(key, mutableSetOf()).also { it.add(LatexPackage((indexKey))) }
+                    true
+                },
+                GlobalSearchScope.everythingScope(project)
+            )
         }
 
         // Do some DFS for indirect inclusions

--- a/src/nl/hannahsten/texifyidea/inspections/TexifyInspectionBase.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/TexifyInspectionBase.kt
@@ -79,7 +79,7 @@ abstract class TexifyInspectionBase : LocalInspectionTool() {
      */
     protected open fun PsiElement.isSuppressed(): Boolean {
         return magicComment()?.containsPair("suppress", inspectionId) == true ||
-                allParentMagicComments().containsPair("suppress", inspectionId)
+            allParentMagicComments().containsPair("suppress", inspectionId)
     }
 
     override fun getBatchSuppressActions(element: PsiElement?): Array<SuppressQuickFix> {

--- a/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexDocumentclassNotInRootInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexDocumentclassNotInRootInspection.kt
@@ -31,13 +31,13 @@ class LatexDocumentclassNotInRootInspection : TexifyInspectionBase() {
 
         if (!hasDocumentEnvironment) {
             return listOf(
-                    manager.createProblemDescriptor(
-                            documentClass,
-                            displayName,
-                            true,
-                            ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
-                            isOntheFly
-                    )
+                manager.createProblemDescriptor(
+                    documentClass,
+                    displayName,
+                    true,
+                    ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                    isOntheFly
+                )
             )
         }
         return emptyList()

--- a/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexLabelConventionInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexLabelConventionInspection.kt
@@ -41,14 +41,14 @@ open class LatexLabelConventionInspection : TexifyInspectionBase() {
                     }
 
                     if (label.inDirectEnvironmentMatching {
-                            val conventionSettings = TexifyConventionsSettingsManager
-                                .getInstance(label.project).getSettings()
-                            conventionSettings.getLabelConvention(
+                        val conventionSettings = TexifyConventionsSettingsManager
+                            .getInstance(label.project).getSettings()
+                        conventionSettings.getLabelConvention(
                                 it.environmentName,
                                 LabelConventionType.ENVIRONMENT
                             ) != null &&
-                                    !EnvironmentMagic.labelAsParameter.contains(it.environmentName)
-                        }
+                            !EnvironmentMagic.labelAsParameter.contains(it.environmentName)
+                    }
                     ) {
                         label.parentOfType(LatexEnvironment::class)
                     }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMathFunctionTextInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMathFunctionTextInspection.kt
@@ -35,19 +35,19 @@ open class LatexMathFunctionTextInspection : TexifyInspectionBase() {
         val descriptors = descriptorList()
 
         file.commandsInFile("\\text").asSequence()
-                .filter { it.inMathContext() }
-                .filter { it.requiredParameter(0)?.trim() in AFFECTED_COMMANDS }
-                .forEach { affectedTextCommand ->
-                    descriptors.add(
-                            manager.createProblemDescriptor(
-                                    affectedTextCommand,
-                                    "Use math function instead of \\text",
-                                    MathFunctionFix(SmartPointerManager.createPointer(affectedTextCommand)),
-                                    ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
-                                    isOntheFly
-                            )
+            .filter { it.inMathContext() }
+            .filter { it.requiredParameter(0)?.trim() in AFFECTED_COMMANDS }
+            .forEach { affectedTextCommand ->
+                descriptors.add(
+                    manager.createProblemDescriptor(
+                        affectedTextCommand,
+                        "Use math function instead of \\text",
+                        MathFunctionFix(SmartPointerManager.createPointer(affectedTextCommand)),
+                        ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                        isOntheFly
                     )
-                }
+                )
+            }
 
         return descriptors
     }
@@ -70,7 +70,7 @@ open class LatexMathFunctionTextInspection : TexifyInspectionBase() {
     companion object {
 
         private val AFFECTED_COMMANDS = CommandMagic.slashlessMathOperators.asSequence()
-                .map { it.command }
-                .toSet()
+            .map { it.command }
+            .toSet()
     }
 }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexMissingDocumentEnvironmentInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexMissingDocumentEnvironmentInspection.kt
@@ -80,7 +80,8 @@ open class LatexMissingDocumentEnvironmentInspection : TexifyInspectionBase() {
                 |
                 |\begin{document}
                 |
-                |\end{document}""".trimMargin())
+                |\end{document}""".trimMargin()
+            )
         }
     }
 }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspection.kt
@@ -238,15 +238,15 @@ class LatexUnicodeInspection : TexifyInspectionBase() {
             val mods = n.substring(matcher.end()).split("".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
 
             val diacritics = (mods.indices)
-                    // Modifiers in reversed order
-                    .map { mods[mods.size - 1 - it] }
-                    .mapNotNull {
-                        @Suppress("USELESS_CAST")
-                        if (inMathMode)
-                            Diacritic.Math.fromUnicode(it) as? Diacritic
-                        else
-                            Diacritic.Normal.fromUnicode(it) as? Diacritic
-                    }
+                // Modifiers in reversed order
+                .map { mods[mods.size - 1 - it] }
+                .mapNotNull {
+                    @Suppress("USELESS_CAST")
+                    if (inMathMode)
+                        Diacritic.Math.fromUnicode(it) as? Diacritic
+                    else
+                        Diacritic.Normal.fromUnicode(it) as? Diacritic
+                }
 
             return Diacritic.buildChain(base, diacritics)
         }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/packages/LatexUndefinedCommandInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/packages/LatexUndefinedCommandInspection.kt
@@ -62,14 +62,16 @@ class LatexUndefinedCommandInspection : TexifyInspectionBase() {
         }
 
         return commandsInFile.filter { allKnownCommands.getOrDefault(it.name, emptyList()).intersect(includedPackages).isEmpty() }
-            .map { command -> manager.createProblemDescriptor(
-                command,
-                "Command ${command.name} is not defined",
-                allKnownCommands.getOrDefault(command.name, emptyList()).map { ImportPackageFix(it) }.toTypedArray(),
-                ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
-                isOntheFly,
-            false
-            ) }
+            .map { command ->
+                manager.createProblemDescriptor(
+                    command,
+                    "Command ${command.name} is not defined",
+                    allKnownCommands.getOrDefault(command.name, emptyList()).map { ImportPackageFix(it) }.toTypedArray(),
+                    ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                    isOntheFly,
+                    false
+                )
+            }
     }
 
     private class ImportPackageFix(val dependency: LatexPackage) : LocalQuickFix {

--- a/src/nl/hannahsten/texifyidea/inspections/latex/redundancy/LatexDuplicateLabelInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/redundancy/LatexDuplicateLabelInspection.kt
@@ -142,7 +142,7 @@ open class LatexDuplicateLabelInspection : TexifyInspectionBase() {
      * make the mapping from command etc. to ProblemDescriptor
      */
     private fun createProblemDescriptor(desc: LabelDescriptor, isOntheFly: Boolean, manager: InspectionManager):
-            ProblemDescriptor {
+        ProblemDescriptor {
         return manager.createProblemDescriptor(
             desc.element,
             desc.textRange,

--- a/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexVerticallyCenteredColonInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexVerticallyCenteredColonInspection.kt
@@ -37,7 +37,7 @@ open class LatexVerticallyCenteredColonInspection : TexifyRegexInspection(
         // Thus, whenever someone fiddles with this, we turn off the inspection to prevent false positives.
         file.commandsInFileSet().any { it.name == "\\mathtoolsset" && it.requiredParameter(0)?.contains("centercolon") == true }
     }
-    ) {
+) {
 
     private data class Pattern(val regex: String, val command: String)
 

--- a/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/spacing/LatexMathOperatorEscapeInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/spacing/LatexMathOperatorEscapeInspection.kt
@@ -46,9 +46,9 @@ class LatexMathOperatorEscapeInspection : TexifyInspectionBase() {
                     ProgressManager.checkCanceled()
                     if (pattern.accepts(element)) {
                         fun hasMathParentBeforeTextParent() = PsiTreeUtil.collectParents(
-                                element,
-                                LatexMathContent::class.java,
-                                false
+                            element,
+                            LatexMathContent::class.java,
+                            false
                         ) { it is LatexCommands && it.name == "\\text" }.size > 0
 
                         fun descriptorAlreadyExists() = descriptors.firstOrNull {
@@ -57,13 +57,13 @@ class LatexMathOperatorEscapeInspection : TexifyInspectionBase() {
 
                         if (element.text in SLASHLESS_MATH_OPERATORS && !descriptorAlreadyExists() && hasMathParentBeforeTextParent()) {
                             descriptors.add(
-                                    manager.createProblemDescriptor(
-                                            element,
-                                            "Non-escaped math operator",
-                                            EscapeMathOperatorFix(),
-                                            ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
-                                            isOntheFly
-                                    )
+                                manager.createProblemDescriptor(
+                                    element,
+                                    "Non-escaped math operator",
+                                    EscapeMathOperatorFix(),
+                                    ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                                    isOntheFly
+                                )
                             )
                         }
                     }
@@ -92,7 +92,7 @@ class LatexMathOperatorEscapeInspection : TexifyInspectionBase() {
     companion object {
 
         private val SLASHLESS_MATH_OPERATORS = CommandMagic.slashlessMathOperators.asSequence()
-                .map { it.command }
-                .toSet()
+            .map { it.command }
+            .toSet()
     }
 }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/spacing/LatexNonBreakingSpaceInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/spacing/LatexNonBreakingSpaceInspection.kt
@@ -70,9 +70,9 @@ open class LatexNonBreakingSpaceInspection : TexifyInspectionBase() {
 
             // Get the NORMAL_TEXT in front of the command.
             val sibling = command.prevSibling
-                    ?: command.parent?.prevSibling
-                    ?: command.parentOfType(LatexNoMathContent::class)?.prevSibling
-                    ?: continue
+                ?: command.parent?.prevSibling
+                ?: command.parentOfType(LatexNoMathContent::class)?.prevSibling
+                ?: continue
 
             // When sibling is whitespace, it's obviously bad news.
             if (sibling is PsiWhiteSpace) {

--- a/src/nl/hannahsten/texifyidea/intentions/LatexAddLabelIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexAddLabelIntention.kt
@@ -58,8 +58,8 @@ abstract class LatexAddLabelIntention : TexifyIntentionBase("Add label") {
         val element = file?.findElementAt(offset) ?: return null
         // Also check one position back, because we want it to trigger in \section{a}<caret>
         return element as? T ?: element.parentOfType<T>()
-        ?: file.findElementAt(max(0, offset - 1)) as? T
-        ?: file.findElementAt(max(0, offset - 1))?.parentOfType<T>()
+            ?: file.findElementAt(max(0, offset - 1)) as? T
+            ?: file.findElementAt(max(0, offset - 1))?.parentOfType<T>()
     }
 
     protected fun getUniqueLabelName(base: String, prefix: String, file: PsiFile): LabelWithPrefix {

--- a/src/nl/hannahsten/texifyidea/lang/BibtexDefaultEntryType.kt
+++ b/src/nl/hannahsten/texifyidea/lang/BibtexDefaultEntryType.kt
@@ -150,7 +150,7 @@ enum class BibtexDefaultEntryType(
     BOOKINBOOK(
         "bookinbook",
         "This type is similar to @inbook but intended for works originally published as a\n" +
-                "stand-alone book.",
+            "stand-alone book.",
         arrayOf(AUTHOR, TITLE, BOOKTITLE, DATE),
         arrayOf(BOOKAUTHOR, EDITOR, EDITORA, EDITORB, EDITORC, TRANSLATOR, ANNOTATOR, COMMENTATOR, INTRODUCTION, FOREWORD, AFTERWORD, SUBTITLE, TITLEADDON, MAINTITLE, MAINSUBTITLE, MAINTITLEADDON, BOOKSUBTITLE, BOOKTITLEADDON, LANGUAGE, ORIGLANGUAGE, VOLUME, PART, EDITION, VOLUMES, SERIES, NUMBER, NOTE, PUBLISHER, LOCATION, ISBN, CHAPTER, PAGES, ADDENDUM, PUBSTATE, DOI, EPRINT, EPRINTCLASS, EPRINTTYPE, URL, URLDATE),
         BIBLATEX
@@ -270,7 +270,7 @@ enum class BibtexDefaultEntryType(
     REFERENCE(
         "reference",
         "A single-volume work of reference such as an encyclopedia or a dictionary. This is a\n" +
-                "more specific variant of the generic @collection entry type",
+            "more specific variant of the generic @collection entry type",
         arrayOf(EDITOR, TITLE, DATE),
         arrayOf(EDITORA, EDITORB, EDITORC, TRANSLATOR, ANNOTATOR, COMMENTATOR, INTRODUCTION, FOREWORD, AFTERWORD, SUBTITLE, TITLEADDON, MAINTITLE, MAINSUBTITLE, MAINTITLEADDON, LANGUAGE, ORIGLANGUAGE, VOLUME, PART, EDITION, VOLUMES, SERIES, NUMBER, NOTE, PUBLISHER, LOCATION, ISBN, CHAPTER, PAGES, PAGETOTAL, ADDENDUM, PUBSTATE, DOI, EPRINT, EPRINTCLASS, EPRINTTYPE, URL, URLDATE),
         BIBLATEX
@@ -299,7 +299,7 @@ enum class BibtexDefaultEntryType(
     SOFTWARE(
         "software",
         "Computer software. The standard styles will treat this entry type as an alias for\n" +
-                "@misc.",
+            "@misc.",
         arrayOf(TITLE, DATE),
         arrayOf(AUTHOR, EDITOR, YEAR, SUBTITLE, TITLEADDON, LANGUAGE, HOWPUBLISHED, TYPE, VERSION, NOTE, ORGANISATION, LOCATION, MONTH, ADDENDUM, PUBSTATE, DOI, EPRINT, EPRINTCLASS, EPRINTTYPE, URL, URLDATE),
         BIBLATEX
@@ -335,7 +335,7 @@ enum class BibtexDefaultEntryType(
     MASTERSTHESIS(
         "mastersthesis",
         "Similar to @thesis except that the type field is optional and defaults to the\n" +
-                "localised term ‘Master’s thesis’. You may still use the type field to override that.",
+            "localised term ‘Master’s thesis’. You may still use the type field to override that.",
         arrayOf(AUTHOR, TITLE, INSTITUTION, DATE),
         arrayOf(YEAR, SUBTITLE, TITLEADDON, LANGUAGE, NOTE, LOCATION, MONTH, ISBN, CHAPTER, PAGES, PAGETOTAL, ADDENDUM, PUBSTATE, DOI, EPRINT, EPRINTCLASS, EPRINTTYPE, URL, URLDATE, TYPE),
         BIBLATEX
@@ -343,7 +343,7 @@ enum class BibtexDefaultEntryType(
     BIBLATEX_PHDTHESIS(
         "phdthesis",
         "Similar to @thesis except that the type field is optional and defaults to the\n" +
-                "localised term ‘PhD thesis’. You may still use the type field to override that.",
+            "localised term ‘PhD thesis’. You may still use the type field to override that.",
         arrayOf(AUTHOR, TITLE, INSTITUTION, DATE),
         arrayOf(YEAR, SUBTITLE, TITLEADDON, LANGUAGE, NOTE, LOCATION, MONTH, ISBN, CHAPTER, PAGES, PAGETOTAL, ADDENDUM, PUBSTATE, DOI, EPRINT, EPRINTCLASS, EPRINTTYPE, URL, URLDATE, TYPE),
         BIBLATEX
@@ -351,7 +351,7 @@ enum class BibtexDefaultEntryType(
     BIBLATEX_TECHREPORT(
         "techreport",
         "Similar to @report except that the type field is optional and defaults to the\n" +
-                "localised term ‘technical report’. You may still use the type field to override that.",
+            "localised term ‘technical report’. You may still use the type field to override that.",
         arrayOf(AUTHOR, TITLE, TYPE, INSTITUTION, DATE),
         arrayOf(YEAR, SUBTITLE, TITLEADDON, LANGUAGE, NUMBER, VERSION, NOTE, LOCATION, MONTH, ISRN, CHAPTER, PAGES, PAGETOTAL, ADDENDUM, PUBSTATE, DOI, EPRINT, EPRINTCLASS, EPRINTTYPE, URL, URLDATE),
         BIBLATEX

--- a/src/nl/hannahsten/texifyidea/lang/DefaultEnvironment.kt
+++ b/src/nl/hannahsten/texifyidea/lang/DefaultEnvironment.kt
@@ -16,12 +16,12 @@ import java.util.*
  * @author Hannah Schellekens, Sten Wessel
  */
 enum class DefaultEnvironment(
-        override val environmentName: String,
-        override val initialContents: String = "",
-        override val context: Context = Context.NORMAL,
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override vararg val arguments: Argument,
-        override val description: String = ""
+    override val environmentName: String,
+    override val initialContents: String = "",
+    override val context: Context = Context.NORMAL,
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override vararg val arguments: Argument,
+    override val description: String = ""
 ) : Environment {
 
     // Vanilla LaTeX

--- a/src/nl/hannahsten/texifyidea/lang/Environment.kt
+++ b/src/nl/hannahsten/texifyidea/lang/Environment.kt
@@ -1,10 +1,10 @@
 package nl.hannahsten.texifyidea.lang
 
-import nl.hannahsten.texifyidea.lang.commands.Argument
 import com.intellij.openapi.project.Project
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.util.indexing.FileBasedIndex
 import nl.hannahsten.texifyidea.index.file.LatexExternalEnvironmentIndex
+import nl.hannahsten.texifyidea.lang.commands.Argument
 import nl.hannahsten.texifyidea.lang.commands.LatexCommand
 import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand.*
 import nl.hannahsten.texifyidea.util.files.removeFileExtension
@@ -33,20 +33,23 @@ interface Environment : Dependend, Described {
          */
         fun lookupInIndex(environmentName: String, project: Project): Set<Environment> {
             val envs = mutableSetOf<Environment>()
-            FileBasedIndex.getInstance().processValues(LatexExternalEnvironmentIndex.id, environmentName, null, { file, value ->
-                val dependency = file.name.removeFileExtension()
-                val env = object : Environment {
-                    override val arguments = extractArgumentsFromDocs(value)
-                    override val description = value
-                    override val dependency =
-                        if (dependency.isBlank()) LatexPackage.DEFAULT else LatexPackage.create(file)
-                    override val context = Context.NORMAL
-                    override val initialContents = ""
-                    override val environmentName = environmentName
-                }
-                envs.add(env)
-                true
-            }, GlobalSearchScope.everythingScope(project))
+            FileBasedIndex.getInstance().processValues(
+                LatexExternalEnvironmentIndex.id, environmentName, null, { file, value ->
+                    val dependency = file.name.removeFileExtension()
+                    val env = object : Environment {
+                        override val arguments = extractArgumentsFromDocs(value)
+                        override val description = value
+                        override val dependency =
+                            if (dependency.isBlank()) LatexPackage.DEFAULT else LatexPackage.create(file)
+                        override val context = Context.NORMAL
+                        override val initialContents = ""
+                        override val environmentName = environmentName
+                    }
+                    envs.add(env)
+                    true
+                },
+                GlobalSearchScope.everythingScope(project)
+            )
 
             // See LatexCommand#lookUpInIndex()
             val filteredEnvs = envs.distinctBy { listOf(it.environmentName, it.dependency, it.context, it.description).plus(it.arguments) }

--- a/src/nl/hannahsten/texifyidea/lang/LatexMathEnvironment.kt
+++ b/src/nl/hannahsten/texifyidea/lang/LatexMathEnvironment.kt
@@ -9,9 +9,9 @@ import java.util.*
  * @author Sten Wessel
  */
 enum class LatexMathEnvironment(
-        val environmentName: String,
-        vararg val arguments: Argument,
-        val initialContents: String? = null
+    val environmentName: String,
+    vararg val arguments: Argument,
+    val initialContents: String? = null
 ) {
 
     /*

--- a/src/nl/hannahsten/texifyidea/lang/SimpleEnvironment.kt
+++ b/src/nl/hannahsten/texifyidea/lang/SimpleEnvironment.kt
@@ -6,12 +6,12 @@ import nl.hannahsten.texifyidea.lang.commands.Argument
  * @author Hannah Schellekens
  */
 class SimpleEnvironment(
-        override val environmentName: String,
-        override val context: Environment.Context = Environment.Context.NORMAL,
-        override val initialContents: String = "",
-        override val arguments: Array<out Argument> = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val description: String = ""
+    override val environmentName: String,
+    override val context: Environment.Context = Environment.Context.NORMAL,
+    override val initialContents: String = "",
+    override val arguments: Array<out Argument> = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val description: String = ""
 ) : Environment {
 
     constructor(environmentName: String) : this(environmentName, context = Environment.Context.NORMAL)

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexAlgorithmicxCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexAlgorithmicxCommand.kt
@@ -7,12 +7,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.ALGPSEUDOCODE
  * @author Hannah Schellekens
  */
 enum class LatexAlgorithmicxCommand(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = false,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = false,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     FOR("For", "condition".asRequired(), dependency = ALGPSEUDOCODE),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexArrowCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexArrowCommand.kt
@@ -9,12 +9,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.STMARYRD
  * @author Hannah Schellekens
  */
 enum class LatexArrowCommand(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = true,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = true,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     NOT_RIGHT_ARROW("nrightarrow", dependency = AMSSYMB, display = "↛", collapse = true),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexBiblatexCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexBiblatexCommand.kt
@@ -7,12 +7,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.BIBLATEX
  * @author Hannah Schellekens
  */
 enum class LatexBiblatexCommand(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = false,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = false,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     CITE_CAPITALIZED("Cite", "prenote".asOptional(), "postnote".asOptional(), "key".asRequired(), dependency = BIBLATEX),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexColoneqCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexColoneqCommand.kt
@@ -7,12 +7,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.MATHTOOLS
  * @author Hannah Schellekens
  */
 enum class LatexColoneqCommand(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = true,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = true,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     COLON_EQUALSS("coloneqq", dependency = MATHTOOLS, display = ":=", collapse = true),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexColorDefinitionCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexColorDefinitionCommand.kt
@@ -8,12 +8,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.XCOLOR
  * @author Hannah Schellekens
  */
 enum class LatexColorDefinitionCommand(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = false,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = false,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     DEFINECOLOR("definecolor", "type".asOptional(), "name".asRequired(), "model-list".asRequired(), "spec-list".asRequired(), dependency = COLOR),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexDelimiterCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexDelimiterCommand.kt
@@ -8,12 +8,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.STMARYRD
  * @author Hannah Schellekens
  */
 enum class LatexDelimiterCommand(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = true,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = true,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     LEFT_PARENTH("left(", display = "("),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexEuroCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexEuroCommand.kt
@@ -7,12 +7,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.EUROSYM
  * @author Hannah Schellekens
  */
 enum class LatexEuroCommand(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = false,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = false,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     EURO_SYMBOL("euro", dependency = EUROSYM, display = "€"),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexGenericMathCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexGenericMathCommand.kt
@@ -9,12 +9,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.WASYSYM
  * @author Hannah Schellekens
  */
 enum class LatexGenericMathCommand(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = true,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = true,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     ACUTE("acute", "a".asRequired()),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexGenericRegularCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexGenericRegularCommand.kt
@@ -20,12 +20,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.XCOLOR
  * @author Hannah Schellekens
  */
 enum class LatexGenericRegularCommand(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = false,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = false,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     ADDTOCOUNTER("addtocounter", "countername".asRequired(), "value".asRequired()),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexGlossariesCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexGlossariesCommand.kt
@@ -52,11 +52,13 @@ enum class LatexGlossariesCommand(
     GLSPLURALUPPER("Glspl", "label".asRequired(), dependency = LatexPackage.GLOSSARIES),
 
     LOADGLSENTRIES(
-        "loadglsentries", RequiredFileArgument(
+        "loadglsentries",
+        RequiredFileArgument(
             "glossariesfile",
             isAbsolutePathSupported = true,
             commaSeparatesArguments = false
-        ), dependency = LatexPackage.GLOSSARIES
+        ),
+        dependency = LatexPackage.GLOSSARIES
     );
 
     companion object {

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexGreekCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexGreekCommand.kt
@@ -7,12 +7,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.AMSMATH
  * @author Hannah Schellekens
  */
 enum class LatexGreekCommand(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = true,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = true,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     ALPHA("alpha", display = "α", collapse = true),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexIfCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexIfCommand.kt
@@ -8,12 +8,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage
  * @author Hannah Schellekens
  */
 enum class LatexIfCommand(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = false,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = false,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     IF("if"),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexListingCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexListingCommand.kt
@@ -9,12 +9,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.PYTHONTEX
  * @author Hannah Schellekens
  */
 enum class LatexListingCommand(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = false,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = false,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     LSTINPUTLISTING("lstinputlisting", "options".asOptional(), RequiredFileArgument("filename", false, commaSeparatesArguments = false), dependency = LISTINGS),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexMathCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexMathCommand.kt
@@ -14,7 +14,7 @@ object LatexMathCommand {
     val UNCATEGORIZED_STMARYRD_SYMBOLS: Set<LatexCommand> = LatexUncategorizedStmaryrdSymbols.values().toSet()
 
     val ALL: Set<LatexCommand> = GREEK_ALPHABET + OPERATORS + MATHTOOLS_COLONEQ + DELIMITERS + ARROWS +
-            GENERIC_COMMANDS + UNCATEGORIZED_STMARYRD_SYMBOLS
+        GENERIC_COMMANDS + UNCATEGORIZED_STMARYRD_SYMBOLS
 
     private val lookup = HashMap<String, MutableSet<LatexCommand>>()
     private val lookupDisplay = HashMap<String, MutableSet<LatexCommand>>()

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexMathtoolsRegularCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexMathtoolsRegularCommand.kt
@@ -7,12 +7,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.MATHTOOLS
  * @author Hannah Schellekens
  */
 enum class LatexMathtoolsRegularCommand(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = false,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = false,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     DECLARE_PAIRED_DELIMITER("DeclarePairedDelimiter", "cmd".asRequired(), "left delimiter".asRequired(), "right delimiter".asRequired(), dependency = MATHTOOLS),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexNatbibCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexNatbibCommand.kt
@@ -7,12 +7,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.NATBIB
  * @author Hannah Schellekens
  */
 enum class LatexNatbibCommand(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = false,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = false,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     CITEP("citep", "before".asOptional(), "after".asOptional(), "keys".asRequired(), dependency = NATBIB),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexNewDefinitionCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexNewDefinitionCommand.kt
@@ -7,12 +7,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.TCOLORBOX
  * @author Hannah Schellekens
  */
 enum class LatexNewDefinitionCommand(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = false,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = false,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     CATCODE("catcode"),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexOperatorCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexOperatorCommand.kt
@@ -8,12 +8,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.STMARYRD
  * @author Hannah Schellekens
  */
 enum class LatexOperatorCommand(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = true,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = true,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     FOR_ALL("forall", display = "∀", collapse = true),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexRegularCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexRegularCommand.kt
@@ -23,7 +23,7 @@ object LatexRegularCommand {
     val GLOSSARY: Set<LatexCommand> = LatexGlossariesCommand.values().toSet()
 
     val ALL: Set<LatexCommand> = GENERIC + TEXTCOMP + EURO + TEXT_SYMBOLS + NEW_DEFINITIONS + MATHTOOLS +
-            XCOLOR + XPARSE + NATBIB + BIBLATEX + SIUNITX + ALGORITHMICX + IFS + LISTINGS + LOREM_IPSUM + GLOSSARY
+        XCOLOR + XPARSE + NATBIB + BIBLATEX + SIUNITX + ALGORITHMICX + IFS + LISTINGS + LOREM_IPSUM + GLOSSARY
 
     private val lookup = HashMap<String, MutableSet<LatexCommand>>()
     private val lookupDisplay = HashMap<String, MutableSet<LatexCommand>>()

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexSiunitxCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexSiunitxCommand.kt
@@ -7,12 +7,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.SIUNITX
  * @author Hannah Schellekens
  */
 enum class LatexSiunitxCommand(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = false,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = false,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     ANG("ang", "options".asOptional(), "angle".asRequired(), dependency = SIUNITX),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexTextSymbolCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexTextSymbolCommand.kt
@@ -9,12 +9,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.WASYSYM
  * @author Hannah Schellekens
  */
 enum class LatexTextSymbolCommand(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = false,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = false,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     CUT_LEFT_ON_LINE("Cutleft", dependency = MARVOSYM),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexTextcompCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexTextcompCommand.kt
@@ -7,12 +7,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.TEXTCOMP
  * @author Hannah Schellekens
  */
 enum class LatexTextcompCommand(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = false,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = false,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     TEXT_TILDE_LOW("texttildelow", dependency = TEXTCOMP, display = "˷"),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexUncategorizedStmaryrdSymbols.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexUncategorizedStmaryrdSymbols.kt
@@ -7,12 +7,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.STMARYRD
  * @author Hannah Schellekens
  */
 enum class LatexUncategorizedStmaryrdSymbols(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = true,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = true,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     Y_LEFT("Yleft", dependency = STMARYRD),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexXparseCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexXparseCommand.kt
@@ -8,12 +8,12 @@ import nl.hannahsten.texifyidea.lang.LatexPackage
  * @author Hannah Schellekens
  */
 enum class LatexXparseCommand(
-        override val command: String,
-        override vararg val arguments: Argument = emptyArray(),
-        override val dependency: LatexPackage = LatexPackage.DEFAULT,
-        override val display: String? = null,
-        override val isMathMode: Boolean = false,
-        val collapse: Boolean = false
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = false,
+    val collapse: Boolean = false
 ) : LatexCommand {
 
     NEWDOCUMENTCOMMAND("NewDocumentCommand", "name".asRequired(), "args spec".asRequired(), "code".asRequired()),

--- a/src/nl/hannahsten/texifyidea/lang/graphic/FigureLocation.kt
+++ b/src/nl/hannahsten/texifyidea/lang/graphic/FigureLocation.kt
@@ -7,9 +7,9 @@ import nl.hannahsten.texifyidea.lang.LatexPackage
  * @author Hannah Schellekens
  */
 enum class FigureLocation(
-        val symbol: String,
-        override val description: String,
-        val requiredPackage: LatexPackage? = null
+    val symbol: String,
+    override val description: String,
+    val requiredPackage: LatexPackage? = null
 ) : Described {
 
     TOP("t", "top"),

--- a/src/nl/hannahsten/texifyidea/lang/magic/TextBasedMagicCommentParser.kt
+++ b/src/nl/hannahsten/texifyidea/lang/magic/TextBasedMagicCommentParser.kt
@@ -78,7 +78,8 @@ open class TextBasedMagicCommentParser(private val comments: List<String>) : Mag
                         key = line.split(" ").first().asKey(),
                         value = line.trim().split(" ").drop(1).joinToString(" ").let {
                             if (it.isEmpty()) null else it
-                        })
+                        }
+                    )
                 }
                 // Fill up contents of the existing key.
                 // Each newline is considered a space.

--- a/src/nl/hannahsten/texifyidea/psi/LatexParameterTextUtil.kt
+++ b/src/nl/hannahsten/texifyidea/psi/LatexParameterTextUtil.kt
@@ -102,7 +102,7 @@ fun setName(element: LatexParameterText, name: String): PsiElement {
     val environment = element.firstParentOfType(LatexEnvironment::class)
     // If we want to rename a label
     if (CommandMagic.reference.contains(command?.name) || element.project.getLabelDefinitionCommands()
-            .contains(command?.name)
+        .contains(command?.name)
     ) {
         // Get a new psi element for the complete label command (\label included),
         // because if we replace the complete command instead of just the normal text

--- a/src/nl/hannahsten/texifyidea/psi/LatexPsiHelper.kt
+++ b/src/nl/hannahsten/texifyidea/psi/LatexPsiHelper.kt
@@ -96,9 +96,11 @@ class LatexPsiHelper(private val project: Project) {
             if (command is LatexCommands) {
                 // For commands insert an optional parameter right after the command name (in case the command has a
                 // star, insert the parameter after the start)
-                command.addAfter(createLatexOptionalParam(),
+                command.addAfter(
+                    createLatexOptionalParam(),
                     command.childrenOfType<LeafPsiElement>().firstOrNull { it.elementType == STAR }
-                        ?: command.commandToken)
+                        ?: command.commandToken
+                )
             }
             else {
                 // Otherwise assume that the command belongs to an environment and insert the optional parameter after
@@ -136,7 +138,8 @@ class LatexPsiHelper(private val project: Project) {
                 existing.keyvalValue?.delete()
                 existing.addAfter(
                     pair.keyvalValue!!,
-                    existing.childrenOfType<LeafPsiElement>().first { it.elementType == EQUALS })
+                    existing.childrenOfType<LeafPsiElement>().first { it.elementType == EQUALS }
+                )
                 existing
             }
             else {

--- a/src/nl/hannahsten/texifyidea/reference/CommandDefinitionReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/CommandDefinitionReference.kt
@@ -29,7 +29,8 @@ class CommandDefinitionReference(element: LatexCommands) : PsiReferenceBase<Late
         // Don't resolve to a definition when you are in a \newcommand,
         // and if this element is the element that is being defined
         if (element.parentsOfType<LatexCommands>().any { it.name in definitionsAndRedefinitions } &&
-            element.parent.firstParentOfType(LatexCommands::class)?.parameterList?.firstOrNull() == element.firstParentOfType(LatexParameter::class)) {
+            element.parent.firstParentOfType(LatexCommands::class)?.parameterList?.firstOrNull() == element.firstParentOfType(LatexParameter::class)
+        ) {
             return emptyArray()
         }
         else {

--- a/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
@@ -29,10 +29,10 @@ import nl.hannahsten.texifyidea.util.magic.CommandMagic
  * @param defaultExtension Default extension of the command in which this reference is.
  */
 class InputFileReference(
-        element: LatexCommands,
-        val range: TextRange,
-        val extensions: Set<String>,
-        val defaultExtension: String
+    element: LatexCommands,
+    val range: TextRange,
+    val extensions: Set<String>,
+    val defaultExtension: String
 ) : PsiReferenceBase<LatexCommands>(element) {
 
     init {
@@ -78,11 +78,11 @@ class InputFileReference(
         // Check environment variables
         val runManager = RunManagerImpl.getInstanceImpl(element.project) as RunManager
         val texInputPath = runManager.allConfigurationsList
-                .filterIsInstance<LatexRunConfiguration>()
-                .firstOrNull { it.mainFile in rootFiles }
-                ?.environmentVariables
-                ?.envs
-                ?.getOrDefault("TEXINPUTS", null)
+            .filterIsInstance<LatexRunConfiguration>()
+            .firstOrNull { it.mainFile in rootFiles }
+            ?.environmentVariables
+            ?.envs
+            ?.getOrDefault("TEXINPUTS", null)
         if (texInputPath != null) {
             val path = texInputPath.trimEnd(':')
             searchPaths.add(path.trimEnd('/'))
@@ -90,9 +90,9 @@ class InputFileReference(
             if (path.endsWith("//")) {
                 LocalFileSystem.getInstance().findFileByPath(path.trimEnd('/'))?.let { parent ->
                     searchPaths.addAll(
-                            parent.allChildDirectories()
-                                    .filter { it.isDirectory }
-                                    .map { it.path }
+                        parent.allChildDirectories()
+                            .filter { it.isDirectory }
+                            .map { it.path }
                     )
                 }
             }
@@ -152,9 +152,9 @@ class InputFileReference(
         // Look for packages/files elsewhere using the kpsewhich command.
         if (targetFile == null && lookForInstalledPackages) {
             targetFile = element.getFileNameWithExtensions(processedKey)
-                    .mapNotNull { LatexPackageLocationCache.getPackageLocation(it, element.project) }
-                    .mapNotNull { getExternalFile(it) }
-                    .firstOrNull()
+                .mapNotNull { LatexPackageLocationCache.getPackageLocation(it, element.project) }
+                .mapNotNull { getExternalFile(it) }
+                .firstOrNull()
         }
 
         if (targetFile == null) targetFile = searchFileByImportPaths(element)?.virtualFile
@@ -223,7 +223,7 @@ class InputFileReference(
         // Recall that \ is a file separator on Windows
         val newText = if (elementNameIsJustFilename) {
             oldNode?.text?.trimStart('\\')?.replaceAfterLast('/', "$newName}", default.trimStart('\\'))
-                    ?.let { "\\" + it } ?: default
+                ?.let { "\\" + it } ?: default
         }
         else {
             default

--- a/src/nl/hannahsten/texifyidea/reference/LatexGlossaryReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/LatexGlossaryReference.kt
@@ -10,7 +10,8 @@ import nl.hannahsten.texifyidea.psi.LatexParameterText
  * This reference allows refactoring of glossary entries. A glossary reference command (e.g. \gls) references the label
  * parameter of a glossary entry command (e.g. \newglossaryentry).
  */
-class LatexGlossaryReference(element: LatexParameterText) : PsiReferenceBase<LatexParameterText>(element),
+class LatexGlossaryReference(element: LatexParameterText) :
+    PsiReferenceBase<LatexParameterText>(element),
     PsiPolyVariantReference {
 
     init {

--- a/src/nl/hannahsten/texifyidea/reference/LatexLabelReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/LatexLabelReference.kt
@@ -45,10 +45,12 @@ class LatexLabelReference(element: LatexCommands, range: TextRange?) : PsiRefere
                                 .withInsertHandler(LatexReferenceInsertHandler())
                                 .withTypeText(
                                     containing.name + ": " +
-                                            (1 + StringUtil.offsetToLineNumber(
+                                        (
+                                            1 + StringUtil.offsetToLineNumber(
                                                 containing.text,
                                                 bibtexEntry.getTextOffset()
-                                            )),
+                                            )
+                                            ),
                                     true
                                 )
                                 .withIcon(TexifyIcons.DOT_BIB)
@@ -75,12 +77,12 @@ class LatexLabelReference(element: LatexCommands, range: TextRange?) : PsiRefere
                         .withInsertHandler(LatexReferenceInsertHandler())
                         .withTypeText(
                             labelingCommand.containingFile.name + ":" +
-                                    (
-                                            1 + StringUtil.offsetToLineNumber(
-                                                labelingCommand.containingFile.text,
-                                                labelingCommand.textOffset
-                                            )
-                                            ),
+                                (
+                                    1 + StringUtil.offsetToLineNumber(
+                                        labelingCommand.containingFile.text,
+                                        labelingCommand.textOffset
+                                    )
+                                    ),
                             true
                         )
                         .withIcon(TexifyIcons.DOT_LABEL)

--- a/src/nl/hannahsten/texifyidea/remotelibraries/mendeley/MendeleyAuthenticator.kt
+++ b/src/nl/hannahsten/texifyidea/remotelibraries/mendeley/MendeleyAuthenticator.kt
@@ -100,9 +100,11 @@ object MendeleyAuthenticator {
     private val authenticationClient by lazy {
         HttpClient(CIO) {
             install(ContentNegotiation) {
-                json(Json {
-                    ignoreUnknownKeys = true
-                })
+                json(
+                    Json {
+                        ignoreUnknownKeys = true
+                    }
+                )
             }
         }
     }
@@ -118,7 +120,8 @@ object MendeleyAuthenticator {
                     append("grant_type", "authorization_code")
                     append("code", it)
                     append("redirect_uri", redirectUrl)
-                }) {
+                }
+            ) {
                 basicAuth(MendeleyCredentials.id, MendeleyCredentials.secret.decipher())
             }.body()
 
@@ -137,7 +140,8 @@ object MendeleyAuthenticator {
                 append("grant_type", "refresh_token")
                 append("refresh_token", refreshToken)
                 append("redirect_uri", "http://localhost:$port/")
-            }) {
+            }
+        ) {
             basicAuth(MendeleyCredentials.id, MendeleyCredentials.secret.decipher())
         }.body()
 

--- a/src/nl/hannahsten/texifyidea/remotelibraries/state/LibraryStateConverter.kt
+++ b/src/nl/hannahsten/texifyidea/remotelibraries/state/LibraryStateConverter.kt
@@ -32,11 +32,14 @@ class LibraryStateConverter : Converter<Map<String, LibraryState>>() {
     override fun toString(value: Map<String, LibraryState>): String? {
         val module = JacksonXmlModule()
 
-        module.addSerializer(BibItems::class.java, object : JsonSerializer<BibItems>() {
-            override fun serialize(p0: BibItems, p1: JsonGenerator, p2: SerializerProvider) {
-                runReadAction { p1.writeString(BibtexEntryListConverter().toString(p0.items)) }
+        module.addSerializer(
+            BibItems::class.java,
+            object : JsonSerializer<BibItems>() {
+                override fun serialize(p0: BibItems, p1: JsonGenerator, p2: SerializerProvider) {
+                    runReadAction { p1.writeString(BibtexEntryListConverter().toString(p0.items)) }
+                }
             }
-        })
+        )
 
         return XmlMapper(module)
             .writerWithDefaultPrettyPrinter()
@@ -46,11 +49,14 @@ class LibraryStateConverter : Converter<Map<String, LibraryState>>() {
     override fun fromString(value: String): Map<String, LibraryState> {
         val module = JacksonXmlModule()
 
-        module.addDeserializer(BibItems::class.java, object : JsonDeserializer<BibItems>() {
-            override fun deserialize(p0: JsonParser, p1: DeserializationContext): BibItems {
+        module.addDeserializer(
+            BibItems::class.java,
+            object : JsonDeserializer<BibItems>() {
+                override fun deserialize(p0: JsonParser, p1: DeserializationContext): BibItems {
                     return runReadAction { BibItems(BibtexEntryListConverter().fromString(p0.text)) }
+                }
             }
-        })
+        )
 
         return XmlMapper(module)
             .readValue<Map<String, LibraryWrapper>>(value)

--- a/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
+++ b/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
@@ -67,11 +67,13 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
             moduleRoot: VirtualFile?,
             moduleRoots: Array<VirtualFile>
         ): MutableList<String> {
-            val command = mutableListOf(runConfig.compilerPath ?: LatexSdkUtil.getExecutableName(
-                executableName,
-                runConfig.project,
-                runConfig.getLatexDistributionType()
-            ))
+            val command = mutableListOf(
+                runConfig.compilerPath ?: LatexSdkUtil.getExecutableName(
+                    executableName,
+                    runConfig.project,
+                    runConfig.getLatexDistributionType()
+                )
+            )
 
             // Some commands are the same as for pdflatex
             command.add("-file-line-error")
@@ -103,11 +105,13 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
             moduleRoot: VirtualFile?,
             moduleRoots: Array<VirtualFile>
         ): MutableList<String> {
-            val command = mutableListOf(runConfig.compilerPath ?: LatexSdkUtil.getExecutableName(
-                executableName,
-                runConfig.project,
-                runConfig.getLatexDistributionType()
-            ))
+            val command = mutableListOf(
+                runConfig.compilerPath ?: LatexSdkUtil.getExecutableName(
+                    executableName,
+                    runConfig.project,
+                    runConfig.getLatexDistributionType()
+                )
+            )
 
             val isLatexmkRcFilePresent = LatexmkRcFileFinder.isLatexmkRcFilePresent(runConfig)
 
@@ -146,11 +150,13 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
             moduleRoot: VirtualFile?,
             moduleRoots: Array<VirtualFile>
         ): MutableList<String> {
-            val command = mutableListOf(runConfig.compilerPath ?: LatexSdkUtil.getExecutableName(
-                executableName,
-                runConfig.project,
-                runConfig.getLatexDistributionType()
-            ))
+            val command = mutableListOf(
+                runConfig.compilerPath ?: LatexSdkUtil.getExecutableName(
+                    executableName,
+                    runConfig.project,
+                    runConfig.getLatexDistributionType()
+                )
+            )
 
             // As usual, available command line options can be viewed with xelatex --help
             // On TeX Live, installing collection-xetex should be sufficient to get xelatex
@@ -190,11 +196,13 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
             moduleRoot: VirtualFile?,
             moduleRoots: Array<VirtualFile>
         ): MutableList<String> {
-            val command = mutableListOf(runConfig.compilerPath ?: LatexSdkUtil.getExecutableName(
-                executableName,
-                runConfig.project,
-                runConfig.getLatexDistributionType()
-            ))
+            val command = mutableListOf(
+                runConfig.compilerPath ?: LatexSdkUtil.getExecutableName(
+                    executableName,
+                    runConfig.project,
+                    runConfig.getLatexDistributionType()
+                )
+            )
 
             // texliveonfly is a Python script which calls other compilers (by default pdflatex), main feature is downloading packages automatically
             // commands can be passed to those compilers with the arguments flag, however apparently IntelliJ cannot handle quotes so we cannot pass multiple arguments to pdflatex.
@@ -324,7 +332,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
             // Custom compiler arguments specified by the user
             runConfig.compilerArguments?.let { arguments ->
                 ParametersListUtil.parse(arguments)
-                        .forEach { wslCommand += " $it" }
+                    .forEach { wslCommand += " $it" }
             }
 
             wslCommand += " ${mainFile.path.toPath(runConfig)}"
@@ -339,7 +347,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
         // Custom compiler arguments specified by the user
         runConfig.compilerArguments?.let { arguments ->
             ParametersListUtil.parse(arguments)
-                    .forEach { command.add(it) }
+                .forEach { command.add(it) }
         }
 
         command.add(mainFile.name)

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexCommandLineState.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexCommandLineState.kt
@@ -244,7 +244,8 @@ open class LatexCommandLineState(environment: ExecutionEnvironment, private val 
             handler.addProcessListener(SumatraForwardSearchListener(runConfig, environment))
         }
         else if (runConfig.pdfViewer is ExternalPdfViewer ||
-                 runConfig.pdfViewer in listOf(InternalPdfViewer.EVINCE, InternalPdfViewer.OKULAR, InternalPdfViewer.ZATHURA, InternalPdfViewer.SKIM)) {
+            runConfig.pdfViewer in listOf(InternalPdfViewer.EVINCE, InternalPdfViewer.OKULAR, InternalPdfViewer.ZATHURA, InternalPdfViewer.SKIM)
+        ) {
             ViewerForwardSearch(runConfig.pdfViewer ?: InternalPdfViewer.NONE).execute(handler, runConfig, environment, focusAllowed)
         }
         else if (SystemInfo.isMac) {

--- a/src/nl/hannahsten/texifyidea/run/latex/ui/LatexSettingsEditor.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/ui/LatexSettingsEditor.kt
@@ -415,8 +415,8 @@ class LatexSettingsEditor(private var project: Project?) : SettingsEditor<LatexR
      */
     private fun addPdfViewerCommandField(panel: JPanel) {
         val viewers = InternalPdfViewer.availableSubset().filter { it != InternalPdfViewer.NONE } +
-                ExternalPdfViewers.getExternalPdfViewers() +
-                listOf(InternalPdfViewer.NONE)
+            ExternalPdfViewers.getExternalPdfViewers() +
+            listOf(InternalPdfViewer.NONE)
 
         val viewerField = ComboBox(viewers.toTypedArray())
         pdfViewer = LabeledComponent.create(viewerField, "PDF viewer")

--- a/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/OpenViewerListener.kt
+++ b/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/OpenViewerListener.kt
@@ -16,12 +16,12 @@ import org.jetbrains.concurrency.runAsync
  * Execute a forward search with the selected viewer after the compilation is done.
  */
 class OpenViewerListener(
-        private val viewer: PdfViewer,
-        val runConfig: LatexRunConfiguration,
-        private val sourceFilePath: String,
-        val line: Int,
-        val project: Project,
-        val focusAllowed: Boolean = true
+    private val viewer: PdfViewer,
+    val runConfig: LatexRunConfiguration,
+    private val sourceFilePath: String,
+    val line: Int,
+    val project: Project,
+    val focusAllowed: Boolean = true
 ) :
     ProcessListener {
 

--- a/src/nl/hannahsten/texifyidea/settings/TexifySettingsState.kt
+++ b/src/nl/hannahsten/texifyidea/settings/TexifySettingsState.kt
@@ -5,16 +5,16 @@ import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
 import nl.hannahsten.texifyidea.run.linuxpdfviewer.InternalPdfViewer
 
 data class TexifySettingsState(
-        var automaticSecondInlineMathSymbol: Boolean = true,
-        var automaticUpDownBracket: Boolean = true,
-        var automaticItemInItemize: Boolean = true,
-        var automaticDependencyCheck: Boolean = true,
-        var autoCompile: Boolean = false,
-        var autoCompileOnSaveOnly: Boolean = false,
-        var continuousPreview: Boolean = false,
-        var includeBackslashInSelection: Boolean = false,
-        var showPackagesInStructureView: Boolean = false,
-        var automaticQuoteReplacement: TexifySettings.QuoteReplacement = TexifySettings.QuoteReplacement.NONE,
-        var missingLabelMinimumLevel: LatexCommand = LatexGenericRegularCommand.SUBSECTION,
-        var pdfViewer: InternalPdfViewer = InternalPdfViewer.firstAvailable()
+    var automaticSecondInlineMathSymbol: Boolean = true,
+    var automaticUpDownBracket: Boolean = true,
+    var automaticItemInItemize: Boolean = true,
+    var automaticDependencyCheck: Boolean = true,
+    var autoCompile: Boolean = false,
+    var autoCompileOnSaveOnly: Boolean = false,
+    var continuousPreview: Boolean = false,
+    var includeBackslashInSelection: Boolean = false,
+    var showPackagesInStructureView: Boolean = false,
+    var automaticQuoteReplacement: TexifySettings.QuoteReplacement = TexifySettings.QuoteReplacement.NONE,
+    var missingLabelMinimumLevel: LatexCommand = LatexGenericRegularCommand.SUBSECTION,
+    var pdfViewer: InternalPdfViewer = InternalPdfViewer.firstAvailable()
 )

--- a/src/nl/hannahsten/texifyidea/settings/codestyle/LatexIndentOptionsEditor.kt
+++ b/src/nl/hannahsten/texifyidea/settings/codestyle/LatexIndentOptionsEditor.kt
@@ -32,8 +32,8 @@ class LatexIndentOptionsEditor(provider: LatexLanguageCodeStyleSettingsProvider)
         val isModified = super.isModified(settings, options)
         val latexSettings = settings?.getCustomSettings(LatexCodeStyleSettings::class.java) ?: return false
         return isModified ||
-                IndentOptionsEditor.isFieldModified(sectionIndents, latexSettings.INDENT_SECTIONS) ||
-                IndentOptionsEditor.isFieldModified(documentIndent, latexSettings.INDENT_DOCUMENT_ENVIRONMENT)
+            IndentOptionsEditor.isFieldModified(sectionIndents, latexSettings.INDENT_SECTIONS) ||
+            IndentOptionsEditor.isFieldModified(documentIndent, latexSettings.INDENT_DOCUMENT_ENVIRONMENT)
     }
 
     override fun apply(settings: CodeStyleSettings?, options: CommonCodeStyleSettings.IndentOptions?) {

--- a/src/nl/hannahsten/texifyidea/settings/sdk/DockerSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/DockerSdk.kt
@@ -40,9 +40,11 @@ class DockerSdk : LatexSdk("LaTeX Docker SDK") {
 
         // There's not really a path with 'sources' for docker except the location of images, but that's OS-dependent
         // and we only need to be able to execute the 'docker' executable anyway
-        return "which docker".runCommand()?.let { output -> mutableListOf(
-            output.split("/").dropLast(1).joinToString("/")
-        ) } ?: mutableListOf()
+        return "which docker".runCommand()?.let { output ->
+            mutableListOf(
+                output.split("/").dropLast(1).joinToString("/")
+            )
+        } ?: mutableListOf()
     }
 
     override fun isValidSdkHome(path: String): Boolean {

--- a/src/nl/hannahsten/texifyidea/structure/filter/CommandDefinitionFilter.kt
+++ b/src/nl/hannahsten/texifyidea/structure/filter/CommandDefinitionFilter.kt
@@ -18,9 +18,9 @@ class CommandDefinitionFilter : Filter {
             true
         }
         else !(
-                treeElement.commandName == "\\newcommand" ||
-                        treeElement.commandName in CommandMagic.mathCommandDefinitions ||
-                        treeElement.presentation is LatexOtherCommandPresentation
+            treeElement.commandName == "\\newcommand" ||
+                treeElement.commandName in CommandMagic.mathCommandDefinitions ||
+                treeElement.presentation is LatexOtherCommandPresentation
             )
     }
 

--- a/src/nl/hannahsten/texifyidea/ui/symbols/CommandUiEntry.kt
+++ b/src/nl/hannahsten/texifyidea/ui/symbols/CommandUiEntry.kt
@@ -37,9 +37,11 @@ class CommandUiEntry(
 
     override val imageLatex = customImageLatex ?: command.commandWithSlash
 
-    override val description = customDescription ?: (command.identifier
-        .lowercase(Locale.getDefault())
-        .replace("_", " ") + if (command.isMathMode) " (math)" else "")
+    override val description = customDescription ?: (
+        command.identifier
+            .lowercase(Locale.getDefault())
+            .replace("_", " ") + if (command.isMathMode) " (math)" else ""
+        )
 
     override val isMathSymbol = command.isMathMode
 }

--- a/src/nl/hannahsten/texifyidea/ui/symbols/DryUiEntry.kt
+++ b/src/nl/hannahsten/texifyidea/ui/symbols/DryUiEntry.kt
@@ -7,12 +7,12 @@ import nl.hannahsten.texifyidea.lang.commands.LatexCommand
  * @author Hannah Schellekens
  */
 class DryUiEntry(
-        override val description: String,
-        override val generatedLatex: String,
-        override val fileName: String,
-        override val imageLatex: String,
-        override val isMathSymbol: Boolean,
-        override val dependency: LatexPackage = LatexPackage.DEFAULT
+    override val description: String,
+    override val generatedLatex: String,
+    override val fileName: String,
+    override val imageLatex: String,
+    override val isMathSymbol: Boolean,
+    override val dependency: LatexPackage = LatexPackage.DEFAULT
 ) : SymbolUiEntry {
 
     override val command: LatexCommand? = null

--- a/src/nl/hannahsten/texifyidea/ui/symbols/SymbolCategories.kt
+++ b/src/nl/hannahsten/texifyidea/ui/symbols/SymbolCategories.kt
@@ -987,18 +987,20 @@ object SymbolCategories {
      *          True if the commands should be preceded with \left and \right. False if the commands alone suffice.
      */
     fun MutableList<SymbolUiEntry>.addLeftRight(
-            left: LatexCommand, right: LatexCommand, description: String, fileName: String, requireLeftRight: Boolean = true
+        left: LatexCommand, right: LatexCommand, description: String, fileName: String, requireLeftRight: Boolean = true
     ) {
         val leftCmd = if (requireLeftRight) "\\left" else ""
         val rightCmd = if (requireLeftRight) "\\right" else ""
-        add(DryUiEntry(
+        add(
+            DryUiEntry(
                 description = description,
                 generatedLatex = "$leftCmd${left.commandWithSlash} <caret> $rightCmd${right.commandWithSlash}",
                 fileName = fileName,
                 imageLatex = "$leftCmd${left.commandWithSlash}...$rightCmd${right.commandWithSlash}",
                 isMathSymbol = true,
                 dependency = left.dependency
-        ))
+            )
+        )
     }
 
     /**
@@ -1006,30 +1008,30 @@ object SymbolCategories {
      * For the parameters see [CommandUiEntry].
      */
     private fun MutableList<SymbolUiEntry>.add(
-            command: LatexCommand,
-            latex: String? = null,
-            fileName: String? = null,
-            description: String? = null,
-            image: String? = null
+        command: LatexCommand,
+        latex: String? = null,
+        fileName: String? = null,
+        description: String? = null,
+        image: String? = null
     ) = add(command.toEntry(latex, fileName, description, image))
 
     /**
      * Turns the command into a ui entry.
      */
     private fun LatexCommand.toEntry(
-            latex: String? = null,
-            fileName: String? = null,
-            description: String? = null,
-            image: String? = null
+        latex: String? = null,
+        fileName: String? = null,
+        description: String? = null,
+        image: String? = null
     ) = CommandUiEntry(this, latex, fileName, description, image)
 
     /**
      * Adds a new category to the map and initializes the symbols.
      */
     private fun MutableMap<SymbolCategory, List<SymbolUiEntry>>.createCategory(
-            name: String,
-            description: String = name,
-            symbolInitializer: MutableList<SymbolUiEntry>.() -> Unit
+        name: String,
+        description: String = name,
+        symbolInitializer: MutableList<SymbolUiEntry>.() -> Unit
     ) {
         val category = SymbolCategory(name, description)
         this[category] = ArrayList<SymbolUiEntry>().apply {

--- a/src/nl/hannahsten/texifyidea/ui/symbols/SymbolToolWindowFactory.kt
+++ b/src/nl/hannahsten/texifyidea/ui/symbols/SymbolToolWindowFactory.kt
@@ -93,7 +93,8 @@ open class SymbolToolWindowFactory : ToolWindowFactory, DumbAware {
                     JBScrollPane.HORIZONTAL_SCROLLBAR_NEVER
                 ).apply {
                     border = EmptyBorder(0, 0, 0, 0)
-                }, BorderLayout.CENTER
+                },
+                BorderLayout.CENTER
             )
         }
 
@@ -144,10 +145,10 @@ open class SymbolToolWindowFactory : ToolWindowFactory, DumbAware {
             btnSymbols.forEach { (category, symbolMap) ->
                 symbolMap.forEach { (symbol, button) ->
                     button.isVisible =
-                            // Selected category must match.
+                        // Selected category must match.
                         (selectedCategory == category || selectedCategory == SymbolCategory.ALL) &&
-                                // When a query is typed, must match as well.
-                                (query.isBlank() || symbol.queryString(category).contains(query))
+                        // When a query is typed, must match as well.
+                        (query.isBlank() || symbol.queryString(category).contains(query))
                 }
             }
         }

--- a/src/nl/hannahsten/texifyidea/ui/symbols/SymbolUiEntry.kt
+++ b/src/nl/hannahsten/texifyidea/ui/symbols/SymbolUiEntry.kt
@@ -49,7 +49,7 @@ interface SymbolUiEntry : Described {
 
     /**
      * The latex used to generate the image.
-      */
+     */
     val imageLatex: String
 
     /**

--- a/src/nl/hannahsten/texifyidea/ui/symbols/tools/SymbolImageGenerator.kt
+++ b/src/nl/hannahsten/texifyidea/ui/symbols/tools/SymbolImageGenerator.kt
@@ -26,7 +26,8 @@ fun generateSymbolImages(symbolDirectory: String, skipExisting: Boolean = true) 
         println("Generating images for symbol " + symbol.command?.commandWithSlash)
 
         if (skipExisting && File("$symbolDirectory/${symbol.fileName}").exists() &&
-                File("$symbolDirectory/${symbol.fileName}").exists()) {
+            File("$symbolDirectory/${symbol.fileName}").exists()
+        ) {
             println("> Skipping")
             return@forEach
         }
@@ -52,22 +53,22 @@ private fun SymbolUiEntry.generateImages(symbolDirectory: String) {
  * Converts the tex file to a png image.
  */
 private fun convertToImage(
-        symbol: SymbolUiEntry,
-        theme: Theme,
-        symbolDirectory: String,
-        latexFileName: String = "texify-symbol.tex",
-        auxilDirectory: String = "auxil"
+    symbol: SymbolUiEntry,
+    theme: Theme,
+    symbolDirectory: String,
+    latexFileName: String = "texify-symbol.tex",
+    auxilDirectory: String = "auxil"
 ) {
     // Create pdf.
     ProcessBuilder(
-            "pdflatex", "-job-name=texify-symbol", "-aux-directory=\"$auxilDirectory\"", latexFileName
+        "pdflatex", "-job-name=texify-symbol", "-aux-directory=\"$auxilDirectory\"", latexFileName
     ).directory(File(symbolDirectory)).start().waitFor(6, TimeUnit.SECONDS)
 
     // Convert pdf to image.
     val imageName = if (theme == Theme.DARK) symbol.fileNameDark else symbol.fileName
     ProcessBuilder(
-            "magick", "convert", "-density", DENSITY.toString(), "-quality", QUALITY.toString(), "texify-symbol.pdf",
-            imageName
+        "magick", "convert", "-density", DENSITY.toString(), "-quality", QUALITY.toString(), "texify-symbol.pdf",
+        imageName
     ).directory(File(symbolDirectory)).start().waitFor(6, TimeUnit.SECONDS)
 
     // Delete leftover pdf.

--- a/src/nl/hannahsten/texifyidea/util/Clipboard.kt
+++ b/src/nl/hannahsten/texifyidea/util/Clipboard.kt
@@ -14,8 +14,8 @@ object Clipboard {
     @JvmStatic
     fun extractHtmlFromClipboard(clipboardContents: String): String? {
         return clipboardContents.indexOf("<html", ignoreCase = true)
-                .takeIf { it >= 0 }
-                ?.let { clipboardContents.substring(it) }
+            .takeIf { it >= 0 }
+            ?.let { clipboardContents.substring(it) }
     }
 
     /**
@@ -25,8 +25,8 @@ object Clipboard {
      */
     @JvmStatic
     fun extractHtmlFragmentFromClipboard(clipboardContents: String) = clipboardContents
-            .split("<!--StartFragment-->")
-            .getOrNull(1)
-            ?.split("<!--EndFragment-->")
-            ?.first()
+        .split("<!--StartFragment-->")
+        .getOrNull(1)
+        ?.split("<!--EndFragment-->")
+        ?.first()
 }

--- a/src/nl/hannahsten/texifyidea/util/Commands.kt
+++ b/src/nl/hannahsten/texifyidea/util/Commands.kt
@@ -49,8 +49,8 @@ fun expandCommandsOnce(inputText: String, project: Project, file: PsiFile?): Str
     for (command in commandsInText) {
         // Expand the command once, and replace the command with the expanded text
         val commandExpansion = LatexCommandsIndex.getCommandsByNames(file ?: return null, *CommandMagic.commandDefinitionsAndRedefinitions.toTypedArray())
-                .firstOrNull { it.getRequiredArgumentValueByName("cmd") == command.text }
-                ?.getRequiredArgumentValueByName("def")
+            .firstOrNull { it.getRequiredArgumentValueByName("cmd") == command.text }
+            ?.getRequiredArgumentValueByName("def")
         text = text.replace(command.text, commandExpansion ?: command.text)
     }
     return text

--- a/src/nl/hannahsten/texifyidea/util/Packages.kt
+++ b/src/nl/hannahsten/texifyidea/util/Packages.kt
@@ -145,8 +145,8 @@ object PackageUtils {
             for (conflicts in PackageMagic.conflictingPackages) {
                 // Assuming the package is not already included
                 if (conflicts.contains(pack) && file.includedPackages().toSet()
-                        .intersect(conflicts)
-                        .isNotEmpty()
+                    .intersect(conflicts)
+                    .isNotEmpty()
                 ) {
                     return false
                 }

--- a/src/nl/hannahsten/texifyidea/util/Projects.kt
+++ b/src/nl/hannahsten/texifyidea/util/Projects.kt
@@ -91,7 +91,7 @@ fun Project.currentTextEditor(): TextEditor? {
  */
 fun Project.hasLatexModule(): Boolean {
     return ModuleManager.getInstance(this).modules
-            .any { it.moduleTypeName == LatexModuleType.ID }
+        .any { it.moduleTypeName == LatexModuleType.ID }
 }
 
 /**
@@ -99,8 +99,8 @@ fun Project.hasLatexModule(): Boolean {
  */
 fun Project.isLatexProject(): Boolean {
     return hasLatexModule() ||
-            getLatexRunConfigurations().isNotEmpty() ||
-            (ApplicationNamesInfo.getInstance().scriptName != "idea" && allFiles(LatexFileType).isNotEmpty())
+        getLatexRunConfigurations().isNotEmpty() ||
+        (ApplicationNamesInfo.getInstance().scriptName != "idea" && allFiles(LatexFileType).isNotEmpty())
 }
 
 /**

--- a/src/nl/hannahsten/texifyidea/util/PsiCommands.kt
+++ b/src/nl/hannahsten/texifyidea/util/PsiCommands.kt
@@ -44,8 +44,10 @@ fun LatexCommands?.usesColor() = this != null && this.name?.substring(1) in Colo
  *         `null` or otherwise.
  */
 fun LatexCommands?.isDefinitionOrRedefinition() = this != null &&
-        (this.name in CommandMagic.commandDefinitionsAndRedefinitions || this.name in CommandMagic.commandRedefinitions ||
-                this.name in CommandMagic.environmentDefinitions || this.name in CommandMagic.environmentRedefinitions)
+    (
+        this.name in CommandMagic.commandDefinitionsAndRedefinitions || this.name in CommandMagic.commandRedefinitions ||
+            this.name in CommandMagic.environmentDefinitions || this.name in CommandMagic.environmentRedefinitions
+        )
 
 /**
  * Checks whether the given LaTeX commands is a command definition or not.
@@ -131,8 +133,8 @@ fun LatexCommands.getRequiredArgumentValueByName(argument: String): String? {
 fun LatexCommands.getOptionalArgumentValueByName(argument: String): String? {
     // Find all pre-defined commands that define `this` command.
     val optionalArgIndices = LatexRegularCommand[
-            name?.substring(1)
-                ?: return null
+        name?.substring(1)
+            ?: return null
     ]
         // Find the index of their optional argument named [argument].
         ?.map {

--- a/src/nl/hannahsten/texifyidea/util/Strings.kt
+++ b/src/nl/hannahsten/texifyidea/util/Strings.kt
@@ -176,10 +176,10 @@ fun String.formatAsFilePath(): String {
  */
 fun String.formatAsLabel(): String {
     return this.let { Normalizer.normalize(it, Normalizer.Form.NFKD) }
-            .replace(" ", "-")
-            .removeAll("%", "~", "#", "\\", ",")
-            .replace("[^\\x00-\\x7F]".toRegex(), "")
-            .lowercase(Locale.getDefault())
+        .replace(" ", "-")
+        .removeAll("%", "~", "#", "\\", ",")
+        .replace("[^\\x00-\\x7F]".toRegex(), "")
+        .lowercase(Locale.getDefault())
 }
 
 /**

--- a/src/nl/hannahsten/texifyidea/util/UserInterface.kt
+++ b/src/nl/hannahsten/texifyidea/util/UserInterface.kt
@@ -33,10 +33,10 @@ import javax.swing.text.JTextComponent
 fun toast(project: Project, type: MessageType, htmlMessage: String) {
     val statusBar = WindowManager.getInstance().getStatusBar(project)
     JBPopupFactory.getInstance()
-            .createHtmlTextBalloonBuilder(htmlMessage, type, null)
-            .setFadeoutTime(7500)
-            .createBalloon()
-            .show(RelativePoint.getCenterOf(statusBar.component), Balloon.Position.above)
+        .createHtmlTextBalloonBuilder(htmlMessage, type, null)
+        .setFadeoutTime(7500)
+        .createBalloon()
+        .show(RelativePoint.getCenterOf(statusBar.component), Balloon.Position.above)
 }
 
 /**
@@ -150,10 +150,10 @@ fun JTextComponent.setInputFilter(allowedCharacters: Set<Char>) = addKeyTypedLis
  *          The fixed label width, or `null` to use the label's inherent size.
  */
 fun JPanel.addLabeledComponent(
-        component: JComponent,
-        description: String,
-        labelWidth: Int? = null,
-        leftPadding: Int = 16
+    component: JComponent,
+    description: String,
+    labelWidth: Int? = null,
+    leftPadding: Int = 16
 ): JPanel {
     // Uses a border layout with West for the label and Center for the control itself.
     // East is reserved for suffix elements.

--- a/src/nl/hannahsten/texifyidea/util/files/Files.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/Files.kt
@@ -86,7 +86,7 @@ fun String.getFileExtension(): String = if (this.contains(".")) FileUtil.FILE_BO
  */
 fun Module.createExcludedDir(path: String) {
     ModuleRootManager.getInstance(this).modifiableModel.addContentEntry(path)
-            .addExcludeFolder(path)
+        .addExcludeFolder(path)
 }
 
 /**
@@ -131,7 +131,7 @@ fun createFile(fileName: String, contents: String): File {
  * Get a(n external) file by its absolute path.
  */
 fun getExternalFile(path: String): VirtualFile? =
-        LocalFileSystem.getInstance().findFileByPath(path)
+    LocalFileSystem.getInstance().findFileByPath(path)
 
 /**
  * Converts the absolute path to a relative path.
@@ -166,12 +166,12 @@ fun Transferable.extractFile() = extractFiles()?.firstOrNull()
  * @return The relative path, relative to all source roots. `null` when no relative path could be found.
  */
 fun ProjectRootManager.relativizePath(absoluteFilePath: String): String? = contentSourceRoots.asSequence()
-        .map { it to absoluteFilePath.toRelativePath(it.path) }
-        .firstOrNull { (contentRoot, relativePath) ->
-            // Make sure to convert to the right file when multiple files exist in the content
-            // roots with the same name. Also convert to [File]s to normalize path names.
-            val original = File(absoluteFilePath)
-            val candidate = File("${contentRoot.path}/$relativePath")
-            candidate.absolutePath == original.absolutePath
-        }
-        ?.second
+    .map { it to absoluteFilePath.toRelativePath(it.path) }
+    .firstOrNull { (contentRoot, relativePath) ->
+        // Make sure to convert to the right file when multiple files exist in the content
+        // roots with the same name. Also convert to [File]s to normalize path names.
+        val original = File(absoluteFilePath)
+        val candidate = File("${contentRoot.path}/$relativePath")
+        candidate.absolutePath == original.absolutePath
+    }
+    ?.second

--- a/src/nl/hannahsten/texifyidea/util/magic/ColorMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/ColorMagic.kt
@@ -9,37 +9,37 @@ object ColorMagic {
      * All commands that have a color as an argument.
      */
     val takeColorCommands = LatexRegularCommand.values()
-            .filter { cmd -> cmd.arguments.map { it.name }.contains("color") }
-            .map { it.command }
+        .filter { cmd -> cmd.arguments.map { it.name }.contains("color") }
+        .map { it.command }
 
     /**
      * All commands that define a new color.
      */
     val colorDefinitions = LatexRegularCommand.values()
-            .filter { cmd -> cmd.dependency == LatexPackage.XCOLOR }
-            .filter { cmd -> cmd.arguments.map { it.name }.contains("name") }
+        .filter { cmd -> cmd.dependency == LatexPackage.XCOLOR }
+        .filter { cmd -> cmd.arguments.map { it.name }.contains("name") }
 
     val colorCommands = takeColorCommands + colorDefinitions.map { it.command }
 
     val defaultXcolors = mapOf(
-            "red" to 0xff0000,
-            "green" to 0x00ff00,
-            "blue" to 0x0000ff,
-            "cyan" to 0x00ffff,
-            "magenta" to 0xff00ff,
-            "yellow" to 0xffff00,
-            "black" to 0x000000,
-            "gray" to 0x808080,
-            "white" to 0xffffff,
-            "darkgray" to 0x404040,
-            "lightgray" to 0xbfbfbf,
-            "brown" to 0xfb8040,
-            "lime" to 0xbfff00,
-            "olive" to 0x808000,
-            "orange" to 0xff8000,
-            "pink" to 0xffbfbf,
-            "purple" to 0xbf0040,
-            "teal" to 0x008080,
-            "violet" to 0x800080
+        "red" to 0xff0000,
+        "green" to 0x00ff00,
+        "blue" to 0x0000ff,
+        "cyan" to 0x00ffff,
+        "magenta" to 0xff00ff,
+        "yellow" to 0xffff00,
+        "black" to 0x000000,
+        "gray" to 0x808080,
+        "white" to 0xffffff,
+        "darkgray" to 0x404040,
+        "lightgray" to 0xbfbfbf,
+        "brown" to 0xfb8040,
+        "lime" to 0xbfff00,
+        "olive" to 0x808000,
+        "orange" to 0xff8000,
+        "pink" to 0xffbfbf,
+        "purple" to 0xbf0040,
+        "teal" to 0x008080,
+        "violet" to 0x800080
     )
 }

--- a/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
@@ -25,23 +25,23 @@ object CommandMagic {
      * LaTeX commands that make the text take up more vertical space.
      */
     val high = hashSetOf(
-            FRAC.cmd, DFRAC.cmd, SQUARE_ROOT.cmd, SUM.cmd, INTEGRAL.cmd, DOUBLE_INTEGRAL.cmd, TRIPLE_INTEGRAL.cmd,
-            QUADRUPLE_INTEGRAL.cmd, N_ARY_PRODUCT.cmd, N_ARY_UNION.cmd, N_ARY_INTERSECTION.cmd,
-            N_ARY_SQUARE_UNION.cmd, BIG_SQUARE_CAP.cmd
+        FRAC.cmd, DFRAC.cmd, SQUARE_ROOT.cmd, SUM.cmd, INTEGRAL.cmd, DOUBLE_INTEGRAL.cmd, TRIPLE_INTEGRAL.cmd,
+        QUADRUPLE_INTEGRAL.cmd, N_ARY_PRODUCT.cmd, N_ARY_UNION.cmd, N_ARY_INTERSECTION.cmd,
+        N_ARY_SQUARE_UNION.cmd, BIG_SQUARE_CAP.cmd
     )
 
     /**
      * Level of labeled commands.
      */
     val labeledLevels: Map<LatexCommand, Int> = mapOf(
-            // See page 23 of the LaTeX Companion
-            PART to -1, // actually, it is level 0 in classes that do not define \chapter and -1 in book and report
-            CHAPTER to 0,
-            SECTION to 1,
-            SUBSECTION to 2,
-            SUBSUBSECTION to 3,
-            PARAGRAPH to 4,
-            SUBPARAGRAPH to 5
+        // See page 23 of the LaTeX Companion
+        PART to -1, // actually, it is level 0 in classes that do not define \chapter and -1 in book and report
+        CHAPTER to 0,
+        SECTION to 1,
+        SUBSECTION to 2,
+        SUBSUBSECTION to 3,
+        PARAGRAPH to 4,
+        SUBPARAGRAPH to 5
     )
 
     /** Section commands sorted from large to small. */
@@ -57,26 +57,26 @@ object CommandMagic {
      * All commands that mark some kind of section.
      */
     val sectionMarkers = listOf(
-            PART,
-            CHAPTER,
-            SECTION,
-            SUBSECTION,
-            SUBSUBSECTION,
-            PARAGRAPH,
-            SUBPARAGRAPH
+        PART,
+        CHAPTER,
+        SECTION,
+        SUBSECTION,
+        SUBSUBSECTION,
+        PARAGRAPH,
+        SUBPARAGRAPH
     ).map { it.cmd }
 
     /**
      * The colours that each section separator has.
      */
     val sectionSeparatorColors = mapOf(
-            PART.cmd to Color(152, 152, 152),
-            CHAPTER.cmd to Color(172, 172, 172),
-            SECTION.cmd to Color(182, 182, 182),
-            SUBSECTION.cmd to Color(202, 202, 202),
-            SUBSUBSECTION.cmd to Color(212, 212, 212),
-            PARAGRAPH.cmd to Color(222, 222, 222),
-            SUBPARAGRAPH.cmd to Color(232, 232, 232)
+        PART.cmd to Color(152, 152, 152),
+        CHAPTER.cmd to Color(172, 172, 172),
+        SECTION.cmd to Color(182, 182, 182),
+        SUBSECTION.cmd to Color(202, 202, 202),
+        SUBSUBSECTION.cmd to Color(212, 212, 212),
+        PARAGRAPH.cmd to Color(222, 222, 222),
+        SUBPARAGRAPH.cmd to Color(232, 232, 232)
     )
 
     /**
@@ -89,7 +89,7 @@ object CommandMagic {
      * All commands that represent a reference to a label, excluding user defined commands.
      */
     val labelReferenceWithoutCustomCommands = hashSetOf(
-            REF, EQREF, NAMEREF, AUTOREF, FULLREF, PAGEREF, VREF, AUTOREF_CAPITAL, CREF, CREF_CAPITAL, LABELCREF, CPAGEREF
+        REF, EQREF, NAMEREF, AUTOREF, FULLREF, PAGEREF, VREF, AUTOREF_CAPITAL, CREF, CREF_CAPITAL, LABELCREF, CPAGEREF
     ).map { it.cmd }.toSet()
 
     /**
@@ -223,21 +223,21 @@ object CommandMagic {
      */
     @JvmField
     val slashlessMathOperators = hashSetOf(
-            INVERSE_COSINE, INVERSE_SINE, INVERSE_TANGENT, ARGUMENT, BMOD, COSINE, HYPERBOLIC_COSINE, COTANGENT,
-            HYPERBOLIC_COTANGENT, COSECANT, DEGREES, DERMINANT, DIMENSION, EXPONENTIAL, GREATEST_COMMON_DIVISOR,
-            HOMOMORPHISM, INFINUM, KERNEL, BASE_2_LOGARITHM, LIMIT, LIMIT_INFERIOR, LIMIT_SUPERIOR,
-            NATURAL_LOGARITHM, LOGARITHM, MAXIMUM, MINIMUM, PMOD, PROBABILITY, SECANT, SINE,
-            HYPERBOLIC_SINE, SUPREMUM, TANGENT, HBOLICTANGENT
+        INVERSE_COSINE, INVERSE_SINE, INVERSE_TANGENT, ARGUMENT, BMOD, COSINE, HYPERBOLIC_COSINE, COTANGENT,
+        HYPERBOLIC_COTANGENT, COSECANT, DEGREES, DERMINANT, DIMENSION, EXPONENTIAL, GREATEST_COMMON_DIVISOR,
+        HOMOMORPHISM, INFINUM, KERNEL, BASE_2_LOGARITHM, LIMIT, LIMIT_INFERIOR, LIMIT_SUPERIOR,
+        NATURAL_LOGARITHM, LOGARITHM, MAXIMUM, MINIMUM, PMOD, PROBABILITY, SECANT, SINE,
+        HYPERBOLIC_SINE, SUPREMUM, TANGENT, HBOLICTANGENT
     )
 
     /**
      * All commands that define regular commands, and that require that the command is not already defined.
      */
     val regularStrictCommandDefinitions = hashSetOf(
-            NEWCOMMAND.cmd,
-            NEWCOMMAND_STAR.cmd,
-            NEWIF.cmd,
-            NEWDOCUMENTCOMMAND.cmd,
+        NEWCOMMAND.cmd,
+        NEWCOMMAND_STAR.cmd,
+        NEWIF.cmd,
+        NEWDOCUMENTCOMMAND.cmd,
     )
 
     /**
@@ -256,9 +256,9 @@ object CommandMagic {
      * All commands that define or redefine other commands, whether it exists or not.
      */
     val commandRedefinitions = setOf(
-            RENEWCOMMAND,
-            RENEWCOMMAND_STAR,
-            CATCODE, // Not really redefining commands, but characters
+        RENEWCOMMAND,
+        RENEWCOMMAND_STAR,
+        CATCODE, // Not really redefining commands, but characters
     ).map { it.cmd } + flexibleCommandDefinitions
 
     /**
@@ -271,10 +271,10 @@ object CommandMagic {
      * in math mode.
      */
     val mathCommandDefinitions = hashSetOf(
-            DECLARE_MATH_OPERATOR.cmd,
-            DECLARE_PAIRED_DELIMITER.cmd,
-            DECLARE_PAIRED_DELIMITER_X.cmd,
-            DECLARE_PAIRED_DELIMITER_XPP.cmd
+        DECLARE_MATH_OPERATOR.cmd,
+        DECLARE_PAIRED_DELIMITER.cmd,
+        DECLARE_PAIRED_DELIMITER_X.cmd,
+        DECLARE_PAIRED_DELIMITER_XPP.cmd
     )
 
     /**
@@ -301,15 +301,15 @@ object CommandMagic {
      * All commands that define new environments.
      */
     val environmentDefinitions = hashSetOf(
-            NEWENVIRONMENT,
-            NEWTHEOREM,
-            NEWDOCUMENTENVIRONMENT,
-            PROVIDEDOCUMENTENVIRONMENT,
-            DECLAREDOCUMENTENVIRONMENT,
-            NEWTCOLORBOX,
-            DECLARETCOLORBOX,
-            NEWTCOLORBOX_,
-            PROVIDETCOLORBOX,
+        NEWENVIRONMENT,
+        NEWTHEOREM,
+        NEWDOCUMENTENVIRONMENT,
+        PROVIDEDOCUMENTENVIRONMENT,
+        DECLAREDOCUMENTENVIRONMENT,
+        NEWTCOLORBOX,
+        DECLARETCOLORBOX,
+        NEWTCOLORBOX_,
+        PROVIDETCOLORBOX,
     ).map { it.cmd }
 
     /**
@@ -330,30 +330,30 @@ object CommandMagic {
      * Commands for which TeXiFy-IDEA has essential custom behaviour and which should not be redefined.
      */
     val fragile = hashSetOf(
-            "\\addtocounter", "\\begin", "\\chapter", "\\def", "\\documentclass", "\\end",
-            "\\include", "\\includeonly", "\\input", "\\label", "\\let", "\\newcommand",
-            "\\overline", "\\paragraph", "\\part", "\\renewcommand", "\\section", "\\setcounter",
-            "\\sout", "\\subparagraph", "\\subsection", "\\subsubsection", "\\textbf",
-            "\\textit", "\\textsc", "\\textsl", "\\texttt", "\\underline", "\\[", "\\]",
-            "\\newenvironment", "\\bibitem",
-            "\\NewDocumentCommand",
-            "\\ProvideDocumentCommand",
-            "\\DeclareDocumentCommand",
-            "\\NewDocumentEnvironment",
-            "\\ProvideDocumentEnvironment",
-            "\\DeclareDocumentEnvironment"
+        "\\addtocounter", "\\begin", "\\chapter", "\\def", "\\documentclass", "\\end",
+        "\\include", "\\includeonly", "\\input", "\\label", "\\let", "\\newcommand",
+        "\\overline", "\\paragraph", "\\part", "\\renewcommand", "\\section", "\\setcounter",
+        "\\sout", "\\subparagraph", "\\subsection", "\\subsubsection", "\\textbf",
+        "\\textit", "\\textsc", "\\textsl", "\\texttt", "\\underline", "\\[", "\\]",
+        "\\newenvironment", "\\bibitem",
+        "\\NewDocumentCommand",
+        "\\ProvideDocumentCommand",
+        "\\DeclareDocumentCommand",
+        "\\NewDocumentEnvironment",
+        "\\ProvideDocumentEnvironment",
+        "\\DeclareDocumentEnvironment"
     )
 
     /**
      * Commands that should not have the given file extensions.
      */
     val illegalExtensions = mapOf(
-            INCLUDE.cmd to listOf(".tex"),
-            SUBFILEINCLUDE.cmd to listOf(".tex"),
-            BIBLIOGRAPHY.cmd to listOf(".bib"),
-            INCLUDEGRAPHICS.cmd to FileMagic.graphicFileExtensions.map { ".$it" }, // https://tex.stackexchange.com/a/1075/98850
-            USEPACKAGE.cmd to listOf(".sty"),
-            EXTERNALDOCUMENT.cmd to listOf(".tex"),
+        INCLUDE.cmd to listOf(".tex"),
+        SUBFILEINCLUDE.cmd to listOf(".tex"),
+        BIBLIOGRAPHY.cmd to listOf(".bib"),
+        INCLUDEGRAPHICS.cmd to FileMagic.graphicFileExtensions.map { ".$it" }, // https://tex.stackexchange.com/a/1075/98850
+        USEPACKAGE.cmd to listOf(".sty"),
+        EXTERNALDOCUMENT.cmd to listOf(".tex"),
     )
 
     /**
@@ -371,24 +371,24 @@ object CommandMagic {
      * Commands that should have the given file extensions.
      */
     val requiredExtensions = mapOf(
-            ADDBIBRESOURCE.cmd to listOf("bib")
+        ADDBIBRESOURCE.cmd to listOf("bib")
     )
 
     /**
      * Extensions that should only be scanned for the provided include commands.
      */
     val includeOnlyExtensions: Map<String, Set<String>> = mapOf(
-            INCLUDE.cmd to hashSetOf("tex"),
-            INCLUDEONLY.cmd to hashSetOf("tex"),
-            SUBFILE.cmd to hashSetOf("tex"),
-            SUBFILEINCLUDE.cmd to hashSetOf("tex"),
-            BIBLIOGRAPHY.cmd to hashSetOf("bib"),
-            ADDBIBRESOURCE.cmd to hashSetOf("bib"),
-            REQUIREPACKAGE.cmd to hashSetOf("sty"),
-            USEPACKAGE.cmd to hashSetOf("sty"),
-            DOCUMENTCLASS.cmd to hashSetOf("cls"),
-            LOADCLASS.cmd to hashSetOf("cls"),
-            EXTERNALDOCUMENT.cmd to hashSetOf("tex") // Not completely true, as it only includes labels. Technically it references an aux file
+        INCLUDE.cmd to hashSetOf("tex"),
+        INCLUDEONLY.cmd to hashSetOf("tex"),
+        SUBFILE.cmd to hashSetOf("tex"),
+        SUBFILEINCLUDE.cmd to hashSetOf("tex"),
+        BIBLIOGRAPHY.cmd to hashSetOf("bib"),
+        ADDBIBRESOURCE.cmd to hashSetOf("bib"),
+        REQUIREPACKAGE.cmd to hashSetOf("sty"),
+        USEPACKAGE.cmd to hashSetOf("sty"),
+        DOCUMENTCLASS.cmd to hashSetOf("cls"),
+        LOADCLASS.cmd to hashSetOf("cls"),
+        EXTERNALDOCUMENT.cmd to hashSetOf("tex") // Not completely true, as it only includes labels. Technically it references an aux file
     )
 
     /**
@@ -398,12 +398,12 @@ object CommandMagic {
 
     @Suppress("unused")
     val startIfs = hashSetOf(
-            IF, IFCAT, IFX,
-            IFCASE, IFNUM, IFODD,
-            IFHMODE, IFVMODE, IFMMODE,
-            IFINNER, IFDIM, IFVOID,
-            IFHBOX, IFVBOX, IFEOF,
-            IFTRUE, IFFALSE
+        IF, IFCAT, IFX,
+        IFCASE, IFNUM, IFODD,
+        IFHMODE, IFVMODE, IFMMODE,
+        IFINNER, IFDIM, IFVOID,
+        IFHBOX, IFVBOX, IFEOF,
+        IFTRUE, IFFALSE
     ).map { it.cmd }
 
     /**
@@ -420,24 +420,24 @@ object CommandMagic {
      * List of all TeX style primitives.
      */
     val stylePrimitives = listOf(
-            RM.cmd, SF.cmd, TT.cmd, IT.cmd, SL.cmd, SC.cmd, BF.cmd
+        RM.cmd, SF.cmd, TT.cmd, IT.cmd, SL.cmd, SC.cmd, BF.cmd
     )
 
     /**
      * The LaTeX counterparts of all [stylePrimitives] commands where %s is the content.
      */
     val stylePrimitveReplacements = listOf(
-            "\\textrm{%s}", "\\textsf{%s}", "\\texttt{%s}", "\\textit{%s}",
-            "\\textsl{%s}", "\\textsc{%s}", "\\textbf{%s}"
+        "\\textrm{%s}", "\\textsf{%s}", "\\texttt{%s}", "\\textit{%s}",
+        "\\textsl{%s}", "\\textsc{%s}", "\\textbf{%s}"
     )
 
     /**
      * Set of text styling commands
      */
     val textStyles = setOf(
-            TEXTRM, TEXTSF, TEXTTT, TEXTIT,
-            TEXTSL, TEXTSC, TEXTBF, EMPH,
-            TEXTUP, TEXTMD
+        TEXTRM, TEXTSF, TEXTTT, TEXTIT,
+        TEXTSL, TEXTSC, TEXTBF, EMPH,
+        TEXTUP, TEXTMD
     ).map { it.cmd }
 
     /**
@@ -456,8 +456,8 @@ object CommandMagic {
      * Maps the name of the command to the registered Language id.
      */
     val languageInjections = hashMapOf(
-            DIRECTLUA.cmd to "Lua",
-            LUAEXEC.cmd to "Lua"
+        DIRECTLUA.cmd to "Lua",
+        LUAEXEC.cmd to "Lua"
     )
 
     /**

--- a/src/nl/hannahsten/texifyidea/util/magic/EnvironmentMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/EnvironmentMagic.kt
@@ -41,8 +41,8 @@ object EnvironmentMagic {
      * Maps the name of the environment to the registered Language id.
      */
     val languageInjections = hashMapOf(
-            LUACODE.env to "Lua",
-            LUACODE_STAR.env to "Lua"
+        LUACODE.env to "Lua",
+        LUACODE_STAR.env to "Lua"
     )
 
     val algorithmEnvironments = setOf(ALGORITHMIC.env)
@@ -51,20 +51,20 @@ object EnvironmentMagic {
      * All environments that define a matrix.
      */
     val matrixEnvironments = setOf(
-            "matrix", "pmatrix", "bmatrix", "vmatrix", "Bmatrix", "Vmatrix",
-            "matrix*", "pmatrix*", "bmatrix*", "vmatrix*", "Bmatrix*", "Vmatrix*",
-            "smallmatrix", "psmallmatrix", "bsmallmatrix", "vsmallmatrix", "Bsmallmatrix", "Vsmallmatrix",
-            "smallmatrix*", "psmallmatrix*", "bsmallmatrix*", "vsmallmatrix*", "Bsmallmatrix*", "Vsmallmatrix*",
-            "gmatrix", "tikz-cd"
+        "matrix", "pmatrix", "bmatrix", "vmatrix", "Bmatrix", "Vmatrix",
+        "matrix*", "pmatrix*", "bmatrix*", "vmatrix*", "Bmatrix*", "Vmatrix*",
+        "smallmatrix", "psmallmatrix", "bsmallmatrix", "vsmallmatrix", "Bsmallmatrix", "Vsmallmatrix",
+        "smallmatrix*", "psmallmatrix*", "bsmallmatrix*", "vsmallmatrix*", "Bsmallmatrix*", "Vsmallmatrix*",
+        "gmatrix", "tikz-cd"
     )
 
     val alignableEnvironments = setOf(
-            "eqnarray", "eqnarray*",
-            "split",
-            "align", "align*",
-            "alignat", "alignat*",
-            "flalign", "flalign*",
-            "aligned", "alignedat",
-            "cases", "dcases"
+        "eqnarray", "eqnarray*",
+        "split",
+        "align", "align*",
+        "alignat", "alignat*",
+        "flalign", "flalign*",
+        "aligned", "alignedat",
+        "cases", "dcases"
     ) + matrixEnvironments
 }

--- a/src/nl/hannahsten/texifyidea/util/magic/FileMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/FileMagic.kt
@@ -12,19 +12,19 @@ object FileMagic {
     val includeExtensions = hashSetOf("tex", "sty", "cls", "bib")
 
     val automaticExtensions = mapOf(
-            INCLUDE.cmd to LatexFileType.defaultExtension,
-            BIBLIOGRAPHY.cmd to BibtexFileType.defaultExtension
+        INCLUDE.cmd to LatexFileType.defaultExtension,
+        BIBLIOGRAPHY.cmd to BibtexFileType.defaultExtension
     )
 
     /**
      * All possible file types.
      */
     val fileTypes = setOf(
-            LatexFileType,
-            StyleFileType,
-            ClassFileType,
-            BibtexFileType,
-            TikzFileType
+        LatexFileType,
+        StyleFileType,
+        ClassFileType,
+        BibtexFileType,
+        TikzFileType
     )
 
     /**

--- a/src/nl/hannahsten/texifyidea/util/magic/IconMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/IconMagic.kt
@@ -8,15 +8,15 @@ object IconMagic {
      * Maps file extentions to their corresponding icons.
      */
     val fileIcons = mapOf(
-            "pdf" to TexifyIcons.PDF_FILE,
-            "dvi" to TexifyIcons.DVI_FILE,
-            "synctex.gz" to TexifyIcons.SYNCTEX_FILE,
-            "bbl" to TexifyIcons.BBL_FILE,
-            "aux" to TexifyIcons.AUX_FILE,
-            "tmp" to TexifyIcons.TEMP_FILE,
-            "dtx" to TexifyIcons.DOCUMENTED_LATEX_SOURCE,
-            "bib" to TexifyIcons.BIBLIOGRAPHY_FILE,
-            "toc" to TexifyIcons.TABLE_OF_CONTENTS_FILE,
-            "tikz" to TexifyIcons.TIKZ_FILE
+        "pdf" to TexifyIcons.PDF_FILE,
+        "dvi" to TexifyIcons.DVI_FILE,
+        "synctex.gz" to TexifyIcons.SYNCTEX_FILE,
+        "bbl" to TexifyIcons.BBL_FILE,
+        "aux" to TexifyIcons.AUX_FILE,
+        "tmp" to TexifyIcons.TEMP_FILE,
+        "dtx" to TexifyIcons.DOCUMENTED_LATEX_SOURCE,
+        "bib" to TexifyIcons.BIBLIOGRAPHY_FILE,
+        "toc" to TexifyIcons.TABLE_OF_CONTENTS_FILE,
+        "tikz" to TexifyIcons.TIKZ_FILE
     )
 }

--- a/src/nl/hannahsten/texifyidea/util/magic/PackageMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/PackageMagic.kt
@@ -18,15 +18,15 @@ object PackageMagic {
      * All unicode enabling packages.
      */
     val unicode = hashSetOf(
-            LatexPackage.INPUTENC.with("utf8"),
-            LatexPackage.FONTENC.with("T1")
+        LatexPackage.INPUTENC.with("utf8"),
+        LatexPackage.FONTENC.with("T1")
     )
 
     /**
      * All known packages which provide an index.
      */
     val index = hashSetOf(
-            MAKEIDX, MULTIND, INDEX, SPLITIDX, SPLITINDEX, IMAKEIDX, HVINDEX, IDXLAYOUT, REPEATINDEX, INDEXTOOLS
+        MAKEIDX, MULTIND, INDEX, SPLITIDX, SPLITINDEX, IMAKEIDX, HVINDEX, IDXLAYOUT, REPEATINDEX, INDEXTOOLS
     )
 
     /**
@@ -38,7 +38,7 @@ object PackageMagic {
      * Known conflicting packages.
      */
     val conflictingPackages = listOf(
-            setOf(LatexPackage.BIBLATEX, LatexPackage.NATBIB)
+        setOf(LatexPackage.BIBLATEX, LatexPackage.NATBIB)
     )
 
     /**
@@ -47,12 +47,12 @@ object PackageMagic {
      * This list is just there as a sort of default for those users who do not have LaTeX packages installed for example.
      */
     val packagesLoadingOtherPackages: Map<LatexPackage, Set<LatexPackage>> = mapOf(
-            LatexPackage.AMSSYMB to setOf(LatexPackage.AMSFONTS),
-            LatexPackage.MATHTOOLS to setOf(LatexPackage.AMSMATH),
-            LatexPackage.GRAPHICX to setOf(LatexPackage.GRAPHICS),
-            LatexPackage.XCOLOR to setOf(LatexPackage.COLOR),
-            LatexPackage.PDFCOMMENT to setOf(LatexPackage.HYPERREF),
-            LatexPackage.ALGORITHM2E to setOf(LatexPackage.ALGPSEUDOCODE), // This is not true, but loading any of these two (incompatible) packages is sufficient as they provide the same commands (roughly)
+        LatexPackage.AMSSYMB to setOf(LatexPackage.AMSFONTS),
+        LatexPackage.MATHTOOLS to setOf(LatexPackage.AMSMATH),
+        LatexPackage.GRAPHICX to setOf(LatexPackage.GRAPHICS),
+        LatexPackage.XCOLOR to setOf(LatexPackage.COLOR),
+        LatexPackage.PDFCOMMENT to setOf(LatexPackage.HYPERREF),
+        LatexPackage.ALGORITHM2E to setOf(LatexPackage.ALGPSEUDOCODE), // This is not true, but loading any of these two (incompatible) packages is sufficient as they provide the same commands (roughly)
     )
 
     /**
@@ -60,18 +60,18 @@ object PackageMagic {
      * optional (false).
      */
     val xparseParamSpecifiers = mapOf(
-            'm' to true,
-            'r' to true,
-            'R' to true,
-            'v' to true,
-            'b' to true,
-            'o' to false,
-            'd' to false,
-            'O' to false,
-            'D' to false,
-            's' to false,
-            't' to false,
-            'e' to false,
-            'E' to false
+        'm' to true,
+        'r' to true,
+        'R' to true,
+        'v' to true,
+        'b' to true,
+        'o' to false,
+        'd' to false,
+        'O' to false,
+        'D' to false,
+        's' to false,
+        't' to false,
+        'e' to false,
+        'E' to false
     )
 }

--- a/src/nl/hannahsten/texifyidea/util/magic/PatternMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/PatternMagic.kt
@@ -58,7 +58,7 @@ object PatternMagic {
      * Abbreviations not detected by [PatternMagic.abbreviation].
      */
     val unRegexableAbbreviations = listOf(
-            "et al."
+        "et al."
     )
 
     /** [abbreviation]s that are missing a normal space (or a non-breaking space) */
@@ -121,10 +121,10 @@ object PatternMagic {
      * Matches the begin and end commands of the cases and split environments.
      */
     val casesOrSplitCommands = Regex(
-            "((?=\\\\begin\\{cases})|(?<=\\\\begin\\{cases}))" +
-                    "|((?=\\\\end\\{cases})|(?<=\\\\end\\{cases}))" +
-                    "|((?=\\\\begin\\{split})|(?<=\\\\begin\\{split}))" +
-                    "|((?=\\\\end\\{split})|(?<=\\\\end\\{split}))"
+        "((?=\\\\begin\\{cases})|(?<=\\\\begin\\{cases}))" +
+            "|((?=\\\\end\\{cases})|(?<=\\\\end\\{cases}))" +
+            "|((?=\\\\begin\\{split})|(?<=\\\\begin\\{split}))" +
+            "|((?=\\\\end\\{split})|(?<=\\\\end\\{split}))"
     )
 
     /**

--- a/src/nl/hannahsten/texifyidea/util/magic/TypographyMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/TypographyMagic.kt
@@ -9,25 +9,25 @@ object TypographyMagic {
      */
     @JvmField
     val braceOpposites = mapOfVarargs(
-            "(", ")",
-            "[", "]",
-            "\\{", "\\}",
-            "<", ">",
-            "|", "|",
-            "\\|", "\\|"
+        "(", ")",
+        "[", "]",
+        "\\{", "\\}",
+        "<", ">",
+        "|", "|",
+        "\\|", "\\|"
     )
 
     /**
      * Algorithmicx pairs (also hardcoded in lexer).
      */
     val pseudoCodeBeginEndOpposites = mapOf(
-            "If" to "EndIf",
-            "For" to "EndFor",
-            "ForAll" to "EndFor",
-            "While" to "EndWhile",
-            "Repeat" to "Until",
-            "Loop" to "EndLoop",
-            "Function" to "EndFunction",
-            "Procedure" to "EndProcedure"
+        "If" to "EndIf",
+        "For" to "EndFor",
+        "ForAll" to "EndFor",
+        "While" to "EndWhile",
+        "Repeat" to "Until",
+        "Loop" to "EndLoop",
+        "Function" to "EndFunction",
+        "Procedure" to "EndProcedure"
     )
 }

--- a/test/nl/hannahsten/texifyidea/completion/BibtexCompletionTest.kt
+++ b/test/nl/hannahsten/texifyidea/completion/BibtexCompletionTest.kt
@@ -16,10 +16,12 @@ class BibtexCompletionTest : BasePlatformTestCase() {
     fun testPreamble() {
         myFixture.configureByText(BibtexFileType, """@prea<caret>""")
         myFixture.complete(CompletionType.BASIC)
-        myFixture.checkResult("""
+        myFixture.checkResult(
+            """
             @preamble{
                 ""
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 }

--- a/test/nl/hannahsten/texifyidea/completion/LatexMagicCommentCompletionTest.kt
+++ b/test/nl/hannahsten/texifyidea/completion/LatexMagicCommentCompletionTest.kt
@@ -7,40 +7,54 @@ import nl.hannahsten.texifyidea.file.LatexFileType
 class LatexMagicCommentCompletionTest : BasePlatformTestCase() {
 
     fun `test magic comment key completion`() {
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             %! comp<caret>
             Kaas
-            """.trimIndent())
+            """.trimIndent()
+        )
         val result = myFixture.complete(CompletionType.BASIC)
         assert(result.any { it.lookupString == "Compiler" })
     }
 
     fun `test magic comment value completion`() {
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             %! begin preamble = t<caret>
             Frikandel
-            """.trimIndent())
+            """.trimIndent()
+        )
         val result = myFixture.complete(CompletionType.BASIC)
         assert(result.any { it.lookupString == "tikz" })
     }
 
     fun `test completion of fake without =`() {
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             %! fak<caret>
             Kroket
-            """.trimIndent())
+            """.trimIndent()
+        )
         myFixture.complete(CompletionType.BASIC)
-        myFixture.checkResult("""
+        myFixture.checkResult(
+            """
             %! fake <caret>
             Kroket
-            """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     fun `test completion of fake section`() {
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             %! fake sect<caret>
             Kip
-        """.trimMargin())
+        """.trimMargin()
+        )
         val result = myFixture.complete(CompletionType.BASIC)
         kotlin.test.assertEquals(3, result.size)
         assert(result.any { it.lookupString == "section" })

--- a/test/nl/hannahsten/texifyidea/completion/LatexPathCompletionWithCommandExpansion.kt
+++ b/test/nl/hannahsten/texifyidea/completion/LatexPathCompletionWithCommandExpansion.kt
@@ -42,10 +42,13 @@ class LatexPathCompletionWithCommandExpansion : BasePlatformTestCase() {
     fun `test expansion in path completion`() {
         // For this use case you would usually use \graphicspath, but just to test that it also works for other use cases
         // than subfiles.
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             \newcommand{\img}{images}
             \includegraphics{\img/p<caret>}
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val result = myFixture.complete(CompletionType.BASIC)
 

--- a/test/nl/hannahsten/texifyidea/editor/LatexParagraphFillHandlerTest.kt
+++ b/test/nl/hannahsten/texifyidea/editor/LatexParagraphFillHandlerTest.kt
@@ -15,49 +15,60 @@ class LatexParagraphFillHandlerTest : BasePlatformTestCase() {
     }
 
     fun `test at start of environment`() {
-        testFillParagraph("""
+        testFillParagraph(
+            """
             \begin{document}
                 Lorem ipsum dolor sit <caret>amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
             \end{document}
-        """.trimIndent(), """
+            """.trimIndent(),
+            """
             \begin{document}
                 Lorem ipsum dolor sit amet, consectetur 
                 adipiscing elit, sed do eiusmod tempor 
                 incididunt ut labore et dolore magna aliqua. 
             \end{document}
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     fun `test after begin section with new line`() {
-        testFillParagraph("""
+        testFillParagraph(
+            """
             \section{hallo}
             Lorem <caret>ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
-        """.trimIndent(), """
+            """.trimIndent(),
+            """
             \section{hallo}
             Lorem ipsum dolor sit amet, consectetur 
             adipiscing elit, sed do eiusmod tempor 
             incididunt ut labore et dolore magna aliqua. 
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     fun `test after begin section without new line`() {
-        testFillParagraph("""
+        testFillParagraph(
+            """
             \section{hallo} Lorem <caret>ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
-        """.trimIndent(), """
+            """.trimIndent(),
+            """
             \section{hallo} Lorem ipsum dolor sit amet, 
             consectetur adipiscing elit, sed do eiusmod 
             tempor incididunt ut labore et dolore magna 
             aliqua. 
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     fun `test lorem ipsum paragraph`() {
-        testFillParagraph("""
+        testFillParagraph(
+            """
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
             Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
             Duis aute iru<caret>re dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. 
             Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-        """.trimIndent(), """
+            """.trimIndent(),
+            """
             Lorem ipsum dolor sit amet, consectetur
             adipiscing elit, sed do eiusmod tempor 
             incididunt ut labore et dolore magna aliqua. Ut 
@@ -68,11 +79,13 @@ class LatexParagraphFillHandlerTest : BasePlatformTestCase() {
             dolore eu fugiat nulla pariatur. Excepteur sint 
             occaecat cupidatat non proident, sunt in culpa 
             qui officia deserunt mollit anim id est laborum.
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     fun `test paragraph that was good`() {
-        testFillParagraph("""
+        testFillParagraph(
+            """
             Lorem ipsum dolor sit amet, consectetur
             adipiscing elit, sed do eiusmod tempor NEW WORDS HERE
             incididunt ut labore et dolore magna aliqua. Ut 
@@ -83,7 +96,8 @@ class LatexParagraphFillHandlerTest : BasePlatformTestCase() {
             dolore eu fugiat nulla pariatur. Excepteur sint 
             occaecat cupidatat non proident, sunt in culpa 
             qui officia deserunt mollit anim id est laborum.
-        """.trimIndent(), """
+            """.trimIndent(),
+            """
             Lorem ipsum dolor sit amet, consectetur 
             adipiscing elit, sed do eiusmod tempor NEW 
             WORDS HERE incididunt ut labore et dolore magna
@@ -94,31 +108,37 @@ class LatexParagraphFillHandlerTest : BasePlatformTestCase() {
             dolore eu fugiat nulla pariatur. Excepteur sint
             occaecat cupidatat non proident, sunt in culpa 
             qui officia deserunt mollit anim id est laborum.
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     fun `test paragraph separated by blank lines`() {
-        testFillParagraph("""
+        testFillParagraph(
+            """
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore ma<caret>gna aliqua. 
 
             Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
-        """.trimIndent(), """
+            """.trimIndent(),
+            """
             Lorem ipsum dolor sit amet, consectetur
             adipiscing elit, sed do eiusmod tempor 
             incididunt ut labore et dolore magna aliqua. 
 
             Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     fun `test paragraph separated by environment`() {
-        testFillParagraph("""
+        testFillParagraph(
+            """
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore ma<caret>gna aliqua. 
             \begin{center}
                 bla
             \end{center}
             Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
-        """.trimIndent(), """
+            """.trimIndent(),
+            """
             Lorem ipsum dolor sit amet, consectetur 
             adipiscing elit, sed do eiusmod tempor 
             incididunt ut labore et dolore magna aliqua.
@@ -126,17 +146,20 @@ class LatexParagraphFillHandlerTest : BasePlatformTestCase() {
                 bla
             \end{center}
             Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     fun `test paragraph separated by display math`() {
-        testFillParagraph("""
+        testFillParagraph(
+            """
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore ma<caret>gna aliqua. 
             \[
                 \sum_{i=1}^\infty \frac{e^i}{i!}
             \]
             Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
-        """.trimIndent(), """
+            """.trimIndent(),
+            """
             Lorem ipsum dolor sit amet, consectetur
             adipiscing elit, sed do eiusmod tempor 
             incididunt ut labore et dolore magna aliqua. 
@@ -144,7 +167,8 @@ class LatexParagraphFillHandlerTest : BasePlatformTestCase() {
                 \sum_{i=1}^\infty \frac{e^i}{i!}
             \]
             Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     private fun testFillParagraph(input: String, expectedOutput: String) {

--- a/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexEnterInCommentHandlerTest.kt
+++ b/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexEnterInCommentHandlerTest.kt
@@ -6,81 +6,111 @@ import nl.hannahsten.texifyidea.file.LatexFileType
 class LatexEnterInCommentHandlerTest : BasePlatformTestCase() {
 
     fun testSimpleComment() {
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             % These forests are to be indicated by the length <caret>according to their truthful measures.
-        """.trimIndent())
+            """.trimIndent()
+        )
         myFixture.type("\n") // It actually presses enter: see EditorTestFixture.java:91
-        myFixture.checkResult("""
+        myFixture.checkResult(
+            """
             % These forests are to be indicated by the length 
             <caret>% according to their truthful measures.
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     fun testCommentWithIndentation() {
         // For example, when having the setting "line comment at first column" unselected
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
 \begin{document}
     \begin{center}
         % All beds diverged by the stated variants <caret>can be written by the algorithm.
     \end{center}
 \end{document}
-        """)
+        """
+        )
         myFixture.type("\n")
-        myFixture.checkResult("""
+        myFixture.checkResult(
+            """
 \begin{document}
     \begin{center}
         % All beds diverged by the stated variants 
         <caret>% can be written by the algorithm.
     \end{center}
 \end{document}
-        """)
+        """
+        )
     }
 
     fun testCommentAtFirstColumn() {
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             %   And to state attentions to the purpose <caret>to sin the clear found by genes.
-        """.trimIndent())
+            """.trimIndent()
+        )
         myFixture.type("\n")
-        myFixture.checkResult("""
+        myFixture.checkResult(
+            """
             %   And to state attentions to the purpose 
             <caret>%   to sin the clear found by genes.
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     fun testMagicComment() {
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             %! compiler=<caret>lualatex
-        """.trimIndent())
+            """.trimIndent()
+        )
         myFixture.type("\n")
-        myFixture.checkResult("""
+        myFixture.checkResult(
+            """
             %! compiler=
             <caret>%! lualatex
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     fun testDoublePercent() {
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             \begin{center}
             %%     It would previously <caret>repair the redundant persons.
             \end{center}
-        """.trimIndent())
+            """.trimIndent()
+        )
         myFixture.type("\n")
-        myFixture.checkResult("""
+        myFixture.checkResult(
+            """
             \begin{center}
             %%     It would previously 
             %%     repair the redundant persons.
             \end{center}
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     fun testFakeComment() {
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             \macro{%<caret>}
-        """.trimIndent())
+            """.trimIndent()
+        )
         myFixture.type("\n")
-        myFixture.checkResult("""
+        myFixture.checkResult(
+            """
             \macro{%
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 }

--- a/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexEnterInEnumerationHandlerTest.kt
+++ b/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexEnterInEnumerationHandlerTest.kt
@@ -6,22 +6,29 @@ import nl.hannahsten.texifyidea.file.LatexFileType
 class LatexEnterInEnumerationHandlerTest : BasePlatformTestCase() {
 
     fun testItemize() {
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             \begin{itemize}
                 \item <caret>
             \end{itemize}
-        """.trimIndent())
+            """.trimIndent()
+        )
         myFixture.type("\n")
-        myFixture.checkResult("""
+        myFixture.checkResult(
+            """
             \begin{itemize}
                 \item 
                 \item <caret>
             \end{itemize}
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     fun `test nested enumeration with prefix`() {
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             \begin{enumerate}
                 \item foo
                 \item[whoo] bar
@@ -30,9 +37,11 @@ class LatexEnterInEnumerationHandlerTest : BasePlatformTestCase() {
                     \item[barfoo:]
                 \end{labeling} <caret>
             \end{enumerate}
-        """.trimIndent())
+            """.trimIndent()
+        )
         myFixture.type("\n")
-        myFixture.checkResult("""
+        myFixture.checkResult(
+            """
             \begin{enumerate}
                 \item foo
                 \item[whoo] bar
@@ -42,6 +51,7 @@ class LatexEnterInEnumerationHandlerTest : BasePlatformTestCase() {
                 \end{labeling} 
                 \item[whoo] 
             \end{enumerate}
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 }

--- a/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandlerTest.kt
+++ b/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandlerTest.kt
@@ -18,17 +18,22 @@ class LatexTypedHandlerTest : BasePlatformTestCase() {
     }
 
     fun testVerbatim() {
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             \begin{verbatim}
                 <caret>
             \end{verbatim}
-        """.trimIndent())
+            """.trimIndent()
+        )
         myFixture.type("$")
-        myFixture.checkResult("""
+        myFixture.checkResult(
+            """
             \begin{verbatim}
                 $<caret>
             \end{verbatim}
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     fun testDisplayMath() {
@@ -40,10 +45,12 @@ class LatexTypedHandlerTest : BasePlatformTestCase() {
     fun testDisplayMath2() {
         myFixture.configureByText(LatexFileType, "\\[<caret>\\]")
         myFixture.type("\n")
-        myFixture.checkResult("""
+        myFixture.checkResult(
+            """
             \[
                 <caret>
             \]
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 }

--- a/test/nl/hannahsten/texifyidea/formatting/LatexSectionIndentTest.kt
+++ b/test/nl/hannahsten/texifyidea/formatting/LatexSectionIndentTest.kt
@@ -89,10 +89,11 @@ class LatexSectionIndentTest : BasePlatformTestCase() {
 
     fun testEnterHandlerSectionIndent() {
         val file = myFixture.configureByText(
-            LatexFileType, """
+            LatexFileType,
+            """
             \section{test}
                 Isn't<caret>
-        """.trimIndent()
+            """.trimIndent()
         )
         CodeStyle.getCustomSettings(file, LatexCodeStyleSettings::class.java).INDENT_SECTIONS = true
         myFixture.type('\n')
@@ -101,18 +102,19 @@ class LatexSectionIndentTest : BasePlatformTestCase() {
             \section{test}
                 Isn't
                 <caret>
-        """.trimIndent()
+            """.trimIndent()
         )
     }
 
     fun testEnterHandlerSectionIndentInMiddle() {
         val file = myFixture.configureByText(
-            LatexFileType, """
+            LatexFileType,
+            """
             \section{test}
                 Text.
                 Isn't<caret>
             \section{two}
-        """.trimIndent()
+            """.trimIndent()
         )
         CodeStyle.getCustomSettings(file, LatexCodeStyleSettings::class.java).INDENT_SECTIONS = true
         myFixture.type('\n')
@@ -123,18 +125,19 @@ class LatexSectionIndentTest : BasePlatformTestCase() {
                 Isn't
                 <caret>
             \section{two}
-        """.trimIndent()
+            """.trimIndent()
         )
     }
 
     fun testEnterHandlerSubsection() {
         val file = myFixture.configureByText(
-            LatexFileType, """
+            LatexFileType,
+            """
             \section{test}
                 \subsection{sub}
                     Isn't $\xi$<caret>
             \section{two}
-        """.trimIndent()
+            """.trimIndent()
         )
         CodeStyle.getCustomSettings(file, LatexCodeStyleSettings::class.java).INDENT_SECTIONS = true
         myFixture.type('\n')
@@ -145,7 +148,7 @@ class LatexSectionIndentTest : BasePlatformTestCase() {
                     Isn't $\xi$
                     <caret>
             \section{two}
-        """.trimIndent()
+            """.trimIndent()
         )
     }
 }

--- a/test/nl/hannahsten/texifyidea/inspections/TexifyInspectionTestBase.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/TexifyInspectionTestBase.kt
@@ -53,7 +53,7 @@ abstract class TexifyInspectionTestBase(vararg val inspections: LocalInspectionT
 
         // Find the fix all problems in this file intention for this inspection.
         val fixAllIntention = myFixture.getAvailableIntention(
-                InspectionsBundle.message("fix.all.inspection.problems.in.file", quickFixName)
+            InspectionsBundle.message("fix.all.inspection.problems.in.file", quickFixName)
         ) ?: return
         myFixture.launchAction(fixAllIntention)
 

--- a/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
@@ -52,7 +52,8 @@ class GrazieInspectionTest : BasePlatformTestCase() {
 
     fun testSentenceStart() {
         myFixture.configureByText(
-            LatexFileType, """
+            LatexFileType,
+            """
                \subsubsection{Something}
                 The hardware requirements 
             """.trimIndent()
@@ -63,7 +64,9 @@ class GrazieInspectionTest : BasePlatformTestCase() {
     fun testGerman() {
         GrazieRemote.download(Lang.GERMANY_GERMAN)
         GrazieConfig.update { it.copy(enabledLanguages = it.enabledLanguages + Lang.GERMANY_GERMAN) }
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             \begin{document}
                 Das ist eine Function ${'$'} f${'$'}.
                 Nur zum Testen.

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codematurity/LatexAvoidEqnarrayInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codematurity/LatexAvoidEqnarrayInspectionTest.kt
@@ -4,36 +4,42 @@ import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
 
 class LatexAvoidEqnarrayInspectionTest : TexifyInspectionTestBase(LatexAvoidEqnarrayInspection()) {
 
-    fun `test eqnarray warning`() = testHighlighting("""
+    fun `test eqnarray warning`() = testHighlighting(
+        """
         \begin{<warning descr="Avoid using the 'eqnarray' environment">eqnarray</warning>}
             x
         \end{eqnarray}
-    """.trimIndent())
+        """.trimIndent()
+    )
 
-    fun `test eqnarray star warning`() = testHighlighting("""
+    fun `test eqnarray star warning`() = testHighlighting(
+        """
         \begin{<warning descr="Avoid using the 'eqnarray*' environment">eqnarray*</warning>}
             x
         \end{eqnarray*}
-    """.trimIndent())
+        """.trimIndent()
+    )
 
-    fun `test no warning for other math environment`() = testHighlighting("""
+    fun `test no warning for other math environment`() = testHighlighting(
+        """
         \begin{align}
             x
         \end{align}
-    """.trimIndent())
+        """.trimIndent()
+    )
 
     fun `test quick fix`() = testQuickFix(
-            before = """
+        before = """
                 \usepackage{amsmath}
                 \begin{eqnarray*}
                     x
                 \end{eqnarray*}
-            """.trimIndent(),
-            after = """
+        """.trimIndent(),
+        after = """
                 \usepackage{amsmath}
                 \begin{align*}
                     x
                 \end{align*}
-            """.trimIndent()
+        """.trimIndent()
     )
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codematurity/LatexDiscouragedUseOfDefInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codematurity/LatexDiscouragedUseOfDefInspectionTest.kt
@@ -9,43 +9,43 @@ class LatexDiscouragedUseOfDefInspectionTest : TexifyInspectionTestBase(LatexDis
     fun `test warning for let`() = testHighlighting("""<warning descr="The use of TeX primitive \let is discouraged">\let</warning>\a1""")
 
     fun `test quick fix def to newcommand`() = testNamedQuickFix(
-            before = """\def\a1""",
-            after = """\newcommand{\a}{1}""",
-            numberOfFixes = 2,
-            quickFixName = "Convert to \\newcommand"
+        before = """\def\a1""",
+        after = """\newcommand{\a}{1}""",
+        numberOfFixes = 2,
+        quickFixName = "Convert to \\newcommand"
     )
 
     fun `test quick fix def to newcommand 2`() = testNamedQuickFix(
-            before = """
+        before = """
                 \def \indentpar {\hangindent=1cm \hangafter=0}
                 \setlength{\parskip}{0.5em}
-            """.trimIndent(),
-            after = """
+        """.trimIndent(),
+        after = """
                 \newcommand{\indentpar}{\hangindent=1cm \hangafter=0}
                 \setlength{\parskip}{0.5em}
-            """.trimIndent(),
-            numberOfFixes = 2,
-            quickFixName = "Convert to \\newcommand"
+        """.trimIndent(),
+        numberOfFixes = 2,
+        quickFixName = "Convert to \\newcommand"
     )
 
     fun `test quick fix def to renewcommand`() = testNamedQuickFix(
-            before = """\def\a1""",
-            after = """\renewcommand{\a}{1}""",
-            numberOfFixes = 2,
-            quickFixName = "Convert to \\renewcommand"
+        before = """\def\a1""",
+        after = """\renewcommand{\a}{1}""",
+        numberOfFixes = 2,
+        quickFixName = "Convert to \\renewcommand"
     )
 
     fun `test quick fix let to newcommand`() = testNamedQuickFix(
-            before = """\let\a1""",
-            after = """\newcommand{\a}{1}""",
-            numberOfFixes = 2,
-            quickFixName = "Convert to \\newcommand"
+        before = """\let\a1""",
+        after = """\newcommand{\a}{1}""",
+        numberOfFixes = 2,
+        quickFixName = "Convert to \\newcommand"
     )
 
     fun `test quick fix let to renewcommand`() = testNamedQuickFix(
-            before = """\let\a1""",
-            after = """\renewcommand{\a}{1}""",
-            numberOfFixes = 2,
-            quickFixName = "Convert to \\renewcommand"
+        before = """\let\a1""",
+        after = """\renewcommand{\a}{1}""",
+        numberOfFixes = 2,
+        quickFixName = "Convert to \\renewcommand"
     )
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codematurity/LatexOverInsteadOfFracInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codematurity/LatexOverInsteadOfFracInspectionTest.kt
@@ -9,22 +9,22 @@ class LatexOverInsteadOfFracInspectionTest : TexifyInspectionTestBase(LatexOverI
     fun `test frac no warning`() = testHighlighting("""$\frac{1}{2}$""")
 
     fun `test quick fix`() = testQuickFix(
-            before = """$1\over 2$""",
-            after = """$\frac{1}{2}$""".trimMargin()
+        before = """$1\over 2$""",
+        after = """$\frac{1}{2}$""".trimMargin()
     )
 
     fun `test quick fix without space`() = testQuickFix(
-            before = """$1\over2$""",
-            after = """$\frac{1}{2}$""".trimMargin()
+        before = """$1\over2$""",
+        after = """$\frac{1}{2}$""".trimMargin()
     )
 
     fun `test quick fix without numerator and denominator`() = testQuickFix(
-            before = """$\over$""",
-            after = """$\frac{}{}$"""
+        before = """$\over$""",
+        after = """$\frac{}{}$"""
     )
 
     fun `test quick fix in formula`() = testQuickFix(
-            before = """${'$'}x = {1\over2} + y$""",
-            after = """${'$'}x = {\frac{1}{2}} + y$""".trimMargin()
+        before = """${'$'}x = {1\over2} + y$""",
+        after = """${'$'}x = {\frac{1}{2}} + y$""".trimMargin()
     )
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexDocumentclassNotInRootInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexDocumentclassNotInRootInspectionTest.kt
@@ -11,8 +11,8 @@ class LatexDocumentclassNotInRootInspectionTest : TexifyInspectionTestBase(Latex
 
     fun testNoWarning() {
         myFixture.configureByText(
-                LatexFileType,
-                """
+            LatexFileType,
+            """
                     \documentclass{article}
                     
                     \begin{document}
@@ -24,8 +24,9 @@ class LatexDocumentclassNotInRootInspectionTest : TexifyInspectionTestBase(Latex
     }
 
     fun `test no warning with environment in preamble`() {
-        myFixture.configureByText(LatexFileType,
-        """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             \documentclass{article}
             
             \begin{filecontents}{a}
@@ -35,7 +36,8 @@ class LatexDocumentclassNotInRootInspectionTest : TexifyInspectionTestBase(Latex
             \begin{document}
                 contents
             \end{document}
-        """.trimIndent())
+            """.trimIndent()
+        )
         myFixture.checkHighlighting()
     }
 

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexGatherEquationsInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexGatherEquationsInspectionTest.kt
@@ -6,31 +6,38 @@ import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
 class LatexGatherEquationsInspectionTest : TexifyInspectionTestBase(LatexGatherEquationsInspection()) {
 
     fun `test two consecutive display math environments`() {
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             <weak_warning descr="Equations can be gathered">\[
                 x = y
             \]</weak_warning>
             <weak_warning descr="Equations can be gathered">\[
                 y = x
             \]</weak_warning>
-        """.trimIndent())
+            """.trimIndent()
+        )
         myFixture.checkHighlighting()
     }
 
     fun `test two consecutive (non-display) math environments`() {
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             \[
                 x = y
             \]
             \begin{equation}\label{eq:yx}
                 y = x            
             \end{equation}
-        """.trimIndent())
+            """.trimIndent()
+        )
         myFixture.checkHighlighting()
     }
 
     fun `test quick fix`() {
-        testQuickFix("""
+        testQuickFix(
+            """
             \usepackage{amsmath}
             \begin{equation}\label{eq:xx}
                 x = x
@@ -47,7 +54,8 @@ class LatexGatherEquationsInspectionTest : TexifyInspectionTestBase(LatexGatherE
             \begin{equation}\label{eq:yy}
                 y = y
             \end{equation}
-        """.trimIndent(), """
+            """.trimIndent(),
+            """
             \usepackage{amsmath}
             \begin{equation}\label{eq:xx}
                 x = x
@@ -60,8 +68,9 @@ class LatexGatherEquationsInspectionTest : TexifyInspectionTestBase(LatexGatherE
             \begin{equation}\label{eq:yy}
                 y = y
             \end{equation}
-        """.trimIndent(),
-                3,
-                2)
+            """.trimIndent(),
+            3,
+            2
+        )
     }
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexLineBreakInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexLineBreakInspectionTest.kt
@@ -37,7 +37,7 @@ This e<weak_warning descr="Sentence does not start on a new line">tc. is missing
         after = """
                 I end.
                 a sentence.
-            """.trimIndent(),
+        """.trimIndent(),
         numberOfFixes = 2,
         selectedFix = 1
     )

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMathFunctionTextInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMathFunctionTextInspectionTest.kt
@@ -12,15 +12,16 @@ class LatexMathFunctionTextInspectionTest : TexifyInspectionTestBase(LatexMathFu
 
     fun testWarning() {
         MATH_FUNCTIONS.forEach {
-            myFixture.configureByText(LatexFileType,
-                    """
+            myFixture.configureByText(
+                LatexFileType,
+                """
                         $<warning descr="Use math function instead of \text">\text{$it}(3, 4)</warning>$
                         \(<warning descr="Use math function instead of \text">\text{$it   }(12)</warning>\)
                         \[<warning descr="Use math function instead of \text">\text{  $it}</warning>   text\]
                         \begin{equation}
                             <warning descr="Use math function instead of \text">\text{  $it    }</warning>
                         \end{equation}
-                    """.trimIndent()
+                """.trimIndent()
             )
             myFixture.checkHighlighting()
         }
@@ -28,29 +29,32 @@ class LatexMathFunctionTextInspectionTest : TexifyInspectionTestBase(LatexMathFu
 
     fun testNoWarning() {
         MATH_FUNCTIONS.forEach {
-            myFixture.configureByText(LatexFileType,
-                    """
+            myFixture.configureByText(
+                LatexFileType,
+                """
                         \text{$it}
                         \text{$it   }
                         \text{  $it}
                         \begin{nonmathenv}
                             \text{  $it    }
                         \end{nonmathenv}
-                    """.trimIndent()
+                """.trimIndent()
             )
             myFixture.checkHighlighting()
         }
 
-        myFixture.configureByText(LatexFileType,
-                """Just some random min text max or \[max(3,4)\] or even \[ \text{nomath} \]"""
+        myFixture.configureByText(
+            LatexFileType,
+            """Just some random min text max or \[max(3,4)\] or even \[ \text{nomath} \]"""
         )
         myFixture.checkHighlighting()
     }
 
     fun testQuickFix() {
         MATH_FUNCTIONS.forEach {
-            myFixture.configureByText(LatexFileType,
-                    """$ Test \text{$it } (3, 4) $ text max"""
+            myFixture.configureByText(
+                LatexFileType,
+                """$ Test \text{$it } (3, 4) $ text max"""
             )
 
             val quickFixes = myFixture.getAllQuickFixes()
@@ -60,7 +64,7 @@ class LatexMathFunctionTextInspectionTest : TexifyInspectionTestBase(LatexMathFu
             }
 
             myFixture.checkResult(
-                    """$ Test \$it (3, 4) $ text max"""
+                """$ Test \$it (3, 4) $ text max"""
             )
         }
     }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMissingLabelInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMissingLabelInspectionTest.kt
@@ -63,7 +63,7 @@ class LatexMissingLabelInspectionTest : TexifyInspectionTestBase(LatexMissingLab
                     \caption{Some text \label{fig:figure-caption-label}}
                 \end{figure}
             \end{document}
-            """.trimIndent()
+        """.trimIndent()
     )
 
     fun `test missing section label no warnings (custom label command)`() {
@@ -139,7 +139,7 @@ class LatexMissingLabelInspectionTest : TexifyInspectionTestBase(LatexMissingLab
                 \begin{lstlisting}[label={label with spaces}]
                 \end{lstlisting}
             \end{document}
-            """.trimIndent()
+        """.trimIndent()
     )
 
     fun `test listings label no warnings`() = testHighlighting(
@@ -152,7 +152,7 @@ class LatexMissingLabelInspectionTest : TexifyInspectionTestBase(LatexMissingLab
                 \begin{lstlisting}[label={label with spaces}]
                 \end{lstlisting}
             \end{document}
-            """.trimIndent()
+        """.trimIndent()
     )
 
     fun `test exam parts`() = testHighlighting(
@@ -166,7 +166,7 @@ class LatexMissingLabelInspectionTest : TexifyInspectionTestBase(LatexMissingLab
                     \end{parts}
                 \end{questions}
             \end{document}
-            """.trimIndent()
+        """.trimIndent()
     )
 
     fun `test quick fix in listings with no other parameters`() = testQuickFix(
@@ -224,13 +224,13 @@ class LatexMissingLabelInspectionTest : TexifyInspectionTestBase(LatexMissingLab
         before = """
                 \section{one}
                 \section{two}
-            """.trimIndent(),
+        """.trimIndent(),
         after = """
                 \section{one}\label{sec:one}
                 
                 
                 \section{two}\label{sec:two}
-            """.trimIndent(),
+        """.trimIndent(),
         quickFixName = "Add label for this command",
         numberOfFixes = 4
     )
@@ -245,7 +245,7 @@ class LatexMissingLabelInspectionTest : TexifyInspectionTestBase(LatexMissingLab
                 
                 \lstinputlisting[label={lst:inputlisting with spaces}]{some/file}
             \end{document}
-            """.trimIndent()
+        """.trimIndent()
     )
 
     fun `test lstinputlistings label no warnings`() = testHighlighting(
@@ -256,7 +256,7 @@ class LatexMissingLabelInspectionTest : TexifyInspectionTestBase(LatexMissingLab
                 
                 \lstinputlisting[label={lst:inputlisting with spaces}]{some/file}
             \end{document}
-            """.trimIndent()
+        """.trimIndent()
     )
 
     fun `test quick fix in lstinputlistings with other parameters`() = testQuickFix(

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexBibinputsRelativePathInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexBibinputsRelativePathInspectionTest.kt
@@ -7,9 +7,12 @@ class LatexBibinputsRelativePathInspectionTest : TexifyInspectionTestBase(LatexB
 
     fun testWarning() {
         // Unfortunately I don't yet know how to trigger this inspection in tests because it depends on run configurations
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             \bibliography{../references}
-        """.trimIndent())
+            """.trimIndent()
+        )
         myFixture.checkHighlighting()
     }
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspectionTest.kt
@@ -66,7 +66,9 @@ class LatexFileNotFoundInspectionTest : TexifyInspectionTestBase(LatexFileNotFou
     @Test
     fun testAbsoluteGraphicsDirWithInclude() {
         myFixture.copyFileToProject("myPicture.png")
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             \graphicspath{{$absoluteWorkingPath/test/resources/completion/path/}}
             \includegraphics{myPicture.png}
             """.trimIndent()

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexMissingDocumentEnvironmentInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexMissingDocumentEnvironmentInspectionTest.kt
@@ -4,11 +4,14 @@ import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
 
 class LatexMissingDocumentEnvironmentInspectionTest : TexifyInspectionTestBase(LatexMissingDocumentEnvironmentInspection()) {
 
-    fun `test missing document environment`() = testHighlighting("""
+    fun `test missing document environment`() = testHighlighting(
+        """
         <error descr="Document doesn't contain a document environment.">\documentclass{article}</error>
-    """.trimIndent())
+        """.trimIndent()
+    )
 
-    fun `test 'wrong' environment`() = testHighlighting("""
+    fun `test 'wrong' environment`() = testHighlighting(
+        """
         <error descr="Document doesn't contain a document environment.">
         \documentclass{article}
         
@@ -16,27 +19,36 @@ class LatexMissingDocumentEnvironmentInspectionTest : TexifyInspectionTestBase(L
             hallo
         \end{center}
         </error>
-    """.trimIndent())
+        """.trimIndent()
+    )
 
-    fun `test no warning when document environment is present`() = testHighlighting("""
+    fun `test no warning when document environment is present`() = testHighlighting(
+        """
         \documentclass{article}
         
         \begin{document}
             hallo
         \end{document}
-    """.trimIndent())
+        """.trimIndent()
+    )
 
     fun `test no warning on sty file`() {
-        myFixture.configureByText("package.sty", """
+        myFixture.configureByText(
+            "package.sty",
+            """
             \ProvidesPackage{package}
-        """.trimIndent())
+            """.trimIndent()
+        )
         myFixture.checkHighlighting()
     }
 
-    fun `test quick fix`() = testQuickFix("""\documentclass{article}""", """
+    fun `test quick fix`() = testQuickFix(
+        """\documentclass{article}""",
+        """
         \documentclass{article}
         \begin{document}
         
         \end{document}
-    """.trimIndent())
+        """.trimIndent()
+    )
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexMissingDocumentclassInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexMissingDocumentclassInspectionTest.kt
@@ -14,12 +14,12 @@ class LatexMissingDocumentclassInspectionTest : TexifyInspectionTestBase(LatexMi
     fun `test warning`() = testHighlighting("""<error descr="Document doesn't contain a \documentclass command.">\usepackage{amsmath}</error>""")
 
     fun `test quick fix`() = testQuickFix(
-            before = """
+        before = """
                 \usepackage{amsmath}
-            """.trimIndent(),
-            after = """
+        """.trimIndent(),
+        after = """
                 \documentclass{article}
                 \usepackage{amsmath}
-            """.trimIndent()
+        """.trimIndent()
     )
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexNonMatchingEnvironmentInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexNonMatchingEnvironmentInspectionTest.kt
@@ -4,39 +4,49 @@ import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
 
 class LatexNonMatchingEnvironmentInspectionTest : TexifyInspectionTestBase(LatexNonMatchingEnvironmentInspection()) {
 
-    fun `test no warning`() = testHighlighting("""
+    fun `test no warning`() = testHighlighting(
+        """
         \begin{center}
             bla
         \end{center}
-    """.trimIndent())
+        """.trimIndent()
+    )
 
-    fun `test warnings`() = testHighlighting("""
+    fun `test warnings`() = testHighlighting(
+        """
         <error descr="DefaultEnvironment name does not match with the name in \end.">\begin{center}</error>
             bla
         <error descr="DefaultEnvironment name does not match with the name in \begin.">\end{left}</error>
-    """.trimIndent())
+        """.trimIndent()
+    )
 
-    fun `test begin quick fix`() = testNamedQuickFix("""
+    fun `test begin quick fix`() = testNamedQuickFix(
+        """
         \begin{center}
             bla
         \end{left}
-    """.trimIndent(), """
+        """.trimIndent(),
+        """
         \begin{left}
             bla
         \end{left}
-    """.trimIndent(),
-    quickFixName = "Change \\begin environment to 'left'",
-    numberOfFixes = 2)
+        """.trimIndent(),
+        quickFixName = "Change \\begin environment to 'left'",
+        numberOfFixes = 2
+    )
 
-    fun `test end quick fix`() = testNamedQuickFix("""
+    fun `test end quick fix`() = testNamedQuickFix(
+        """
         \begin{center}
             bla
         \end{left}
-    """.trimIndent(), """
+        """.trimIndent(),
+        """
         \begin{center}
             bla
         \end{center}
-    """.trimIndent(),
-    quickFixName = "Change \\end environment to 'center'",
-    numberOfFixes = 2)
+        """.trimIndent(),
+        quickFixName = "Change \\end environment to 'center'",
+        numberOfFixes = 2
+    )
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUndefinedCommandInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUndefinedCommandInspectionTest.kt
@@ -12,11 +12,14 @@ class LatexUndefinedCommandInspectionTest : TexifyInspectionTestBase(LatexUndefi
     }
 
     fun testDefinedCommand() {
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             \documentclass{article}
             \newcommand{\floep}{\grq}
             \floep
-        """.trimIndent())
+            """.trimIndent()
+        )
         myFixture.checkHighlighting()
     }
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspectionTest.kt
@@ -18,11 +18,14 @@ class OutsideMathLatexUnicodeInspectionTest : LatexUnicodeInspectionTest() {
     fun `test support by loaded packages`() {
         setUnicodeSupport(false)
 
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             \usepackage[utf8]{inputenc}
             \usepackage[T1]{fontenc}
             î
-""".trimIndent())
+            """.trimIndent()
+        )
         myFixture.checkHighlighting()
     }
 
@@ -52,9 +55,12 @@ class InsideMathLatexUnicodeInspectionTest : LatexUnicodeInspectionTest() {
     fun `test with loaded packages`() {
         setUnicodeSupport()
 
-        myFixture.configureByText(LatexFileType, "\\usepackage[utf8]{inputenc}\n" +
+        myFixture.configureByText(
+            LatexFileType,
+            "\\usepackage[utf8]{inputenc}\n" +
                 "            \\usepackage[T1]{fontenc}\n" +
-                "\$<error descr=\"Unsupported non-ASCII character\">î</error>\$")
+                "\$<error descr=\"Unsupported non-ASCII character\">î</error>\$"
+        )
         myFixture.checkHighlighting()
     }
 
@@ -71,11 +77,15 @@ class LatexUnicodeInspectionQuickFix : LatexUnicodeInspectionTest() {
     fun `test include packages quick fix`() {
         setUnicodeSupport(false)
 
-        testNamedQuickFix("\nî", """
+        testNamedQuickFix(
+            "\nî",
+            """
             \usepackage[utf8]{inputenc}
             \usepackage[T1]{fontenc}
-            î""".trimIndent(),
-                "Include Unicode support packages", 2)
+            î
+            """.trimIndent(),
+            "Include Unicode support packages", 2
+        )
     }
 
     @Suppress("NonAsciiCharacters")

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnresolvedReferenceInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnresolvedReferenceInspectionTest.kt
@@ -70,11 +70,11 @@ class LatexUnresolvedReferenceInspectionTest : TexifyInspectionTestBase(LatexUnr
         myFixture.checkHighlighting()
     }
 
-     fun testBibtexReference() {
-         val name = getTestName(false) + ".tex"
-         myFixture.configureByFiles(name, "references.bib")
-         myFixture.checkHighlighting()
-     }
+    fun testBibtexReference() {
+        val name = getTestName(false) + ".tex"
+        myFixture.configureByFiles(name, "references.bib")
+        myFixture.checkHighlighting()
+    }
 
     fun testFigureReferencedCustomCommandOptionalParameter() {
         myFixture.configureByText(

--- a/test/nl/hannahsten/texifyidea/inspections/latex/redundancy/LatexTrimWhiteSpaceInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/redundancy/LatexTrimWhiteSpaceInspectionTest.kt
@@ -15,17 +15,17 @@ class LatexTrimWhiteSpaceInspectionTest : TexifyInspectionTestBase(LatexTrimWhit
     fun `test warning whitespace front and back`() = testHighlighting("""\section{<weak_warning descr="Unnecessary whitespace"> test </weak_warning>}""")
 
     fun `test quick fix front`() = testQuickFix(
-            before = """\section{ test}""",
-            after = """\section{test}"""
+        before = """\section{ test}""",
+        after = """\section{test}"""
     )
 
     fun `test quick fix back`() = testQuickFix(
-            before = """\section{test }""",
-            after = """\section{test}"""
+        before = """\section{test }""",
+        after = """\section{test}"""
     )
 
     fun `test quick fix front and back`() = testQuickFix(
-            before = """\section{ test }""",
-            after = """\section{test}"""
+        before = """\section{ test }""",
+        after = """\section{test}"""
     )
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexDiacriticIJInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexDiacriticIJInspectionTest.kt
@@ -9,22 +9,22 @@ class LatexDiacriticIJInspectionTest : TexifyInspectionTestBase(LatexDiacriticIJ
     fun `test no warning`() = testHighlighting("""\^{\i}""")
 
     fun `test quick fix i`() = testQuickFix(
-            before = """\^i""",
-            after = """\^{\i}"""
+        before = """\^i""",
+        after = """\^{\i}"""
     )
 
     fun `test quick fix j`() = testQuickFix(
-            before = """\^j""",
-            after = """\^{\j}"""
+        before = """\^j""",
+        after = """\^{\j}"""
     )
 
     fun `test quick fix i in math mode`() = testQuickFix(
-            before = """$\^i$""",
-            after = """$\^\imath$"""
+        before = """$\^i$""",
+        after = """$\^\imath$"""
     )
 
     fun `test quick fix j in math mode`() = testQuickFix(
-            before = """$\^j$""",
-            after = """$\^\jmath$"""
+        before = """$\^j$""",
+        after = """$\^\jmath$"""
     )
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexQuoteInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexQuoteInspectionTest.kt
@@ -100,7 +100,7 @@ internal class LatexQuoteInspectionTest : TexifyInspectionTestBase(LatexQuoteIns
             \usepackage{csquotes}
             \MakeOuterQuote{"}
             Specifying of "algorithms"
-            """.trimIndent()
+        """.trimIndent()
         myFixture.configureByText(
             LatexFileType, original
         )

--- a/test/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexVerticallyCenteredColonInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexVerticallyCenteredColonInspectionTest.kt
@@ -6,10 +6,12 @@ class LatexVerticallyCenteredColonInspectionTest : TexifyInspectionTestBase(Late
 
     fun `test warning`() = testHighlighting("""\[ a <warning descr="Colon is vertically uncentered">:=</warning> b \]""")
 
-    fun `test no warning with setting enabled`() = testHighlighting("""
+    fun `test no warning with setting enabled`() = testHighlighting(
+        """
             \mathtoolsset{centercolon=true}
             \[ a := b \]
-        """.trimIndent())
+        """.trimIndent()
+    )
 
     fun `test warning lookahead`() = testHighlighting("""\[ a <warning descr="Colon is vertically uncentered">:\approx</warning>\infty \]""")
 
@@ -17,12 +19,14 @@ class LatexVerticallyCenteredColonInspectionTest : TexifyInspectionTestBase(Late
 
     fun `test warning spaces`() = testHighlighting("""\[ a <warning descr="Colon is vertically uncentered">: :  =</warning> b \]""")
 
-    fun `test no warning newline`() = testHighlighting("""
+    fun `test no warning newline`() = testHighlighting(
+        """
             \[
                 a : 
                  = b
             \]
-        """.trimIndent())
+        """.trimIndent()
+    )
 
     fun `test no warning outside math mode`() = testHighlighting("""a := b \[ a : b \]""")
 

--- a/test/nl/hannahsten/texifyidea/inspections/latex/typesetting/spacing/LatexMathOperatorEscapeInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/typesetting/spacing/LatexMathOperatorEscapeInspectionTest.kt
@@ -13,14 +13,16 @@ class LatexMathOperatorEscapeInspectionTest : TexifyInspectionTestBase(LatexMath
     }
 
     fun `test trigger in math inside text`() {
-        testHighlighting("""
+        testHighlighting(
+            """
             \[
                 \begin{cases}
                     1 & \text{if ${'$'}<warning descr="Non-escaped math operator">cos</warning>(x) = 1${'$'}} \\
                     0 & \text{otherwise}
                 \end{cases}
             \]
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     fun `test no trigger inside text in inline math`() {

--- a/test/nl/hannahsten/texifyidea/lang/magic/MagicCommentPsiTest.kt
+++ b/test/nl/hannahsten/texifyidea/lang/magic/MagicCommentPsiTest.kt
@@ -15,7 +15,9 @@ class MagicCommentPsiTest : BasePlatformTestCase() {
     }
 
     fun `test get magic comment for file`() {
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             %!compiler = xelatex
             \documentclass{article}
 
@@ -23,7 +25,8 @@ class MagicCommentPsiTest : BasePlatformTestCase() {
             \begin{document}
                 ...
             \end{document}
-        """.trimIndent())
+            """.trimIndent()
+        )
         val magic = myFixture.file.magicComment()
         assertEquals(arrayListOf("compiler = xelatex"), magic.toCommentString())
     }

--- a/test/nl/hannahsten/texifyidea/psi/LatexCommandsImplUtilTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/LatexCommandsImplUtilTest.kt
@@ -38,7 +38,8 @@ class LatexCommandsImplUtilTest : BasePlatformTestCase() {
     @Test
     fun `test simple optional parameters map with whitespaces`() {
         // given
-        myFixture.configureByText(LatexFileType,
+        myFixture.configureByText(
+            LatexFileType,
             """
             \begin{document}
                 \lstinputlisting[param1    = value1  , param2=value2]{some/file}
@@ -63,7 +64,8 @@ class LatexCommandsImplUtilTest : BasePlatformTestCase() {
     @Test
     fun `test multiple optional parameters map`() {
         // given
-        myFixture.configureByText(LatexFileType,
+        myFixture.configureByText(
+            LatexFileType,
             """
             \begin{document}
                 \lstinputlisting[param1=value1][param2=value2,param3]{some/file}
@@ -89,7 +91,8 @@ class LatexCommandsImplUtilTest : BasePlatformTestCase() {
     @Test
     fun `test grouped optional parameters map`() {
         // given
-        myFixture.configureByText(LatexFileType,
+        myFixture.configureByText(
+            LatexFileType,
             """
             \begin{document}
                 \lstinputlisting[param1={value11,value12},param2=value2,{param3,param4}=value3,onlykey,param5={x=y},param6={ with space }{parts}]{some/file}
@@ -118,7 +121,8 @@ class LatexCommandsImplUtilTest : BasePlatformTestCase() {
     @Test
     fun `test grouped key optional parameters map`() {
         // given
-        myFixture.configureByText(LatexFileType,
+        myFixture.configureByText(
+            LatexFileType,
             """
             \begin{document}
                 \lstinputlisting[{param1}=value1,param2=value2]{some/file}

--- a/test/nl/hannahsten/texifyidea/reference/BibtexIdRemoteLibraryCompletionTest.kt
+++ b/test/nl/hannahsten/texifyidea/reference/BibtexIdRemoteLibraryCompletionTest.kt
@@ -24,7 +24,8 @@ class BibtexIdRemoteLibraryCompletionTest : BasePlatformTestCase() {
      * Complete item from remote bib, and add it to the bib file.
      */
     fun testCiteFromLibraryCompletionWithBib() {
-        completionWithRemoteBib("""
+        completionWithRemoteBib(
+            """
             @book{gardner_knots_2014,
                 address = {New York : Washington, DC},
                 edition = {New edition},
@@ -39,14 +40,16 @@ class BibtexIdRemoteLibraryCompletionTest : BasePlatformTestCase() {
                 year = {2014},
                 keywords = {MATHEMATICS / General, Mathematical recreations},
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     /**
      * Complete item from remote bib, and add it to the currently empty bib file.
      */
     fun testCiteFromLibraryCompletion() {
-        completionWithRemoteBib("""
+        completionWithRemoteBib(
+            """
             @book{newey_how_2017,
                 address = {London},
                 title = {How to build a car},
@@ -56,7 +59,8 @@ class BibtexIdRemoteLibraryCompletionTest : BasePlatformTestCase() {
                 author = {Newey, Adrian},
                 year = {2017},
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     /**
@@ -64,7 +68,8 @@ class BibtexIdRemoteLibraryCompletionTest : BasePlatformTestCase() {
      * from the local bib (we can't check this) and it should not be added to the local bib again (this is what we check).
      */
     fun testCiteFromLibraryAlreadyLocal() {
-        completionWithRemoteBib("""
+        completionWithRemoteBib(
+            """
             @book{newey_how_2017,
                 address = {London},
                 title = {How to build a car},
@@ -74,7 +79,8 @@ class BibtexIdRemoteLibraryCompletionTest : BasePlatformTestCase() {
                 author = {Newey, Adrian},
                 year = {2017},
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
     }
 
     /**

--- a/test/nl/hannahsten/texifyidea/reference/CommandDefinitionReferenceTest.kt
+++ b/test/nl/hannahsten/texifyidea/reference/CommandDefinitionReferenceTest.kt
@@ -12,16 +12,21 @@ class CommandDefinitionReferenceTest : BasePlatformTestCase() {
     }
 
     fun testResolveInDefinition() {
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             \newcommand{\MyCommand}{Hello World!}
             \newcommand{\AnotherCommand}{\MyCommand<caret>}
             \AnotherCommand
-            """.trimIndent())
+            """.trimIndent()
+        )
         myFixture.renameElementAtCaret("\\floep")
-        myFixture.checkResult("""
+        myFixture.checkResult(
+            """
             \newcommand{\floep}{Hello World!}
             \newcommand{\AnotherCommand}{\floep<caret>}
             \AnotherCommand
-            """.trimIndent())
+            """.trimIndent()
+        )
     }
 }

--- a/test/nl/hannahsten/texifyidea/remotelibraries/state/LibraryStateConverterTest.kt
+++ b/test/nl/hannahsten/texifyidea/remotelibraries/state/LibraryStateConverterTest.kt
@@ -37,7 +37,7 @@ class LibraryStateConverterTest : BasePlatformTestCase() {
           </a1234>
         </LinkedHashMap>
         
-        """.trimIndent()
+    """.trimIndent()
 
     fun testToString() {
         myFixture.configureByText(BibtexFileType, bibString)


### PR DESCRIPTION
As explained in https://kotlinlang.org/docs/code-style-migration-guide.html#differences-between-kotlin-coding-conventions-and-intellij-idea-default-code-style the continuation indent rule should not be used for Kotlin.
I enabled the ktlint indent rule and ran ktlintFormat.

Note: the gradle plugin we use wraps an older version of ktlint which has some bugs.