### PR TITLE
Reorder demo text styles

### DIFF
--- a/src/nl/hannahsten/texifyidea/highlighting/LatexColorSettingsPage.kt
+++ b/src/nl/hannahsten/texifyidea/highlighting/LatexColorSettingsPage.kt
@@ -134,12 +134,12 @@ class LatexColorSettingsPage : ColorSettingsPage {
                 |    Also, some text styles:
                 |    \textbf{<styleBold>Bold</styleBold>}
                 |    \textit{<styleItalic>Italic</styleItalic>}
-                |    \underline{<styleUnderline>Underline</styleUnderline>}
-                |    \sout{<styleStrikethrough>Strikethrough</styleStrikethrough>}
-                |    \textsc{<styleSmallCapitals>SMALL CAPITALS</styleSmallCapitals>}
                 |    \overline{<styleOverline>Overline</styleOverline>}
-                |    \texttt{<styleTypewriter>Typewriter</styleTypewriter>}
                 |    \textsl{<styleSlanted>Slanted</styleSlanted>}
+                |    \textsc{<styleSmallCapitals>SMALL CAPITALS</styleSmallCapitals>}
+                |    \sout{<styleStrikethrough>Strikethrough</styleStrikethrough>}
+                |    \texttt{<styleTypewriter>Typewriter</styleTypewriter>}
+                |    \underline{<styleUnderline>Underline</styleUnderline>}
                 |
                 |    \section{Conclusions}\label{<labelDefinition>sec:conclusions</labelDefinition>}
                 |    We worked hard, and achieved very little. Or did we?


### PR DESCRIPTION
Fix #2758 

#### Summary of additions and changes

* Reorder the examples in the color menu to agree with the order of the settings

If this is viewed as not being necessary, important, or that the ordering of the demo (presumably by importance/use frequency) is better as is, i will not be sad to see the request rejected. It is simply here because the fix was easy. 