### PR TITLE
Quick workaround for missing parser tokens in keyval_value

### DIFF
--- a/gen/nl/hannahsten/texifyidea/parser/LatexParser.java
+++ b/gen/nl/hannahsten/texifyidea/parser/LatexParser.java
@@ -320,13 +320,19 @@ public class LatexParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // parameter_text | parameter_group
+  // parameter_text | parameter_group | OPEN_PAREN | CLOSE_PAREN | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET | commands | math_environment
   public static boolean keyval_content(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "keyval_content")) return false;
     boolean r;
     Marker m = enter_section_(b, l, _NONE_, KEYVAL_CONTENT, "<keyval content>");
     r = parameter_text(b, l + 1);
     if (!r) r = parameter_group(b, l + 1);
+    if (!r) r = consumeToken(b, OPEN_PAREN);
+    if (!r) r = consumeToken(b, CLOSE_PAREN);
+    if (!r) r = consumeToken(b, OPEN_ANGLE_BRACKET);
+    if (!r) r = consumeToken(b, CLOSE_ANGLE_BRACKET);
+    if (!r) r = commands(b, l + 1);
+    if (!r) r = math_environment(b, l + 1);
     exit_section_(b, l, m, r, false, null);
     return r;
   }
@@ -463,8 +469,7 @@ public class LatexParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | commands | group |
-  //     normal_text | OPEN_PAREN | CLOSE_PAREN | OPEN_BRACKET | CLOSE_BRACKET
+  // raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | normal_text
   public static boolean no_math_content(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "no_math_content")) return false;
     boolean r;
@@ -479,10 +484,6 @@ public class LatexParser implements PsiParser, LightPsiParser {
     if (!r) r = commands(b, l + 1);
     if (!r) r = group(b, l + 1);
     if (!r) r = normal_text(b, l + 1);
-    if (!r) r = consumeToken(b, OPEN_PAREN);
-    if (!r) r = consumeToken(b, CLOSE_PAREN);
-    if (!r) r = consumeToken(b, OPEN_BRACKET);
-    if (!r) r = consumeToken(b, CLOSE_BRACKET);
     exit_section_(b, l, m, r, false, null);
     return r;
   }

--- a/gen/nl/hannahsten/texifyidea/psi/LatexKeyvalContent.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexKeyvalContent.java
@@ -8,6 +8,12 @@ import com.intellij.psi.PsiElement;
 public interface LatexKeyvalContent extends PsiElement {
 
   @Nullable
+  LatexCommands getCommands();
+
+  @Nullable
+  LatexMathEnvironment getMathEnvironment();
+
+  @Nullable
   LatexParameterGroup getParameterGroup();
 
   @Nullable

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexKeyvalContentImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexKeyvalContentImpl.java
@@ -29,6 +29,18 @@ public class LatexKeyvalContentImpl extends ASTWrapperPsiElement implements Late
 
   @Override
   @Nullable
+  public LatexCommands getCommands() {
+    return PsiTreeUtil.getChildOfType(this, LatexCommands.class);
+  }
+
+  @Override
+  @Nullable
+  public LatexMathEnvironment getMathEnvironment() {
+    return PsiTreeUtil.getChildOfType(this, LatexMathEnvironment.class);
+  }
+
+  @Override
+  @Nullable
   public LatexParameterGroup getParameterGroup() {
     return PsiTreeUtil.getChildOfType(this, LatexParameterGroup.class);
   }

--- a/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
+++ b/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
@@ -141,7 +141,7 @@ keyval_key ::= (group | NORMAL_TEXT_WORD | STAR | AMPERSAND | QUOTATION_MARK | P
 keyval_value ::= keyval_content+ {
     methods=[toString]
 }
-keyval_content ::= parameter_text | parameter_group
+keyval_content ::= parameter_text | parameter_group | OPEN_PAREN | CLOSE_PAREN | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET | commands | math_environment
 
 
 // The lowest level of a parameter must have the getReferences etc. implemented

--- a/src/nl/hannahsten/texifyidea/highlighting/TextidoteAnnotator.kt
+++ b/src/nl/hannahsten/texifyidea/highlighting/TextidoteAnnotator.kt
@@ -102,6 +102,11 @@ class TextidoteAnnotator : DumbAware, ExternalAnnotator<TextidoteAnnotatorInitia
         for (warning in annotationResult.warnings) {
             val document = annotationResult.document
 
+            // Don't show obsolete warnings out of range
+            if (warning.endLine > document.lineCount) {
+                continue
+            }
+
             // In Textidote, everything is 1-based, and here everyting is 0-based
             val lineStartOffset1 = document.getLineStartOffset(warning.startLine - 1)
             val lineStartOffset2 = document.getLineStartOffset(warning.endLine - 1)

--- a/test/nl/hannahsten/texifyidea/formatting/LatexFormattingTest.kt
+++ b/test/nl/hannahsten/texifyidea/formatting/LatexFormattingTest.kt
@@ -56,6 +56,20 @@ class LatexFormattingTest : BasePlatformTestCase() {
         """.trimIndent()
     }
 
+    fun `test environment parameters`() {
+        """
+            \begin{enumerate*}[label=(\roman*)]
+                \item item1
+                \item item2
+            \end{enumerate*}
+        """.trimIndent() `should be reformatted to` """
+            \begin{enumerate*}[label=(\roman*)]
+                \item item1
+                \item item2
+            \end{enumerate*}
+        """.trimIndent()
+    }
+
     fun `test leading comment in environment`() {
         """
             \begin{document}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2684

This is just a quick fix, we should probably restructure some things in the parser to avoid more of these missing token problems.