### PR TITLE
Check parents to decide if element is in math context

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 [*.{kt,kts}]
-disabled_rules = final-newline,no-wildcard-imports,parameter-list-wrapping,import-ordering,keyword-spacing
+disabled_rules = final-newline,no-wildcard-imports,parameter-list-wrapping,chain-wrapping,import-ordering,keyword-spacing
 insert_final_newline = false
 
 ij_kotlin_else_on_new_line = true

--- a/src/nl/hannahsten/texifyidea/lang/DefaultEnvironment.kt
+++ b/src/nl/hannahsten/texifyidea/lang/DefaultEnvironment.kt
@@ -130,8 +130,8 @@ enum class DefaultEnvironment(
     // other
     ALGORITHM("algorithm"),
     ALGORITHMIC("algorithmic", dependency = ALGORITHMICX),
-    BLOCKARRAY(environmentName = "blockarray", context = Context.MATH, dependency = LatexPackage.BLKARRAY),
-    BLOCK(environmentName = "block", context = Context.MATH, dependency = LatexPackage.BLKARRAY),
+    BLOCKARRAY(environmentName = "blockarray", dependency = LatexPackage.BLKARRAY),
+    BLOCK(environmentName = "block", dependency = LatexPackage.BLKARRAY),
     GMATRIX(environmentName = "gmatrix", context = Context.MATH, dependency = GAUSS),
     COMMENT(environmentName = "comment", context = Context.COMMENT, dependency = LatexPackage.COMMENT),
     LISTINGS(environmentName = "lstlisting", dependency = LatexPackage.LISTINGS),

--- a/src/nl/hannahsten/texifyidea/util/Psi.kt
+++ b/src/nl/hannahsten/texifyidea/util/Psi.kt
@@ -122,10 +122,20 @@ fun <T : PsiElement> PsiElement.hasParent(clazz: KClass<T>): Boolean = parentOfT
  * @return `true` when the element is in math mode, `false` when the element is in no math mode.
  */
 fun PsiElement.inMathContext(): Boolean {
-    return hasParent(LatexMathContent::class) || hasParent(LatexDisplayMath::class) || inDirectEnvironmentContext(
-        Environment.Context.MATH
-    )
+    // Do the cheap tests first.
+    return inDirectMathContext()
+        // Check if any of the parents are in math context, because the direct environment might not be explicitly
+        // defined as math context.
+        || parents().any { it.inDirectMathContext() }
 }
+
+/**
+ * Checks if the psi element is in a direct math context or not.
+ */
+fun PsiElement.inDirectMathContext(): Boolean =
+    hasParent(LatexMathContent::class)
+        || hasParent(LatexDisplayMath::class)
+        || inDirectEnvironmentContext(Environment.Context.MATH)
 
 /**
  * Returns the outer math environment.
@@ -398,6 +408,7 @@ fun PsiElement.remove(removeLeadingWhiteSpace: Boolean = true) {
     }
     parent.node.removeChild(node)
 }
+
 /**
  * Get a sequence of all the parents of this PsiElement with the given type.
  */

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexEscapeUnderscoreInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexEscapeUnderscoreInspectionTest.kt
@@ -170,4 +170,31 @@ internal class LatexEscapeUnderscoreInspectionTest : TexifyInspectionTestBase(La
             """.trimIndent()
         )
     }
+
+    fun `test unescaped _ character warnings in block environment`() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            This block is not in math context.
+            \begin{block}{block title}
+                a<warning descr="Escape character \ expected">_</warning> underscore
+            \end{block}
+            
+            The block inside the equation (and thus the contents sf the equation) are in math context.
+            \begin{equation*}
+                \B{A} =
+                \begin{blockarray}{ccccc}
+                    & 1 & 2 & & m \\
+                  \begin{block}{c(cccc)}
+                    1 & a_{1,1} & a_{1,2} & \cdots & a_{1,m} \\
+                    2 & a_{2,1} & a_{2,2} & \cdots & a_{2,m} \\
+                    & \vdots  & \vdots  & \ddots & \vdots \\
+                    n & a_{n,1} & a_{n,2} & \cdots & a_{n,m} \\
+                  \end{block}
+                \end{blockarray}
+            \end{equation*}
+            """.trimIndent()
+        )
+        myFixture.checkHighlighting(true, false, false, false)
+    }
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2694 

#### Summary of additions and changes

* Remove the `Context.MATH` from the `block` and `blockarray` environments of the `blkarray` package. These environments can be used outside math as well, and the block environment also exists in `beamer`.
* Instead of only checking the direct parent when checking if an element is in math context, check all its parents. The fix in #2504 relied on the math context of the `block` command. After removing that, anything inside the block environment was not in math context because the block environment stated that it wasn't math context.

#### How to test this pull request

```latex
\begin{block}{block title}
    % type itm and Tab here.
\end{block}

\begin{equation*}
    \B{A} =
    \begin{blockarray}{ccccc}
        & 1 & 2 & & m \\
      \begin{block}{c(cccc)}
        1 & a_{1,1} & a_{1,2} & \cdots & a_{1,m} \\
        2 & a_{2,1} & a_{2,2} & \cdots & a_{2,m} \\
        & \vdots  & \vdots  & \ddots & \vdots \\
        n & a_{n,1} & a_{n,2} & \cdots & a_{n,m} \\
      \end{block}
    \end{blockarray}
\end{equation*}
```