### PR TITLE
Exit inline math with tab

### DIFF
--- a/src/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandler.kt
+++ b/src/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandler.kt
@@ -1,6 +1,7 @@
 package nl.hannahsten.texifyidea.editor.typedhandlers
 
 import com.intellij.codeInsight.CodeInsightSettings
+import com.intellij.codeInsight.editorActions.TabOutScopesTracker
 import com.intellij.codeInsight.editorActions.TypedHandlerDelegate
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.ex.EditorEx
@@ -73,6 +74,8 @@ class LatexTypedHandler : TypedHandlerDelegate() {
                     editor.document.insertString(
                         editor.caretModel.offset, c.toString()
                     )
+                    // Use CodeInsightSettings.getInstance().TAB_EXITS_BRACKETS_AND_QUOTES
+                    TabOutScopesTracker.getInstance().registerEmptyScope(editor, editor.caretModel.offset)
                     return Result.STOP
                 }
             }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2685

#### Summary of additions and changes

* IntelliJ uses scopes to maintain when tab can exit something, so all we have to do is create a scope for inline math.
Note: scopes behave like live templates, if you go out of the scope it disappears and using tab to exit won't work anymore.

#### How to test this pull request

Type `$x^3` then use tab to exit.

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: