### PR TITLE
Fix ignored file-level magic comments

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Token for releasing to Jetbrains using the Gradle intellij/publishPlugin task, for more information see the Gradle build file.
 intellijPublishToken=mytoken
-org.gradle.jvmargs=-Xmx4096m
+org.gradle.jvmargs=-Xmx6144m
 # https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library
 kotlin.stdlib.default.dependency = false

--- a/src/nl/hannahsten/texifyidea/action/InsertEditorAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/InsertEditorAction.kt
@@ -5,6 +5,8 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import nl.hannahsten.texifyidea.util.files.psiFile
+import nl.hannahsten.texifyidea.util.isLatexOrBibtex
 import javax.swing.Icon
 
 /**
@@ -41,11 +43,15 @@ open class InsertEditorAction(
     private val after: String = after ?: ""
 
     override fun actionPerformed(file: VirtualFile, project: Project, textEditor: TextEditor) {
+
         val editor = textEditor.editor
         val document = editor.document
         val selection = editor.selectionModel
         val start = selection.selectionStart
         val end = selection.selectionEnd
+
+        // Don't touch any file content that is not related to TeXiFy
+        if (file.psiFile(project)?.findElementAt(start)?.isLatexOrBibtex() == false) return
 
         runWriteAction(project) { insert(document, start, end, editor.caretModel) }
     }

--- a/src/nl/hannahsten/texifyidea/lang/magic/MagicComments.kt
+++ b/src/nl/hannahsten/texifyidea/lang/magic/MagicComments.kt
@@ -151,7 +151,7 @@ fun PsiElement.magicCommentLookup(
  */
 fun PsiElement.forwardMagicCommentLookup(initial: PsiElement.() -> PsiElement?) = magicCommentLookup(
     initial,
-    PsiElement::nextSiblingIgnoreWhitespace,
+    PsiElement::nextLeafIgnoreWhitespace,
     reversed = false
 )
 

--- a/src/nl/hannahsten/texifyidea/util/Psi.kt
+++ b/src/nl/hannahsten/texifyidea/util/Psi.kt
@@ -10,6 +10,8 @@ import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.nextLeaf
 import com.intellij.util.ProcessingContext
+import nl.hannahsten.texifyidea.BibtexLanguage
+import nl.hannahsten.texifyidea.LatexLanguage
 import nl.hannahsten.texifyidea.lang.DefaultEnvironment
 import nl.hannahsten.texifyidea.lang.Environment
 import nl.hannahsten.texifyidea.lang.magic.TextBasedMagicCommentParser
@@ -231,8 +233,6 @@ fun PsiElement.nextLeafIgnoreWhitespace(): PsiElement? {
     return null
 }
 
-
-
 /**
  * Finds the next sibling of the element that has the given type.
  * If the element has the given type, it is returned directly.
@@ -310,6 +310,8 @@ inline fun PsiElement.hasParentMatching(maxDepth: Int, predicate: (PsiElement) -
 fun PsiElement.isComment(): Boolean {
     return this is PsiComment || inDirectEnvironmentContext(Environment.Context.COMMENT)
 }
+
+fun PsiElement.isLatexOrBibtex() = language == LatexLanguage || language == BibtexLanguage
 
 /**
  * Checks if the element is in a direct environment.

--- a/src/nl/hannahsten/texifyidea/util/Psi.kt
+++ b/src/nl/hannahsten/texifyidea/util/Psi.kt
@@ -8,6 +8,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.nextLeaf
 import com.intellij.util.ProcessingContext
 import nl.hannahsten.texifyidea.lang.DefaultEnvironment
 import nl.hannahsten.texifyidea.lang.Environment
@@ -212,6 +213,25 @@ fun PsiElement.nextSiblingIgnoreWhitespace(): PsiElement? {
     }
     return null
 }
+
+/**
+ * Finds the next leaf element (which is not necessarily a sibling) but skips over whitespace.
+ *
+ * @receiver The element to get the next sibling of.
+ * @return The next sibling of the given psi element, or `null` when there is no previous
+ * sibling.
+ */
+fun PsiElement.nextLeafIgnoreWhitespace(): PsiElement? {
+    var leaf: PsiElement? = this
+    while (leaf?.nextLeaf(true).also { leaf = it } != null) {
+        if (leaf !is PsiWhiteSpace) {
+            return leaf
+        }
+    }
+    return null
+}
+
+
 
 /**
  * Finds the next sibling of the element that has the given type.

--- a/test/nl/hannahsten/texifyidea/lang/magic/MagicCommentPsiTest.kt
+++ b/test/nl/hannahsten/texifyidea/lang/magic/MagicCommentPsiTest.kt
@@ -30,4 +30,17 @@ class MagicCommentPsiTest : BasePlatformTestCase() {
         val magic = myFixture.file.magicComment()
         assertEquals(arrayListOf("compiler = xelatex"), magic.toCommentString())
     }
+
+    fun `test get multiple magic comments for file`() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            %! suppress = NonBreakingSpace
+            %! suppress = UnresolvedReference
+            I \ref{nolabel}
+            """.trimIndent()
+        )
+        val magic = myFixture.file.magicComment()
+        assertEquals(arrayListOf("suppress = NonBreakingSpace", "suppress = UnresolvedReference"), magic.toCommentString())
+    }
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix [TEX-158](https://texify-idea.myjetbrains.com/youtrack/issue/TEX-158)
Fix [TEX-148](https://texify-idea.myjetbrains.com/youtrack/issue/TEX-148)

#### Summary of additions and changes

* Due to (I think) a change in parser structure the next magic comment is no longer a sibling

#### How to test this pull request

```latex
            %! suppress = NonBreakingSpace
            %! suppress = UnresolvedReference
            I \ref{nolabel}
```
