### PR TITLE
Fix #2622: Zathura inverse search goes to correct file

### DIFF
--- a/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/zathura/ZathuraConversation.kt
+++ b/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/zathura/ZathuraConversation.kt
@@ -25,7 +25,7 @@ object ZathuraConversation : ViewerConversation() {
             val path = PathManager.getBinPath()
             val name = ApplicationNamesInfo.getInstance().scriptName
             val command =
-                """zathura --synctex-forward="$line:1:$sourceFilePath" --synctex-editor-command="$path/$name.sh --line %{line} $sourceFilePath" $pdfPathGuess"""
+                """zathura --synctex-forward="$line:1:$sourceFilePath" --synctex-editor-command="$path/$name.sh --line %{line} %{input}" $pdfPathGuess"""
             Runtime.getRuntime().exec(arrayOf("bash", "-c", command))
         }
         else {


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2622 

#### Summary of additions and changes

* Zathura now uses the `%{input}` argument instead of always inverse searching to the file that was compiled from

#### How to test this pull request

See #2622 for a detailed description