### PR TITLE
Guarantee slash in rename

### DIFF
--- a/src/nl/hannahsten/texifyidea/psi/LatexCommandsImplUtil.kt
+++ b/src/nl/hannahsten/texifyidea/psi/LatexCommandsImplUtil.kt
@@ -222,7 +222,9 @@ fun hasLabel(element: LatexCommands): Boolean {
 }
 
 fun setName(element: LatexCommands, newName: String): PsiElement {
-    val newText = element.text.replace(element.name ?: return element, newName)
+    var newText = element.text.replace(element.name ?: return element, newName)
+    if (!newText.startsWith("\\"))
+        newText = "\\" + newText
     val newElement = LatexPsiHelper(element.project).createFromText(newText).firstChild
     val oldNode = element.node
     val newNode = newElement.node

--- a/src/nl/hannahsten/texifyidea/refactoring/LatexNamesValidator.kt
+++ b/src/nl/hannahsten/texifyidea/refactoring/LatexNamesValidator.kt
@@ -17,6 +17,6 @@ class LatexNamesValidator : NamesValidator {
         // Unfortunately this is a global rule
         /** See [formatAsLabel] */
         // Exclude the first \ to allow renaming commands
-        return name.substring(1).toSet().intersect(setOf('%', '~', '#', '\\')).isEmpty()
+        return name.matches("^\\\\?[^%~#\\\\]+$".toRegex())
     }
 }


### PR DESCRIPTION
Minimal fix to #2752 

#### Summary of additions and changes

* Help prevent the user from renaming the command to an illegal or incomplete command name

#### How to test this pull request

```latex
\newcommand{\mycommand}{my command}
```