### PR TITLE
Fix #2660: include parens in normal_text

### DIFF
--- a/gen/nl/hannahsten/texifyidea/parser/LatexParser.java
+++ b/gen/nl/hannahsten/texifyidea/parser/LatexParser.java
@@ -1,17 +1,16 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.parser;
 
-import com.intellij.lang.ASTNode;
-import com.intellij.lang.LightPsiParser;
 import com.intellij.lang.PsiBuilder;
 import com.intellij.lang.PsiBuilder.Marker;
-import com.intellij.lang.PsiParser;
-import com.intellij.psi.tree.IElementType;
-
-import static com.intellij.lang.WhitespacesBinders.GREEDY_LEFT_BINDER;
-import static com.intellij.lang.WhitespacesBinders.GREEDY_RIGHT_BINDER;
-import static nl.hannahsten.texifyidea.psi.LatexParserUtil.*;
 import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
+import static nl.hannahsten.texifyidea.psi.LatexParserUtil.*;
+import com.intellij.psi.tree.IElementType;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.tree.TokenSet;
+import com.intellij.lang.PsiParser;
+import com.intellij.lang.LightPsiParser;
+import static com.intellij.lang.WhitespacesBinders.*;
 
 @SuppressWarnings({"SimplifiableIfStatement", "UnusedAssignment"})
 public class LatexParser implements PsiParser, LightPsiParser {
@@ -465,7 +464,7 @@ public class LatexParser implements PsiParser, LightPsiParser {
 
   /* ********************************************************** */
   // raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | commands | group |
-  //     OPEN_PAREN | CLOSE_PAREN | OPEN_BRACKET | CLOSE_BRACKET | normal_text
+  //     normal_text | OPEN_PAREN | CLOSE_PAREN | OPEN_BRACKET | CLOSE_BRACKET
   public static boolean no_math_content(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "no_math_content")) return false;
     boolean r;
@@ -479,17 +478,17 @@ public class LatexParser implements PsiParser, LightPsiParser {
     if (!r) r = consumeToken(b, COMMAND_IFNEXTCHAR);
     if (!r) r = commands(b, l + 1);
     if (!r) r = group(b, l + 1);
+    if (!r) r = normal_text(b, l + 1);
     if (!r) r = consumeToken(b, OPEN_PAREN);
     if (!r) r = consumeToken(b, CLOSE_PAREN);
     if (!r) r = consumeToken(b, OPEN_BRACKET);
     if (!r) r = consumeToken(b, CLOSE_BRACKET);
-    if (!r) r = normal_text(b, l + 1);
     exit_section_(b, l, m, r, false, null);
     return r;
   }
 
   /* ********************************************************** */
-  // (NORMAL_TEXT_WORD | STAR | AMPERSAND | QUOTATION_MARK | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET | PIPE | EXCLAMATION_MARK | BACKSLASH | EQUALS | COMMA | DASH)+
+  // (NORMAL_TEXT_WORD | STAR | AMPERSAND | QUOTATION_MARK | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET | OPEN_PAREN | CLOSE_PAREN | OPEN_BRACKET | CLOSE_BRACKET | PIPE | EXCLAMATION_MARK | BACKSLASH | EQUALS | COMMA | DASH)+
   public static boolean normal_text(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "normal_text")) return false;
     boolean r;
@@ -504,7 +503,7 @@ public class LatexParser implements PsiParser, LightPsiParser {
     return r;
   }
 
-  // NORMAL_TEXT_WORD | STAR | AMPERSAND | QUOTATION_MARK | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET | PIPE | EXCLAMATION_MARK | BACKSLASH | EQUALS | COMMA | DASH
+  // NORMAL_TEXT_WORD | STAR | AMPERSAND | QUOTATION_MARK | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET | OPEN_PAREN | CLOSE_PAREN | OPEN_BRACKET | CLOSE_BRACKET | PIPE | EXCLAMATION_MARK | BACKSLASH | EQUALS | COMMA | DASH
   private static boolean normal_text_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "normal_text_0")) return false;
     boolean r;
@@ -514,6 +513,10 @@ public class LatexParser implements PsiParser, LightPsiParser {
     if (!r) r = consumeToken(b, QUOTATION_MARK);
     if (!r) r = consumeToken(b, OPEN_ANGLE_BRACKET);
     if (!r) r = consumeToken(b, CLOSE_ANGLE_BRACKET);
+    if (!r) r = consumeToken(b, OPEN_PAREN);
+    if (!r) r = consumeToken(b, CLOSE_PAREN);
+    if (!r) r = consumeToken(b, OPEN_BRACKET);
+    if (!r) r = consumeToken(b, CLOSE_BRACKET);
     if (!r) r = consumeToken(b, PIPE);
     if (!r) r = consumeToken(b, EXCLAMATION_MARK);
     if (!r) r = consumeToken(b, BACKSLASH);

--- a/gen/nl/hannahsten/texifyidea/psi/LatexCommands.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexCommands.java
@@ -1,15 +1,14 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi;
 
+import java.util.List;
+import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiNameIdentifierOwner;
-import com.intellij.psi.PsiReference;
 import com.intellij.psi.StubBasedPsiElement;
 import nl.hannahsten.texifyidea.index.stub.LatexCommandsStub;
-import org.jetbrains.annotations.NotNull;
-
+import com.intellij.psi.PsiReference;
 import java.util.LinkedHashMap;
-import java.util.List;
 
 public interface LatexCommands extends PsiNameIdentifierOwner, LatexCommandWithParams, StubBasedPsiElement<LatexCommandsStub> {
 
@@ -19,8 +18,7 @@ public interface LatexCommands extends PsiNameIdentifierOwner, LatexCommandWithP
   @NotNull
   PsiElement getCommandToken();
 
-  @NotNull
-  PsiReference[] getReferences();
+  @NotNull PsiReference[] getReferences();
 
   PsiReference getReference();
 

--- a/gen/nl/hannahsten/texifyidea/psi/LatexEnvironment.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexEnvironment.java
@@ -1,12 +1,13 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi;
 
-import com.intellij.psi.LiteralTextEscaper;
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiLanguageInjectionHost;
 import com.intellij.psi.StubBasedPsiElement;
 import nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStub;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import com.intellij.psi.LiteralTextEscaper;
 
 public interface LatexEnvironment extends PsiLanguageInjectionHost, StubBasedPsiElement<LatexEnvironmentStub> {
 
@@ -27,7 +28,6 @@ public interface LatexEnvironment extends PsiLanguageInjectionHost, StubBasedPsi
 
   PsiLanguageInjectionHost updateText(@NotNull String text);
 
-  @NotNull
-  LiteralTextEscaper<LatexEnvironment> createLiteralTextEscaper();
+  @NotNull LiteralTextEscaper<LatexEnvironment> createLiteralTextEscaper();
 
 }

--- a/gen/nl/hannahsten/texifyidea/psi/LatexKeyvalKey.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexKeyvalKey.java
@@ -1,10 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi;
 
-import com.intellij.psi.PsiElement;
-import org.jetbrains.annotations.NotNull;
-
 import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElement;
 
 public interface LatexKeyvalKey extends PsiElement {
 

--- a/gen/nl/hannahsten/texifyidea/psi/LatexParameter.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexParameter.java
@@ -1,10 +1,11 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi;
 
-import com.intellij.psi.LiteralTextEscaper;
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiLanguageInjectionHost;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import com.intellij.psi.LiteralTextEscaper;
 
 public interface LatexParameter extends PsiLanguageInjectionHost {
 
@@ -24,7 +25,6 @@ public interface LatexParameter extends PsiLanguageInjectionHost {
 
   PsiLanguageInjectionHost updateText(@NotNull String text);
 
-  @NotNull
-  LiteralTextEscaper<LatexParameter> createLiteralTextEscaper();
+  @NotNull LiteralTextEscaper<LatexParameter> createLiteralTextEscaper();
 
 }

--- a/gen/nl/hannahsten/texifyidea/psi/LatexParameterGroupText.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexParameterGroupText.java
@@ -1,10 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi;
 
-import com.intellij.psi.PsiElement;
-import org.jetbrains.annotations.NotNull;
-
 import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElement;
 
 public interface LatexParameterGroupText extends PsiElement {
 

--- a/gen/nl/hannahsten/texifyidea/psi/LatexRequiredParam.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexRequiredParam.java
@@ -1,10 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi;
 
-import com.intellij.psi.PsiElement;
-import org.jetbrains.annotations.NotNull;
-
 import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElement;
 
 public interface LatexRequiredParam extends PsiElement {
 

--- a/gen/nl/hannahsten/texifyidea/psi/LatexStrictKeyvalPair.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexStrictKeyvalPair.java
@@ -1,9 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi;
 
+import java.util.List;
+import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public interface LatexStrictKeyvalPair extends PsiElement {
 

--- a/gen/nl/hannahsten/texifyidea/psi/LatexTypes.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexTypes.java
@@ -1,9 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi;
 
-import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.PsiElement;
+import com.intellij.lang.ASTNode;
 import nl.hannahsten.texifyidea.index.stub.LatexCommandsStubElementType;
 import nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStubElementType;
 import nl.hannahsten.texifyidea.index.stub.LatexMagicCommentStubElementType;
@@ -185,7 +185,8 @@ public interface LatexTypes {
       }
       else if (type == REQUIRED_PARAM_CONTENT) {
         return new LatexRequiredParamContentImpl(node);
-      } else if (type == STRICT_KEYVAL_PAIR) {
+      }
+      else if (type == STRICT_KEYVAL_PAIR) {
         return new LatexStrictKeyvalPairImpl(node);
       }
       throw new AssertionError("Unknown element type: " + type);

--- a/gen/nl/hannahsten/texifyidea/psi/LatexVisitor.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexVisitor.java
@@ -1,11 +1,11 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi;
 
-import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.PsiLanguageInjectionHost;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiNameIdentifierOwner;
-import org.jetbrains.annotations.NotNull;
+import com.intellij.psi.PsiLanguageInjectionHost;
 
 public class LatexVisitor extends PsiElementVisitor {
 

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexCommandsImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexCommandsImpl.java
@@ -1,21 +1,20 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi.impl;
 
+import java.util.List;
+import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
+import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
+import nl.hannahsten.texifyidea.psi.LatexCommandsImplMixin;
+import nl.hannahsten.texifyidea.psi.*;
 import com.intellij.psi.PsiReference;
+import java.util.LinkedHashMap;
+import nl.hannahsten.texifyidea.index.stub.LatexCommandsStub;
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.tree.IElementType;
-import com.intellij.psi.util.PsiTreeUtil;
-import nl.hannahsten.texifyidea.index.stub.LatexCommandsStub;
-import nl.hannahsten.texifyidea.psi.*;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.LinkedHashMap;
-import java.util.List;
-
-import static nl.hannahsten.texifyidea.psi.LatexTypes.COMMAND_TOKEN;
 
 public class LatexCommandsImpl extends LatexCommandsImplMixin implements LatexCommands {
 
@@ -54,8 +53,7 @@ public class LatexCommandsImpl extends LatexCommandsImplMixin implements LatexCo
   }
 
   @Override
-  @NotNull
-  public PsiReference[] getReferences() {
+  public @NotNull PsiReference[] getReferences() {
     return LatexPsiImplUtil.getReferences(this);
   }
 

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexEnvironmentImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexEnvironmentImpl.java
@@ -1,18 +1,20 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi.impl;
 
-import com.intellij.extapi.psi.StubBasedPsiElementBase;
+import java.util.List;
+import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.LiteralTextEscaper;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
+import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
+import com.intellij.extapi.psi.StubBasedPsiElementBase;
+import nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStub;
+import nl.hannahsten.texifyidea.psi.*;
+import com.intellij.psi.LiteralTextEscaper;
 import com.intellij.psi.PsiLanguageInjectionHost;
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.tree.IElementType;
-import com.intellij.psi.util.PsiTreeUtil;
-import nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStub;
-import nl.hannahsten.texifyidea.psi.*;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public class LatexEnvironmentImpl extends StubBasedPsiElementBase<LatexEnvironmentStub> implements LatexEnvironment {
 
@@ -77,8 +79,7 @@ public class LatexEnvironmentImpl extends StubBasedPsiElementBase<LatexEnvironme
   }
 
   @Override
-  @NotNull
-  public LiteralTextEscaper<LatexEnvironment> createLiteralTextEscaper() {
+  public @NotNull LiteralTextEscaper<LatexEnvironment> createLiteralTextEscaper() {
     return LatexPsiImplUtil.createLiteralTextEscaper(this);
   }
 

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexKeyvalKeyImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexKeyvalKeyImpl.java
@@ -1,17 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi.impl;
 
-import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import java.util.List;
+import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import nl.hannahsten.texifyidea.psi.LatexGroup;
-import nl.hannahsten.texifyidea.psi.LatexKeyvalKey;
-import nl.hannahsten.texifyidea.psi.LatexPsiImplUtil;
-import nl.hannahsten.texifyidea.psi.LatexVisitor;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.List;
+import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import nl.hannahsten.texifyidea.psi.*;
 
 public class LatexKeyvalKeyImpl extends ASTWrapperPsiElement implements LatexKeyvalKey {
 

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexMagicCommentImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexMagicCommentImpl.java
@@ -1,18 +1,18 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi.impl;
 
-import com.intellij.extapi.psi.StubBasedPsiElementBase;
+import java.util.List;
+import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
+import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
+import com.intellij.extapi.psi.StubBasedPsiElementBase;
+import nl.hannahsten.texifyidea.index.stub.LatexMagicCommentStub;
+import nl.hannahsten.texifyidea.psi.*;
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.tree.IElementType;
-import nl.hannahsten.texifyidea.index.stub.LatexMagicCommentStub;
-import nl.hannahsten.texifyidea.psi.LatexMagicComment;
-import nl.hannahsten.texifyidea.psi.LatexVisitor;
-import org.jetbrains.annotations.NotNull;
-
-import static nl.hannahsten.texifyidea.psi.LatexTypes.MAGIC_COMMENT_TOKEN;
 
 public class LatexMagicCommentImpl extends StubBasedPsiElementBase<LatexMagicCommentStub> implements LatexMagicComment {
 

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexParameterGroupTextImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexParameterGroupTextImpl.java
@@ -1,17 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi.impl;
 
-import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import java.util.List;
+import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import nl.hannahsten.texifyidea.psi.LatexGroup;
-import nl.hannahsten.texifyidea.psi.LatexParameterGroupText;
-import nl.hannahsten.texifyidea.psi.LatexParameterText;
-import nl.hannahsten.texifyidea.psi.LatexVisitor;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.List;
+import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import nl.hannahsten.texifyidea.psi.*;
 
 public class LatexParameterGroupTextImpl extends ASTWrapperPsiElement implements LatexParameterGroupText {
 
@@ -25,7 +23,7 @@ public class LatexParameterGroupTextImpl extends ASTWrapperPsiElement implements
 
   @Override
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof LatexVisitor) accept((LatexVisitor) visitor);
+    if (visitor instanceof LatexVisitor) accept((LatexVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexParameterImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexParameterImpl.java
@@ -1,15 +1,17 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi.impl;
 
-import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import java.util.List;
+import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.LiteralTextEscaper;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.PsiLanguageInjectionHost;
 import com.intellij.psi.util.PsiTreeUtil;
+import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import nl.hannahsten.texifyidea.psi.*;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import com.intellij.psi.LiteralTextEscaper;
+import com.intellij.psi.PsiLanguageInjectionHost;
 
 public class LatexParameterImpl extends ASTWrapperPsiElement implements LatexParameter {
 
@@ -62,8 +64,7 @@ public class LatexParameterImpl extends ASTWrapperPsiElement implements LatexPar
   }
 
   @Override
-  @NotNull
-  public LiteralTextEscaper<LatexParameter> createLiteralTextEscaper() {
+  public @NotNull LiteralTextEscaper<LatexParameter> createLiteralTextEscaper() {
     return LatexPsiImplUtil.createLiteralTextEscaper(this);
   }
 

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexRequiredParamImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexRequiredParamImpl.java
@@ -1,17 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi.impl;
 
-import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import java.util.List;
+import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import nl.hannahsten.texifyidea.psi.LatexRequiredParam;
-import nl.hannahsten.texifyidea.psi.LatexRequiredParamContent;
-import nl.hannahsten.texifyidea.psi.LatexStrictKeyvalPair;
-import nl.hannahsten.texifyidea.psi.LatexVisitor;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.List;
+import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import nl.hannahsten.texifyidea.psi.*;
 
 public class LatexRequiredParamImpl extends ASTWrapperPsiElement implements LatexRequiredParam {
 
@@ -25,7 +23,7 @@ public class LatexRequiredParamImpl extends ASTWrapperPsiElement implements Late
 
   @Override
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof LatexVisitor) accept((LatexVisitor) visitor);
+    if (visitor instanceof LatexVisitor) accept((LatexVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexStrictKeyvalPairImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexStrictKeyvalPairImpl.java
@@ -1,16 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package nl.hannahsten.texifyidea.psi.impl;
 
-import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import java.util.List;
+import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import nl.hannahsten.texifyidea.psi.LatexKeyvalKey;
-import nl.hannahsten.texifyidea.psi.LatexKeyvalValue;
-import nl.hannahsten.texifyidea.psi.LatexStrictKeyvalPair;
-import nl.hannahsten.texifyidea.psi.LatexVisitor;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import static nl.hannahsten.texifyidea.psi.LatexTypes.*;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import nl.hannahsten.texifyidea.psi.*;
 
 public class LatexStrictKeyvalPairImpl extends ASTWrapperPsiElement implements LatexStrictKeyvalPair {
 
@@ -24,7 +23,7 @@ public class LatexStrictKeyvalPairImpl extends ASTWrapperPsiElement implements L
 
   @Override
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof LatexVisitor) accept((LatexVisitor) visitor);
+    if (visitor instanceof LatexVisitor) accept((LatexVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
+++ b/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
@@ -65,10 +65,9 @@ latexFile ::= content
 // Make sure that there is a root element with multiple children, for example for Grazie to allow ignoring certain types of no_math_content
 content ::= no_math_content*
 
-no_math_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | commands | group |
-    OPEN_PAREN | CLOSE_PAREN | OPEN_BRACKET | CLOSE_BRACKET | normal_text
+no_math_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | normal_text
 
-normal_text ::= (NORMAL_TEXT_WORD | STAR | AMPERSAND | QUOTATION_MARK | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET | PIPE | EXCLAMATION_MARK | BACKSLASH | EQUALS | COMMA | DASH)+
+normal_text ::= (NORMAL_TEXT_WORD | STAR | AMPERSAND | QUOTATION_MARK | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET | OPEN_PAREN | CLOSE_PAREN | OPEN_BRACKET | CLOSE_BRACKET | PIPE | EXCLAMATION_MARK | BACKSLASH | EQUALS | COMMA | DASH)+
 
 environment ::= begin_command environment_content? end_command {
     pin=1

--- a/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
@@ -61,6 +61,13 @@ class GrazieInspectionTest : BasePlatformTestCase() {
         myFixture.checkHighlighting()
     }
 
+    fun testMatchingParens() {
+        myFixture.configureByText(
+            LatexFileType, """a (in this case) . aa"""
+        )
+        myFixture.checkHighlighting()
+    }
+
     fun testGerman() {
         GrazieRemote.download(Lang.GERMANY_GERMAN)
         GrazieConfig.update { it.copy(enabledLanguages = it.enabledLanguages + Lang.GERMANY_GERMAN) }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2660

#### Summary of additions and changes

* `( ) { }` are now part of normal text, so we don't exclude them from the Grazie inspections.

#### How to test this pull request

```latex
a (in this case) . aa
```

In the old case, removing the first `a`, or a character within the parentheses, or one of the last `a`'s would trigger Grazie's unpaired symbol inspection.