### PR TITLE
Remove extension on input command

### DIFF
--- a/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
@@ -350,6 +350,7 @@ object CommandMagic {
      * Commands that should not have the given file extensions.
      */
     val illegalExtensions = mapOf(
+        INPUT.cmd to listOf(".tex"),
         INCLUDE.cmd to listOf(".tex"),
         SUBFILEINCLUDE.cmd to listOf(".tex"),
         BIBLIOGRAPHY.cmd to listOf(".bib"),

--- a/test/nl/hannahsten/texifyidea/reference/InputFileReferenceTest.kt
+++ b/test/nl/hannahsten/texifyidea/reference/InputFileReferenceTest.kt
@@ -13,7 +13,7 @@ class InputFileReferenceTest : BasePlatformTestCase() {
         myFixture.configureByFile("oldname.tex")
         myFixture.configureByText(LatexFileType, "\\input{oldname<caret>.tex}")
         myFixture.renameElementAtCaret("newname.tex")
-        myFixture.checkResult("\\input{newname.tex}")
+        myFixture.checkResult("\\input{newname}")
     }
 
     fun testRenameInclude() {


### PR DESCRIPTION
Fix #2745 

#### Summary of additions and changes

* Added `input` to the list of commands that have an illegal extension.

I also stumbled across a really annoying bug, wherein if the extension was implied *before* creating a new file, then you can't undo the process, but if an necessary extension was present, then undoing is possible. 

I have no idea why.

```latex
\input{otherfile.tex} % will drop the tex
```

```latex
\input{otherfile}
```