### PR TITLE
Add 'indent document environment' setting to enter handler

### DIFF
--- a/src/nl/hannahsten/texifyidea/editor/typedhandlers/LatexEnterHandler.kt
+++ b/src/nl/hannahsten/texifyidea/editor/typedhandlers/LatexEnterHandler.kt
@@ -19,13 +19,15 @@ import nl.hannahsten.texifyidea.util.firstChildOfType
  * Technically, this is not a typed handler, but it's easier to find this way.
  */
 object LatexEnterHandler {
+
     fun getChildAttributes(newChildIndex: Int, node: ASTNode, subBlocks: MutableList<Block>): ChildAttributes {
-        val shouldIndentDocumentEnvironment = CodeStyle.getCustomSettings(node.psi.containingFile, LatexCodeStyleSettings::class.java).INDENT_DOCUMENT_ENVIRONMENT
+        val shouldIndentDocumentEnvironment =
+            CodeStyle.getCustomSettings(node.psi.containingFile, LatexCodeStyleSettings::class.java).INDENT_DOCUMENT_ENVIRONMENT
         val shouldIndentEnvironment = node.elementType === LatexTypes.ENVIRONMENT && (
-                (node.psi as? LatexEnvironment)
-                    ?.firstChildOfType(LatexBeginCommand::class)
-                    ?.firstChildOfType(LatexParameterText::class)?.text != "document" || shouldIndentDocumentEnvironment
-                )
+            (node.psi as? LatexEnvironment)
+                ?.firstChildOfType(LatexBeginCommand::class)
+                ?.firstChildOfType(LatexParameterText::class)?.text != "document" || shouldIndentDocumentEnvironment
+            )
 
         val type = node.elementType
         if (type === LatexTypes.DISPLAY_MATH || shouldIndentEnvironment) {

--- a/src/nl/hannahsten/texifyidea/editor/typedhandlers/LatexEnterHandler.kt
+++ b/src/nl/hannahsten/texifyidea/editor/typedhandlers/LatexEnterHandler.kt
@@ -1,0 +1,57 @@
+package nl.hannahsten.texifyidea.editor.typedhandlers
+
+import com.intellij.application.options.CodeStyle
+import com.intellij.formatting.Block
+import com.intellij.formatting.ChildAttributes
+import com.intellij.formatting.Indent
+import com.intellij.lang.ASTNode
+import nl.hannahsten.texifyidea.formatting.LatexBlock
+import nl.hannahsten.texifyidea.psi.LatexBeginCommand
+import nl.hannahsten.texifyidea.psi.LatexEnvironment
+import nl.hannahsten.texifyidea.psi.LatexParameterText
+import nl.hannahsten.texifyidea.psi.LatexTypes
+import nl.hannahsten.texifyidea.settings.codestyle.LatexCodeStyleSettings
+import nl.hannahsten.texifyidea.util.firstChildOfType
+
+/**
+ * Configure the indent after pressing enter.
+ *
+ * Technically, this is not a typed handler, but it's easier to find this way.
+ */
+object LatexEnterHandler {
+    fun getChildAttributes(newChildIndex: Int, node: ASTNode, subBlocks: MutableList<Block>): ChildAttributes {
+        val shouldIndentDocumentEnvironment = CodeStyle.getCustomSettings(node.psi.containingFile, LatexCodeStyleSettings::class.java).INDENT_DOCUMENT_ENVIRONMENT
+        val shouldIndentEnvironment = node.elementType === LatexTypes.ENVIRONMENT && (
+                (node.psi as? LatexEnvironment)
+                    ?.firstChildOfType(LatexBeginCommand::class)
+                    ?.firstChildOfType(LatexParameterText::class)?.text != "document" || shouldIndentDocumentEnvironment
+                )
+
+        val type = node.elementType
+        if (type === LatexTypes.DISPLAY_MATH || shouldIndentEnvironment) {
+            return ChildAttributes(Indent.getNormalIndent(true), null)
+        }
+        val indentSections = CodeStyle.getCustomSettings(node.psi.containingFile, LatexCodeStyleSettings::class.java).INDENT_SECTIONS
+        if (indentSections) {
+            // This function will be called on the block for which the caret is adding something in the children at the given index,
+            // however this may mean that the current block may be Content and a block will be added in the last child of the children of this block (so not directly into the children of this block).
+            // Therefore to find the section indent of the line the caret was on, we need the previous leaf in the tree
+            var currentBlock = subBlocks.getOrNull(newChildIndex - 1)
+            var indentSize = (currentBlock as? LatexBlock)?.sectionIndent ?: 0
+            while (currentBlock != null && !currentBlock.isLeaf) {
+                currentBlock = currentBlock.subBlocks.lastOrNull()
+                if (currentBlock is LatexBlock) {
+                    indentSize = Integer.max(indentSize, currentBlock.sectionIndent)
+                }
+            }
+
+            if (indentSize > 0) {
+                // We may need to provide more than one indent, because of the problem that the parent-child relationship
+                // does not match the indent sizes
+                val singleIndentSize = CodeStyle.getIndentSize(node.psi.containingFile)
+                return ChildAttributes(Indent.getSpaceIndent(indentSize * singleIndentSize), null)
+            }
+        }
+        return ChildAttributes(Indent.getNoneIndent(), null)
+    }
+}

--- a/src/nl/hannahsten/texifyidea/formatting/LatexBlock.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexBlock.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.TokenType
 import com.intellij.psi.formatter.common.AbstractBlock
 import com.intellij.psi.util.prevLeaf
+import nl.hannahsten.texifyidea.editor.typedhandlers.LatexEnterHandler
 import nl.hannahsten.texifyidea.lang.commands.LatexCommand
 import nl.hannahsten.texifyidea.psi.*
 import nl.hannahsten.texifyidea.settings.codestyle.LatexCodeStyleSettings
@@ -204,31 +205,6 @@ class LatexBlock(
 
     // Automatic indent when enter is pressed
     override fun getChildAttributes(newChildIndex: Int): ChildAttributes {
-        val type = myNode.elementType
-        if (type === LatexTypes.DISPLAY_MATH || type === LatexTypes.ENVIRONMENT) {
-            return ChildAttributes(Indent.getNormalIndent(true), null)
-        }
-        val indentSections = CodeStyle.getCustomSettings(node.psi.containingFile, LatexCodeStyleSettings::class.java).INDENT_SECTIONS
-        if (indentSections) {
-            // This function will be called on the block for which the caret is adding something in the children at the given index,
-            // however this may mean that the current block may be Content and a block will be added in the last child of the children of this block (so not directly into the children of this block).
-            // Therefore to find the section indent of the line the caret was on, we need the previous leaf in the tree
-            var currentBlock = subBlocks.getOrNull(newChildIndex - 1)
-            var indentSize = (currentBlock as? LatexBlock)?.sectionIndent ?: 0
-            while (currentBlock != null && !currentBlock.isLeaf) {
-                currentBlock = currentBlock.subBlocks.lastOrNull()
-                if (currentBlock is LatexBlock) {
-                    indentSize = max(indentSize, currentBlock.sectionIndent)
-                }
-            }
-
-            if (indentSize > 0) {
-                // We may need to provide more than one indent, because of the problem that the parent-child relationship
-                // does not match the indent sizes
-                val singleIndentSize = CodeStyle.getIndentSize(node.psi.containingFile)
-                return ChildAttributes(Indent.getSpaceIndent(indentSize * singleIndentSize), null)
-            }
-        }
-        return ChildAttributes(Indent.getNoneIndent(), null)
+        return LatexEnterHandler.getChildAttributes(newChildIndex, node, subBlocks)
     }
 }

--- a/test/nl/hannahsten/texifyidea/formatting/LatexFormattingTest.kt
+++ b/test/nl/hannahsten/texifyidea/formatting/LatexFormattingTest.kt
@@ -286,6 +286,25 @@ fun Int?.ifPositiveAddTwo(): Int =
         myFixture.checkResult(expected2)
     }
 
+    fun `test enter handler for unindented document`() {
+        val text = """
+            \begin{document}
+            Don't indent this if turned off.<caret>
+            \end{document}
+        """.trimIndent()
+        val file = myFixture.configureByText(LatexFileType, text)
+        CodeStyle.getCustomSettings(file, LatexCodeStyleSettings::class.java).INDENT_DOCUMENT_ENVIRONMENT = false
+        myFixture.type("\nDon't indent this either")
+
+        val expected = """
+            \begin{document}
+            Don't indent this if turned off.
+            Don't indent this either<caret>
+            \end{document}
+        """.trimIndent()
+        myFixture.checkResult(expected)
+    }
+
     fun testComments() {
         // Wanted to test line breaking, but not sure how to enable it in test
         val text = """


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2617

#### Summary of additions and changes

* Do not indent in the document environment on enter when that setting is disabled

#### How to test this pull request

```latex
\begin{document}
\begin{test}
    Indent the next line<caret>
\end{test}
Don't indent the next line<caret>
\end{document}
```
