### PR TITLE
Stop offering to inline when impossible

### DIFF
--- a/src/nl/hannahsten/texifyidea/refactoring/inlinefile/LatexInlineFileHandler.kt
+++ b/src/nl/hannahsten/texifyidea/refactoring/inlinefile/LatexInlineFileHandler.kt
@@ -72,7 +72,7 @@ class LatexInlineFileHandler : InlineActionHandler() {
  * This is static only so that the unit tests can use it, and also since it can be static
  */
 fun canInlineLatexElement(element: PsiElement?): Boolean {
-    val out = when (element) {
+    return when (element) {
         is LatexFile -> {
             element.containingFile.isLatexFile()
         }
@@ -81,10 +81,8 @@ fun canInlineLatexElement(element: PsiElement?): Boolean {
             (element.references.filterIsInstance<InputFileReference>().isNotEmpty())
         }
 
-        else -> true
+        else -> false
     }
-
-    return out
 }
 
 fun resolveInlineFile(element: PsiElement) = when (element) {


### PR DESCRIPTION
I didn't make an issue, but after my #2741 I didnt realize that IJ would *offer* to inline everything, but ignore the request on almost everything. This will prefent `inline` from showing up on top of nearly anything (notice the old else branch). Kind of embarrassing that I missed it, but now it will be fixed.