### PR TITLE
Fix #2704 NPE

### DIFF
--- a/src/nl/hannahsten/texifyidea/util/labels/LabelExtraction.kt
+++ b/src/nl/hannahsten/texifyidea/util/labels/LabelExtraction.kt
@@ -62,7 +62,7 @@ fun PsiElement.extractLabelName(referencingFileSetCommands: Collection<LatexComm
         is BibtexEntry -> identifier() ?: ""
         is LatexCommands -> {
             if (CommandMagic.labelAsParameter.contains(name)) {
-                optionalParameterMap.toStringMap()["label"]!!
+                optionalParameterMap.toStringMap()["label"] ?: ""
             }
             else {
                 // For now just take the first label name (which may be multiple for user defined commands)


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2704

#### Summary of additions and changes

I couldn't reproduce the NPE, but it had a logical fix: return `""` when `null` like in other places in the same method.