### PR TITLE
Fix #2710: open pdf viewer when no tex file is open in editor

### DIFF
--- a/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/ViewerForwardSearch.kt
+++ b/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/ViewerForwardSearch.kt
@@ -15,17 +15,20 @@ class ViewerForwardSearch(private val viewer: PdfViewer) {
 
     /**
      * Execute forward search when the process is done.
+     *
+     * In the case that no tex file is open, forward search from the first line of the main file that is selected in the
+     * run config.
      */
     fun execute(handler: ProcessHandler, runConfig: LatexRunConfiguration, environment: ExecutionEnvironment, focusAllowed: Boolean = true) {
         // We have to find the file and line number before scheduling the forward search
         val mainPsiFile = runConfig.mainFile?.psiFile(environment.project) ?: return
-        val editor = mainPsiFile.openedEditor() ?: return
+        val editor = mainPsiFile.openedEditor()
 
         // Get the line number in the currently open file
-        val line = editor.document.getLineNumber(editor.caretOffset()) + 1
+        val line = editor?.document?.getLineNumber(editor.caretOffset())?.plus(1) ?: 0
 
         // Get the currently open file to use for forward search.
-        val currentPsiFile = editor.document.psiFile(environment.project) ?: return
+        val currentPsiFile = editor?.document?.psiFile(environment.project) ?: mainPsiFile
 
         // Set the OpenViewerListener to execute when the compilation is done.
         handler.addProcessListener(OpenViewerListener(viewer, runConfig, currentPsiFile.virtualFile.path, line, environment.project, focusAllowed))


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2710 

#### Summary of additions and changes

* Use the main file as default file for forward search in case there is no file open in the editor. Tested with Zathura, Okular, Evince, and the Built-in PDF Viewer on linux.

#### How to test this pull request

Run a run configuration when no tex file is open in the editor.