### PR TITLE
Fix "Move Section Contents to Seperate File" intention

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexTooLargeSectionInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexTooLargeSectionInspection.kt
@@ -23,7 +23,6 @@ import nl.hannahsten.texifyidea.util.*
 import nl.hannahsten.texifyidea.util.files.commandsInFile
 import nl.hannahsten.texifyidea.util.files.findRootFile
 import nl.hannahsten.texifyidea.util.files.writeToFileUndoable
-import java.io.File
 import java.util.*
 
 /**
@@ -187,14 +186,11 @@ open class LatexTooLargeSectionInspection : TexifyInspectionBase() {
                     .newFileFullPath ?: return
 
             runWriteAction {
-                val createdFile = File(writeToFileUndoable(project, filePath, text, root))
+                val fn = writeToFileUndoable(project, filePath, text, root)
                 document.deleteString(startIndex, endIndex)
                 LocalFileSystem.getInstance().refresh(true)
-                val fileNameRelativeToRoot = createdFile.absolutePath
-                    .replace(File.separator, "/")
-                    .replace("$root/", "")
                 val indent = cmd.findIndentation()
-                document.insertString(startIndex, "\n$indent\\input{${fileNameRelativeToRoot.dropLast(4)}}\n\n")
+                document.insertString(startIndex, "\n$indent\\input{${fn.dropLast(4)}}\n\n")
             }
         }
     }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexTooLargeSectionInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexTooLargeSectionInspection.kt
@@ -21,8 +21,8 @@ import nl.hannahsten.texifyidea.settings.conventions.TexifyConventionsSettingsMa
 import nl.hannahsten.texifyidea.ui.CreateFileDialog
 import nl.hannahsten.texifyidea.util.*
 import nl.hannahsten.texifyidea.util.files.commandsInFile
-import nl.hannahsten.texifyidea.util.files.createFile
 import nl.hannahsten.texifyidea.util.files.findRootFile
+import nl.hannahsten.texifyidea.util.files.writeToFileUndoable
 import java.io.File
 import java.util.*
 
@@ -187,7 +187,7 @@ open class LatexTooLargeSectionInspection : TexifyInspectionBase() {
                     .newFileFullPath ?: return
 
             runWriteAction {
-                val createdFile = createFile("$filePath.tex", text)
+                val createdFile = File(writeToFileUndoable(project, filePath, text, root))
                 document.deleteString(startIndex, endIndex)
                 LocalFileSystem.getInstance().refresh(true)
                 val fileNameRelativeToRoot = createdFile.absolutePath

--- a/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexTooLargeSectionInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexTooLargeSectionInspection.kt
@@ -56,12 +56,12 @@ open class LatexTooLargeSectionInspection : TexifyInspectionBase() {
                     continue
                 }
 
-                if (cmd == command && i + 1 < commands.size) {
-                    val next = commands[i + 1]
+                for (j in i + 1 until commands.size) {
+                    val next = commands[j]
 
                     val indexOfNext = SECTION_NAMES.indexOf(next.name)
                     if (indexOfNext in 0..indexOfCurrent) {
-                        return commands[i + 1]
+                        return commands[j]
                     }
                 }
             }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexTooLargeSectionInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexTooLargeSectionInspection.kt
@@ -66,7 +66,8 @@ open class LatexTooLargeSectionInspection : TexifyInspectionBase() {
             }
 
             // If no command was found, find the end of the document.
-            return command.containingFile.childrenOfType(LatexEndCommand::class).lastOrNull()
+            return command.containingFile.childrenOfType(LatexEndCommand::class)
+                .lastOrNull { it.environmentName() == "document" }
         }
     }
 

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspection.kt
@@ -13,12 +13,8 @@ import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.reference.InputFileReference
 import nl.hannahsten.texifyidea.ui.CreateFileDialog
 import nl.hannahsten.texifyidea.util.*
-import nl.hannahsten.texifyidea.util.files.commandsInFile
-import nl.hannahsten.texifyidea.util.files.createFile
-import nl.hannahsten.texifyidea.util.files.findRootFile
-import nl.hannahsten.texifyidea.util.files.getFileExtension
+import nl.hannahsten.texifyidea.util.files.*
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
-import java.io.File
 import java.util.*
 
 /**
@@ -115,14 +111,7 @@ open class LatexFileNotFoundInspection : TexifyInspectionBase() {
 
             runWriteAction {
                 val expandedFilePath = expandCommandsOnce(newFilePath, file.project, file) ?: newFilePath
-                createFile("$expandedFilePath.$extension", "")
-
-                // Update LaTeX command parameter with chosen filename.
-                // We can safely add the extension since illegal extensions are removed later.
-                // We add the extension for consistency with the file name auto completion, which also adds the extension.
-                var fileNameRelativeToRoot = "$newFilePath.$extension"
-                    .replace(File.separator, "/")
-                    .replace("$root/", "")
+                var fileNameRelativeToRoot = writeToFileUndoable(project, expandedFilePath, "", root, extension)
 
                 val command = (cmd as? LatexCommands)?.name
                 if (command in CommandMagic.illegalExtensions) {

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspection.kt
@@ -106,7 +106,7 @@ open class LatexFileNotFoundInspection : TexifyInspectionBase() {
 
             // Display a dialog to ask for the location and name of the new file.
             // By default, all inclusion paths are relative to the main file
-            val newFilePath = CreateFileDialog(file.findRootFile().containingDirectory?.virtualFile?.canonicalPath, filePath.formatAsFilePath())
+            val newFilePath = CreateFileDialog(root, filePath.replace("$root/", "").formatAsFilePath())
                 .newFileFullPath ?: return
 
             runWriteAction {

--- a/src/nl/hannahsten/texifyidea/intentions/LatexMoveSectionToFileIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexMoveSectionToFileIntention.kt
@@ -1,18 +1,11 @@
 package nl.hannahsten.texifyidea.intentions
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.CommandProcessor
 import com.intellij.openapi.command.UndoConfirmationPolicy
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.TextRange
-import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiFileFactory
-import com.intellij.psi.PsiManager
-import nl.hannahsten.texifyidea.file.LatexFile
-import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.latex.codestyle.LatexTooLargeSectionInspection.Companion.findNextSection
 import nl.hannahsten.texifyidea.inspections.latex.codestyle.LatexTooLargeSectionInspection.InspectionFix.Companion.findLabel
 import nl.hannahsten.texifyidea.psi.LatexCommands
@@ -20,12 +13,9 @@ import nl.hannahsten.texifyidea.ui.CreateFileDialog
 import nl.hannahsten.texifyidea.util.*
 import nl.hannahsten.texifyidea.util.files.document
 import nl.hannahsten.texifyidea.util.files.findRootFile
-import nl.hannahsten.texifyidea.util.files.getUniqueFileName
 import nl.hannahsten.texifyidea.util.files.isLatexFile
+import nl.hannahsten.texifyidea.util.files.writeToFileUndoable
 import java.io.File
-import java.io.IOException
-import java.nio.file.Path
-import kotlin.io.path.pathString
 
 /**
  * @author Hannah Schellekens
@@ -83,72 +73,13 @@ open class LatexMoveSectionToFileIntention : TexifyIntentionBase("Move section c
         else file.containingDirectory?.virtualFile?.canonicalPath + File.separator + fileName
 
         // Execute write actions.
-        ApplicationManager.getApplication().runWriteAction {
+        runWriteAction {
             CommandProcessor.getInstance().executeCommand(project, {
-                // Create file...but not on fs yet
-                val fileFactory = PsiFileFactory.getInstance(project)
-                val newfile = fileFactory.createFileFromText(
-                    getUniqueFileName(
-                        Path.of(filePath).fileName.toString().appendExtension("tex"),
-                        Path.of(filePath).parent.pathString
-                    ),
-                    LatexFileType,
-                    text
-                )
-
-                val projectRootManager = ProjectRootManager.getInstance(project)
-                val allRoots = projectRootManager.contentRoots + projectRootManager.contentSourceRoots
-
-                // The following is going to resolve the PsiDirectory that we need to add the new file to.
-                var relativePath = ""
-                var bestRoot: VirtualFile? = null
-                for (testFile in allRoots) {
-                    val rootPath = testFile.path
-                    if (root.startsWith(rootPath)) {
-                        relativePath = root.substring(rootPath.length)
-                        bestRoot = testFile
-                        break
-                    }
-                }
-                if (bestRoot == null) {
-                    throw IOException("Can't find '$root' among roots")
-                }
-
-                val dirs = relativePath.split("/".toRegex()).dropLastWhile { it.isEmpty() }
-                    .toTypedArray()
-
-                var resultDir: VirtualFile = bestRoot
-                if (dirs.isNotEmpty()) {
-                    var i = 0
-                    if (dirs[0].isEmpty()) i = 1
-
-                    while (i < dirs.size) {
-                        val subdir = resultDir.findChild(dirs[i])
-                        if (subdir != null) {
-                            if (!subdir.isDirectory) {
-                                throw IOException("Expected resultDir, but got non-resultDir: " + subdir.path)
-                            }
-                        }
-                        if (subdir != null) {
-                            resultDir = subdir
-                        }
-                        else
-                            throw Exception("Could not locate directory")
-                        i += 1
-                    }
-                }
-
-                // Actually create the file on fs
-                val thing = PsiManager.getInstance(project).findDirectory(resultDir)?.add(newfile)
-
-                // back to your regularly scheduled programming
-                val fileNameRelativeToRoot = (thing as LatexFile).virtualFile.path
-                    .replace(File.separator, "/")
-                    .replace("$root/", "")
+                val createdFile = writeToFileUndoable(project, filePath, text, root)
 
                 document.deleteString(start, end)
                 val indent = sectionCommand.findIndentation()
-                document.insertString(start, "\n$indent\\input{${fileNameRelativeToRoot.dropLast(4)}}\n\n")
+                document.insertString(start, "\n$indent\\input{${createdFile.dropLast(4)}}\n\n")
             }, "Move Section to File", "Texify", UndoConfirmationPolicy.DO_NOT_REQUEST_CONFIRMATION)
         }
     }

--- a/src/nl/hannahsten/texifyidea/intentions/LatexMoveSectionToFileIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexMoveSectionToFileIntention.kt
@@ -89,7 +89,7 @@ open class LatexMoveSectionToFileIntention : TexifyIntentionBase("Move section c
                 val fileFactory = PsiFileFactory.getInstance(project)
                 val newfile = fileFactory.createFileFromText(
                     getUniqueFileName(
-                        fileName.appendExtension("tex"),
+                        Path.of(filePath).fileName.toString().appendExtension("tex"),
                         Path.of(filePath).parent.pathString
                     ),
                     LatexFileType,

--- a/src/nl/hannahsten/texifyidea/intentions/LatexMoveSectionToFileIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexMoveSectionToFileIntention.kt
@@ -1,19 +1,31 @@
 package nl.hannahsten.texifyidea.intentions
 
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.command.CommandProcessor
+import com.intellij.openapi.command.UndoConfirmationPolicy
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.PsiManager
+import nl.hannahsten.texifyidea.file.LatexFile
+import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.latex.codestyle.LatexTooLargeSectionInspection.Companion.findNextSection
 import nl.hannahsten.texifyidea.inspections.latex.codestyle.LatexTooLargeSectionInspection.InspectionFix.Companion.findLabel
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.ui.CreateFileDialog
 import nl.hannahsten.texifyidea.util.*
-import nl.hannahsten.texifyidea.util.files.createFile
 import nl.hannahsten.texifyidea.util.files.document
 import nl.hannahsten.texifyidea.util.files.findRootFile
+import nl.hannahsten.texifyidea.util.files.getUniqueFileName
 import nl.hannahsten.texifyidea.util.files.isLatexFile
 import java.io.File
+import java.io.IOException
+import java.nio.file.Path
+import kotlin.io.path.pathString
 
 /**
  * @author Hannah Schellekens
@@ -64,18 +76,72 @@ open class LatexMoveSectionToFileIntention : TexifyIntentionBase("Move section c
         val root = file.findRootFile().containingDirectory?.virtualFile?.canonicalPath ?: return
 
         // Display a dialog to ask for the location and name of the new file.
-        val filePath = CreateFileDialog(file.containingDirectory?.virtualFile?.canonicalPath, fileName.formatAsFileName())
-            .newFileFullPath ?: return
+        val filePath =
+            CreateFileDialog(file.containingDirectory?.virtualFile?.canonicalPath, fileName.formatAsFileName())
+                .newFileFullPath ?: return
 
         // Execute write actions.
-        runWriteAction {
-            val createdFile = createFile("$filePath.tex", text)
-            document.deleteString(start, end)
-            val fileNameRelativeToRoot = createdFile.absolutePath
-                .replace(File.separator, "/")
-                .replace("$root/", "")
-            val indent = sectionCommand.findIndentation()
-            document.insertString(start, "\n$indent\\input{${fileNameRelativeToRoot.dropLast(4)}}\n\n")
+        ApplicationManager.getApplication().runWriteAction {
+            CommandProcessor.getInstance().executeCommand(project, {
+                //Create file...but not on fs yet
+                val fileFactory = PsiFileFactory.getInstance(project)
+                val newfile = fileFactory.createFileFromText(
+                    getUniqueFileName(
+                        fileName.appendExtension("tex"),
+                        Path.of(filePath).parent.pathString
+                    ), LatexFileType, text
+                )
+
+                val projectRootManager = ProjectRootManager.getInstance(project)
+                val allRoots = projectRootManager.contentRoots + projectRootManager.contentSourceRoots
+
+                // The following is going to resolve the PsiDirectory that we need to add the new file to.
+                var relativePath = ""
+                var bestRoot: VirtualFile? = null
+                for (testFile in allRoots) {
+                    val rootPath = testFile.path
+                    if (root.startsWith(rootPath)) {
+                        relativePath = root.substring(rootPath.length)
+                        bestRoot = testFile
+                        break
+                    }
+                }
+                if (bestRoot == null) {
+                    throw IOException("Can't find '$root' among roots")
+                }
+
+                val dirs = relativePath.split("/".toRegex()).dropLastWhile { it.isEmpty() }
+                    .toTypedArray()
+                var i = 0
+                if (dirs[0].isEmpty()) i = 1
+                var resultDir: VirtualFile = bestRoot
+                while (i < dirs.size) {
+                    val subdir = resultDir.findChild(dirs[i])
+                    if (subdir != null) {
+                        if (!subdir.isDirectory) {
+                            throw IOException("Expected resultDir, but got non-resultDir: " + subdir.path)
+                        }
+                    }
+                    if (subdir != null) {
+                        resultDir = subdir
+                    }
+                    else
+                        throw Exception("Could not locate directory")
+                    i += 1
+                }
+
+                //Actually create the file on fs
+                val thing = PsiManager.getInstance(project).findDirectory(resultDir)?.add(newfile)
+
+                // back to your regularly scheduled programming
+                val fileNameRelativeToRoot = (thing as LatexFile).virtualFile.path
+                    .replace(File.separator, "/")
+                    .replace("$root/", "")
+
+                document.deleteString(start, end)
+                val indent = sectionCommand.findIndentation()
+                document.insertString(start, "\n$indent\\input{${fileNameRelativeToRoot.dropLast(4)}}\n\n")
+            }, "Move Section to File", "Texify", UndoConfirmationPolicy.DO_NOT_REQUEST_CONFIRMATION)
         }
     }
 }

--- a/src/nl/hannahsten/texifyidea/intentions/LatexMoveSectionToFileIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexMoveSectionToFileIntention.kt
@@ -83,13 +83,15 @@ open class LatexMoveSectionToFileIntention : TexifyIntentionBase("Move section c
         // Execute write actions.
         ApplicationManager.getApplication().runWriteAction {
             CommandProcessor.getInstance().executeCommand(project, {
-                //Create file...but not on fs yet
+                // Create file...but not on fs yet
                 val fileFactory = PsiFileFactory.getInstance(project)
                 val newfile = fileFactory.createFileFromText(
                     getUniqueFileName(
                         fileName.appendExtension("tex"),
                         Path.of(filePath).parent.pathString
-                    ), LatexFileType, text
+                    ),
+                    LatexFileType,
+                    text
                 )
 
                 val projectRootManager = ProjectRootManager.getInstance(project)
@@ -130,7 +132,7 @@ open class LatexMoveSectionToFileIntention : TexifyIntentionBase("Move section c
                     i += 1
                 }
 
-                //Actually create the file on fs
+                // Actually create the file on fs
                 val thing = PsiManager.getInstance(project).findDirectory(resultDir)?.add(newfile)
 
                 // back to your regularly scheduled programming

--- a/src/nl/hannahsten/texifyidea/intentions/LatexMoveSelectionToFileIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexMoveSelectionToFileIntention.kt
@@ -6,9 +6,9 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.ui.CreateFileDialog
-import nl.hannahsten.texifyidea.util.files.createFile
 import nl.hannahsten.texifyidea.util.files.findRootFile
 import nl.hannahsten.texifyidea.util.files.isLatexFile
+import nl.hannahsten.texifyidea.util.files.writeToFileUndoable
 import nl.hannahsten.texifyidea.util.removeIndents
 import org.intellij.lang.annotations.Language
 import java.io.File
@@ -58,11 +58,11 @@ open class LatexMoveSelectionToFileIntention : TexifyIntentionBase("Move selecti
         @Language("RegExp")
         // Note that we do not override the user-specified filename to be LaTeX-like.
         // Path of virtual file always contains '/' as file separators.
-        val root = file.findRootFile().containingDirectory?.virtualFile?.canonicalPath
+        val root = file.findRootFile().containingDirectory?.virtualFile?.canonicalPath ?: return
 
         // Execute write actions.
         runWriteAction {
-            val createdFile = createFile("$filePath.tex", text.toString())
+            val createdFile = File(writeToFileUndoable(project, filePath, text.toString(), root))
 
             for ((start, end) in offsets.reversed()) {
                 document.deleteString(start, end)

--- a/src/nl/hannahsten/texifyidea/util/files/Files.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/Files.kt
@@ -77,7 +77,8 @@ fun String.removeFileExtension() = FileUtil.FILE_EXTENSION.matcher(this).replace
 /**
  * Returns the extension of given filename
  */
-fun String.getFileExtension(): String = if (this.contains(".")) FileUtil.FILE_BODY.matcher(this).replaceAll("")!! else ""
+fun String.getFileExtension(): String =
+    if (this.contains(".")) FileUtil.FILE_BODY.matcher(this).replaceAll("")!! else ""
 
 /**
  * Creates a project directory at `path` which will be marked as excluded.
@@ -106,9 +107,28 @@ fun Document.psiFile(project: Project): PsiFile? = PsiDocumentManager.getInstanc
  * @return The created file.
  */
 fun createFile(fileName: String, contents: String): File {
+    val currentFileName = getUniqueFileName(fileName)
+
+    return File(currentFileName).apply {
+        createNewFile()
+        LocalFileSystem.getInstance().refresh(true)
+        writeText(contents, StandardCharsets.UTF_8)
+    }
+}
+
+/**
+ * Returns the name first non-conflicting filename with the provided base name
+ */
+fun getUniqueFileName(fileName: String, directory: String? = null): String {
     var count = 0
     var currentFileName = fileName
-    while (File(currentFileName).exists()) {
+    while (File(
+            (if (directory != null) {
+                directory + File.separator
+            }
+            else "") + currentFileName
+        ).exists()
+    ) {
         val extension = "." + FileUtilRt.getExtension(currentFileName)
         var stripped = currentFileName.substring(0, currentFileName.length - extension.length)
 
@@ -119,12 +139,7 @@ fun createFile(fileName: String, contents: String): File {
 
         currentFileName = stripped + (++count) + extension
     }
-
-    return File(currentFileName).apply {
-        createNewFile()
-        LocalFileSystem.getInstance().refresh(true)
-        writeText(contents, StandardCharsets.UTF_8)
-    }
+    return currentFileName
 }
 
 /**

--- a/src/nl/hannahsten/texifyidea/util/files/Files.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/Files.kt
@@ -13,7 +13,7 @@ import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.PsiManager
-import nl.hannahsten.texifyidea.file.LatexFile
+import com.intellij.psi.impl.source.PsiFileImpl
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.util.appendExtension
 import nl.hannahsten.texifyidea.util.magic.FileMagic
@@ -129,18 +129,19 @@ fun createFile(fileName: String, contents: String): File {
  * Needs to be wrapped in a writable environment
  *
  * @param project The project this is for
- * @param filePath The absolute path of the file to create. File extension will be .tex no matter what
+ * @param filePath The absolute path of the file to create. File extension provided later
  * @param text The text to add to the file
  * @param root The root path of the project? Could possibly be replaced
+ * @param extension The desired file extension **without** a dot, tex by default
  *
  * @return Returns the name of the file that was created without folder names, and with the extension
  */
-fun writeToFileUndoable(project: Project, filePath: String, text: String, root: String): String {
+fun writeToFileUndoable(project: Project, filePath: String, text: String, root: String, extension: String = "tex"): String {
     // Create file...but not on fs yet
     val fileFactory = PsiFileFactory.getInstance(project)
     val newfile = fileFactory.createFileFromText(
         getUniqueFileName(
-            Path.of(filePath).fileName.toString().appendExtension("tex"),
+            Path.of(filePath).fileName.toString().appendExtension(extension),
             Path.of(filePath).parent.pathString
         ),
         LatexFileType,
@@ -192,8 +193,8 @@ fun writeToFileUndoable(project: Project, filePath: String, text: String, root: 
     // Actually create the file on fs
     val thing = PsiManager.getInstance(project).findDirectory(resultDir)?.add(newfile)
 
-    // back to your regularly scheduled programming
-    return (thing as LatexFile).virtualFile.path
+    // back to your regularly scheduled programming. Does not cast to LatexFile because virtualFile inherits from PsiFileImpl
+    return (thing as PsiFileImpl).virtualFile.path
         .replace(File.separator, "/")
         .replace("$root/", "")
 }

--- a/src/nl/hannahsten/texifyidea/util/files/Files.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/Files.kt
@@ -130,10 +130,10 @@ fun createFile(fileName: String, contents: String): File {
  *
  * @param project The project this is for
  * @param filePath The absolute path of the file to create. File extension will be .tex no matter what
- * @param test The text to add to the file
+ * @param text The text to add to the file
  * @param root The root path of the project? Could possibly be replaced
  *
- * @return Returns the name of the file that was created without folder names
+ * @return Returns the name of the file that was created without folder names, and with the extension
  */
 fun writeToFileUndoable(project: Project, filePath: String, text: String, root: String): String {
     // Create file...but not on fs yet

--- a/src/nl/hannahsten/texifyidea/util/files/Files.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/Files.kt
@@ -122,11 +122,14 @@ fun createFile(fileName: String, contents: String): File {
 fun getUniqueFileName(fileName: String, directory: String? = null): String {
     var count = 0
     var currentFileName = fileName
-    while (File(
-            (if (directory != null) {
-                directory + File.separator
-            }
-            else "") + currentFileName
+    while (
+        File(
+            (
+                if (directory != null) {
+                    directory + File.separator
+                }
+                else ""
+                ) + currentFileName
         ).exists()
     ) {
         val extension = "." + FileUtilRt.getExtension(currentFileName)

--- a/src/nl/hannahsten/texifyidea/util/files/Files.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/Files.kt
@@ -140,6 +140,9 @@ fun writeToFileUndoable(project: Project, filePath: String, text: String, root: 
     val filenameNoExtension = Path.of(filePath).fileName.toString()
     val filepathNoFilename = Path.of(filePath).parent.pathString
 
+    // for windows
+    val filepathNoFilenameForwardSeperators = filepathNoFilename.replace("\\", "/")
+
     // Create file...but not on fs yet
     val fileFactory = PsiFileFactory.getInstance(project)
     val newfile = fileFactory.createFileFromText(
@@ -159,8 +162,8 @@ fun writeToFileUndoable(project: Project, filePath: String, text: String, root: 
     var bestRoot: VirtualFile? = null
     for (testFile in allRoots) {
         val rootPath = testFile.path
-        if (filepathNoFilename.startsWith(rootPath)) {
-            relativePath = filepathNoFilename.substring(rootPath.length)
+        if (filepathNoFilenameForwardSeperators.startsWith(rootPath)) {
+            relativePath = filepathNoFilenameForwardSeperators.substring(rootPath.length)
             bestRoot = testFile
             break
         }

--- a/test/nl/hannahsten/texifyidea/intentions/LatexMoveSectionToFileIntentionTest.kt
+++ b/test/nl/hannahsten/texifyidea/intentions/LatexMoveSectionToFileIntentionTest.kt
@@ -1,0 +1,512 @@
+package nl.hannahsten.texifyidea.intentions
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import nl.hannahsten.texifyidea.file.LatexFileType
+
+class LatexMoveSectionToFileIntentionTest : BasePlatformTestCase() {
+
+    fun testBaseCaseMiddle() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \begin{document}
+                \chapter{Simple<caret> Chapter}
+                With text
+            \end{document}
+            """.trimIndent()
+        )
+
+        myFixture.filterAvailableIntentions("Move section contents to separate file")[0]
+            .invoke(myFixture.project, myFixture.editor, myFixture.file)
+
+        myFixture.checkResult(
+            """
+            \begin{document}
+                \chapter{Simple<caret> Chapter}
+                \input{simple-chapter}
+            
+            \end{document}
+            """.trimIndent()
+        )
+
+        myFixture.checkResult("simple-chapter.tex", "With text", true)
+
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \begin{document}
+                \section{Simple<caret> Section}
+                With More text
+            \end{document}
+            """.trimIndent()
+        )
+        myFixture.filterAvailableIntentions("Move section contents to separate file")[0]
+            .invoke(myFixture.project, myFixture.editor, myFixture.file)
+        myFixture.checkResult(
+            """
+            \begin{document}
+                \section{Simple<caret> Section}
+                \input{simple-section}
+            
+            \end{document}
+            """.trimIndent()
+        )
+
+        myFixture.checkResult("simple-section.tex", "With More text", true)
+    }
+
+    fun testMultipleChaptersInDocumentSingleExtraction() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \begin{document}
+                \ch<caret>apter{Simple Chapter}
+                With text
+            \end{document}
+            """.trimIndent()
+        )
+        myFixture.filterAvailableIntentions("Move section contents to separate file")[0]
+            .invoke(myFixture.project, myFixture.editor, myFixture.file)
+        myFixture.checkResult(
+            """
+            \begin{document}
+                \ch<caret>apter{Simple Chapter}
+                \input{simple-chapter}
+            
+            \end{document}
+            """.trimIndent()
+        )
+
+        myFixture.checkResult("simple-chapter.tex", "With text", true)
+    }
+
+    fun testMultipleChaptersInDocumentMultipleExtraction() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \begin{document}
+                \chapter{First<caret> Chapter}
+                First text case
+                \chapter{Second Chapter}
+                Second text case
+                \chapter{Last Chapter}
+                Last text case
+            \end{document}
+            """.trimIndent()
+        )
+        myFixture.filterAvailableIntentions("Move section contents to separate file")[0]
+            .invoke(myFixture.project, myFixture.editor, myFixture.file)
+        myFixture.checkResult(
+            """
+            \begin{document}
+                \chapter{First<caret> Chapter}
+                \input{first-chapter}
+            
+                \chapter{Second Chapter}
+                Second text case
+                \chapter{Last Chapter}
+                Last text case
+            \end{document}
+            """.trimIndent()
+        )
+
+        myFixture.checkResult("first-chapter.tex", "First text case", true)
+
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \begin{document}
+                \chapter{First Chapter}
+                \input{first-chapter}
+            
+                \chapter{Second Chapter}
+                Second text case
+                \chapter{Last Chapt<caret>er}
+                Last text case
+            \end{document}
+            """.trimIndent()
+        )
+        myFixture.filterAvailableIntentions("Move section contents to separate file")[0]
+            .invoke(myFixture.project, myFixture.editor, myFixture.file)
+        myFixture.checkResult(
+            """
+            \begin{document}
+                \chapter{First Chapter}
+                \input{first-chapter}
+            
+                \chapter{Second Chapter}
+                Second text case
+                \chapter{Last Chapt<caret>er}
+                \input{last-chapter}
+            
+            \end{document}
+            """.trimIndent()
+        )
+
+        myFixture.checkResult("last-chapter.tex", "Last text case", true)
+
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \begin{document}
+                \chapter{First Chapter}
+                \input{first-chapter}
+            
+                \chapter{Second <caret>Chapter}
+                Second text case
+                \chapter{Last Chapter}
+                \input{last-chapter}
+            
+            \end{document}
+            """.trimIndent()
+        )
+        myFixture.filterAvailableIntentions("Move section contents to separate file")[0]
+            .invoke(myFixture.project, myFixture.editor, myFixture.file)
+        myFixture.checkResult(
+            """
+            \begin{document}
+                \chapter{First Chapter}
+                \input{first-chapter}
+            
+                \chapter{Second <caret>Chapter}
+                \input{second-chapter}
+            
+                \chapter{Last Chapter}
+                \input{last-chapter}
+            
+            \end{document}
+            """.trimIndent()
+        )
+
+        myFixture.checkResult("second-chapter.tex", "Second text case", true)
+    }
+
+    fun testMultipleChaptersAndSetionsInDocumentMultipleExtraction() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \begin{document}
+                \chapter{First Chapter}
+                First text case
+                \section{Secon<caret>d Section}
+                Second text case
+                \chapter{Last Chapter}
+                Last text case
+            \end{document}
+            """.trimIndent()
+        )
+        myFixture.filterAvailableIntentions("Move section contents to separate file")[0]
+            .invoke(myFixture.project, myFixture.editor, myFixture.file)
+        myFixture.checkResult(
+            """
+            \begin{document}
+                \chapter{First Chapter}
+                First text case
+                \section{Secon<caret>d Section}
+                \input{second-section}
+            
+                \chapter{Last Chapter}
+                Last text case
+            \end{document}
+            """.trimIndent()
+        )
+
+        myFixture.checkResult("second-section.tex", "Second text case", true)
+
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \begin{document}
+                \chapter{First Chapter<caret>}
+                First text case
+                \section{Second Section}
+                \input{second-section}
+            
+                \chapter{Last Chapter}
+                Last text case
+            \end{document}
+            """.trimIndent()
+        )
+        myFixture.filterAvailableIntentions("Move section contents to separate file")[0]
+            .invoke(myFixture.project, myFixture.editor, myFixture.file)
+        myFixture.checkResult(
+            """
+            \begin{document}
+                \chapter{First Chapter<caret>}
+                \input{first-chapter}
+            
+                \chapter{Last Chapter}
+                Last text case
+            \end{document}
+            """.trimIndent()
+        )
+
+        myFixture.checkResult("second-section.tex", "Second text case", true)
+        myFixture.checkResult(
+            "first-chapter.tex",
+            """
+            First text case
+            \section{Second Section}
+            \input{second-section}
+            """.trimIndent(),
+            true
+        )
+    }
+
+    fun testNoDocument() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \chapter{Simple<caret> Chapter}
+            With text
+            """.trimIndent()
+        )
+
+        myFixture.filterAvailableIntentions("Move section contents to separate file")[0]
+            .invoke(myFixture.project, myFixture.editor, myFixture.file)
+
+        myFixture.checkResult(
+            """
+            \chapter{Simple<caret> Chapter}
+            \input{simple-chapter}
+            
+            
+            """.trimIndent()
+        )
+
+        myFixture.checkResult("simple-chapter.tex", "With text", true)
+
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \section{Simple<caret> Section}
+            With More text
+            """.trimIndent()
+        )
+        myFixture.filterAvailableIntentions("Move section contents to separate file")[0]
+            .invoke(myFixture.project, myFixture.editor, myFixture.file)
+        myFixture.checkResult(
+            """
+            \section{Simple<caret> Section}
+            \input{simple-section}
+            
+            
+            """.trimIndent()
+        )
+
+        myFixture.checkResult("simple-section.tex", "With More text", true)
+    }
+
+    fun testMultipleChaptersOutsideDocumentSingleExtraction() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \ch<caret>apter{Simple Chapter}
+            With text
+            """.trimIndent()
+        )
+        myFixture.filterAvailableIntentions("Move section contents to separate file")[0]
+            .invoke(myFixture.project, myFixture.editor, myFixture.file)
+        myFixture.checkResult(
+            """
+            \ch<caret>apter{Simple Chapter}
+            \input{simple-chapter}
+            
+            
+            """.trimIndent()
+        )
+
+        myFixture.checkResult("simple-chapter.tex", "With text", true)
+    }
+
+    fun testMultipleChaptersOutsideDocumentMultipleExtraction() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \chapter{First<caret> Chapter}
+            First text case
+            \chapter{Second Chapter}
+            Second text case
+            \chapter{Last Chapter}
+            Last text case
+            """.trimIndent()
+        )
+        myFixture.filterAvailableIntentions("Move section contents to separate file")[0]
+            .invoke(myFixture.project, myFixture.editor, myFixture.file)
+        myFixture.checkResult(
+            """
+            \chapter{First<caret> Chapter}
+            \input{first-chapter}
+        
+            \chapter{Second Chapter}
+            Second text case
+            \chapter{Last Chapter}
+            Last text case
+            """.trimIndent()
+        )
+
+        myFixture.checkResult("first-chapter.tex", "First text case", true)
+
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \chapter{First Chapter}
+            \input{first-chapter}
+        
+            \chapter{Second Chapter}
+            Second text case
+            \chapter{Last Chapt<caret>er}
+            Last text case
+            """.trimIndent()
+        )
+        myFixture.filterAvailableIntentions("Move section contents to separate file")[0]
+            .invoke(myFixture.project, myFixture.editor, myFixture.file)
+        myFixture.checkResult(
+            """
+            \chapter{First Chapter}
+            \input{first-chapter}
+        
+            \chapter{Second Chapter}
+            Second text case
+            \chapter{Last Chapt<caret>er}
+            \input{last-chapter}
+            
+            
+            """.trimIndent()
+        )
+
+        myFixture.checkResult("last-chapter.tex", "Last text case", true)
+
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \chapter{First Chapter}
+            \input{first-chapter}
+        
+            \chapter{Second <caret>Chapter}
+            Second text case
+            \chapter{Last Chapter}
+            \input{last-chapter}
+            
+            
+            """.trimIndent()
+        )
+        myFixture.filterAvailableIntentions("Move section contents to separate file")[0]
+            .invoke(myFixture.project, myFixture.editor, myFixture.file)
+        myFixture.checkResult(
+            """
+            \chapter{First Chapter}
+            \input{first-chapter}
+        
+            \chapter{Second <caret>Chapter}
+            \input{second-chapter}
+        
+            \chapter{Last Chapter}
+            \input{last-chapter}
+            
+            
+            """.trimIndent()
+        )
+
+        myFixture.checkResult("second-chapter.tex", "Second text case", true)
+    }
+
+    fun testMultipleChaptersAndSetionsOutsideDocumentMultipleExtraction() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \chapter{First Chapter}
+            First text case
+            \section{Secon<caret>d Section}
+            Second text case
+            \chapter{Last Chapter}
+            Last text case
+            """.trimIndent()
+        )
+        myFixture.filterAvailableIntentions("Move section contents to separate file")[0]
+            .invoke(myFixture.project, myFixture.editor, myFixture.file)
+        myFixture.checkResult(
+            """
+            \chapter{First Chapter}
+            First text case
+            \section{Secon<caret>d Section}
+            \input{second-section}
+        
+            \chapter{Last Chapter}
+            Last text case
+            """.trimIndent()
+        )
+
+        myFixture.checkResult("second-section.tex", "Second text case", true)
+
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \chapter{First Chapter<caret>}
+            First text case
+            \section{Second Section}
+            \input{second-section}
+        
+            \chapter{Last Chapter}
+            Last text case
+            """.trimIndent()
+        )
+        myFixture.filterAvailableIntentions("Move section contents to separate file")[0]
+            .invoke(myFixture.project, myFixture.editor, myFixture.file)
+        myFixture.checkResult(
+            """
+            \chapter{First Chapter<caret>}
+            \input{first-chapter}
+        
+            \chapter{Last Chapter}
+            Last text case
+            """.trimIndent()
+        )
+
+        myFixture.checkResult("second-section.tex", "Second text case", true)
+        myFixture.checkResult(
+            "first-chapter.tex",
+            """
+            First text case
+            \section{Second Section}
+            \input{second-section}
+            """.trimIndent(),
+            true
+        )
+    }
+
+    fun testMultipleChaptersAndSetionsOutsideDocumentWithEquation() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \chapter{First Chapter}
+            \begin{equation}
+                The Math adds up
+            \end{equation}
+            \chapter{Last Chapter}
+            Last text case
+            """.trimIndent()
+        )
+        myFixture.filterAvailableIntentions("Move section contents to separate file")[0]
+            .invoke(myFixture.project, myFixture.editor, myFixture.file)
+        myFixture.checkResult(
+            """
+            \chapter{First Chapter}
+            \input{first-chapter}
+        
+            \chapter{Last Chapter}
+            Last text case
+            """.trimIndent()
+        )
+
+        myFixture.checkResult(
+            "first-chapter.tex",
+            """
+            \begin{equation}
+                The Math adds up
+            \end{equation}
+            """.trimIndent(),
+            true
+        )
+    }
+}


### PR DESCRIPTION
Fix #2724 

#### Summary of additions and changes

* Fixes bug outlined in #2724 
* Changed the semantics behind `nl.hannahsten.texifyidea.inspections.latex.codestyle.LatexTooLargeSectionInspection#findNextSection(LatexCommands)` to require a section/chapter. I don't think it is the *best*, but I am unsure what else it is used for. If the function is only used to find the next section, from a section, then there will be no issue.
* Note there is no guard to verify that the passed command is actually a valid section. I did this because I wanted to steer away from backsearching for one, since that requires more intimate knowledge of the usage than a basic "Find Usages" will provide.

#### How to test this pull request

```latex
\documentclass[11pt]{article}

\usepackage{amsmath}

\begin{document}

    \chapter{Foo}


    \section{SubFoo}
    Bar

    \subsubsection{SubbFoo}
    Barr

    \section{SubFooToo}


    \chapter{Too}


    \section{SubToo}
    \begin{equation}
        mathisfun
    \end{equation}

\end{document}
```

To test, take the above test file, and use the `Move Section Contents to new File` inspection. Perform this on every section and chapter and verify it works as expected. After running the inspection, undo the inspection, then try a second one. After each one works individually, try combinations thereof.