### PR TITLE
File editor forward search

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/bibtex/BibtexMissingBibliographystyleInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/bibtex/BibtexMissingBibliographystyleInspection.kt
@@ -13,7 +13,7 @@ import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.util.endOffset
 import nl.hannahsten.texifyidea.util.files.commandsInFileSet
 import nl.hannahsten.texifyidea.util.files.document
-import nl.hannahsten.texifyidea.util.files.openedEditor
+import nl.hannahsten.texifyidea.util.files.openedTextEditor
 import nl.hannahsten.texifyidea.util.lineIndentationByOffset
 
 /**
@@ -64,7 +64,7 @@ open class BibtexMissingBibliographystyleInspection : TexifyInspectionBase() {
             val command = descriptor.psiElement as LatexCommands
             val file = command.containingFile
             val document = file.document() ?: return
-            val editor = file.openedEditor() ?: return
+            val editor = file.openedTextEditor()?.editor ?: return
 
             val offset = command.endOffset()
             val indent = document.lineIndentationByOffset(offset)

--- a/src/nl/hannahsten/texifyidea/inspections/bibtex/BibtexMissingBibliographystyleInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/bibtex/BibtexMissingBibliographystyleInspection.kt
@@ -64,7 +64,7 @@ open class BibtexMissingBibliographystyleInspection : TexifyInspectionBase() {
             val command = descriptor.psiElement as LatexCommands
             val file = command.containingFile
             val document = file.document() ?: return
-            val editor = file.openedTextEditor()?.editor ?: return
+            val editor = file.openedTextEditor() ?: return
 
             val offset = command.endOffset()
             val indent = document.lineIndentationByOffset(offset)

--- a/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMissingLabelInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMissingLabelInspection.kt
@@ -152,7 +152,7 @@ open class LatexMissingLabelInspection : TexifyInspectionBase() {
             val command = descriptor.psiElement as LatexCommands
             LatexAddLabelToCommandIntention(command.createSmartPointer()).invoke(
                 project,
-                command.containingFile.openedEditor(),
+                command.containingFile.openedTextEditor()?.editor,
                 command.containingFile
             )
         }
@@ -166,7 +166,7 @@ open class LatexMissingLabelInspection : TexifyInspectionBase() {
             val command = descriptor.psiElement as LatexEnvironment
             LatexAddLabelToEnvironmentIntention(command.createSmartPointer()).invoke(
                 project,
-                command.containingFile.openedEditor(),
+                command.containingFile.openedTextEditor()?.editor,
                 command.containingFile
             )
         }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMissingLabelInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMissingLabelInspection.kt
@@ -152,7 +152,7 @@ open class LatexMissingLabelInspection : TexifyInspectionBase() {
             val command = descriptor.psiElement as LatexCommands
             LatexAddLabelToCommandIntention(command.createSmartPointer()).invoke(
                 project,
-                command.containingFile.openedTextEditor()?.editor,
+                command.containingFile.openedTextEditor(),
                 command.containingFile
             )
         }
@@ -166,7 +166,7 @@ open class LatexMissingLabelInspection : TexifyInspectionBase() {
             val command = descriptor.psiElement as LatexEnvironment
             LatexAddLabelToEnvironmentIntention(command.createSmartPointer()).invoke(
                 project,
-                command.containingFile.openedTextEditor()?.editor,
+                command.containingFile.openedTextEditor(),
                 command.containingFile
             )
         }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexIncorrectSectionNestingInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexIncorrectSectionNestingInspection.kt
@@ -11,7 +11,7 @@ import nl.hannahsten.texifyidea.inspections.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.util.files.document
-import nl.hannahsten.texifyidea.util.files.openedEditor
+import nl.hannahsten.texifyidea.util.files.openedTextEditor
 import nl.hannahsten.texifyidea.util.lineIndentation
 import nl.hannahsten.texifyidea.util.replaceString
 
@@ -61,7 +61,7 @@ open class LatexIncorrectSectionNestingInspection : TexifyInspectionBase() {
             val lineNumber = document.getLineNumber(offset)
             val newParentCommand = command.commandToken.text.replaceFirst("sub", "")
             val replacement = "$newParentCommand{}\n${document.lineIndentation(lineNumber)}"
-            val caret = command.containingFile.openedEditor()?.caretModel
+            val caret = command.containingFile.openedTextEditor()?.editor?.caretModel
             document.insertString(offset, replacement)
             caret?.moveToOffset(offset + newParentCommand.length + 1)
         }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexIncorrectSectionNestingInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexIncorrectSectionNestingInspection.kt
@@ -61,7 +61,7 @@ open class LatexIncorrectSectionNestingInspection : TexifyInspectionBase() {
             val lineNumber = document.getLineNumber(offset)
             val newParentCommand = command.commandToken.text.replaceFirst("sub", "")
             val replacement = "$newParentCommand{}\n${document.lineIndentation(lineNumber)}"
-            val caret = command.containingFile.openedTextEditor()?.editor?.caretModel
+            val caret = command.containingFile.openedTextEditor()?.caretModel
             document.insertString(offset, replacement)
             caret?.moveToOffset(offset + newParentCommand.length + 1)
         }

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraForwardSearchListener.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraForwardSearchListener.kt
@@ -14,7 +14,7 @@ import nl.hannahsten.texifyidea.run.linuxpdfviewer.InternalPdfViewer
 import nl.hannahsten.texifyidea.util.caretOffset
 import nl.hannahsten.texifyidea.util.files.document
 import nl.hannahsten.texifyidea.util.files.isRoot
-import nl.hannahsten.texifyidea.util.files.openedEditor
+import nl.hannahsten.texifyidea.util.files.openedTextEditor
 import nl.hannahsten.texifyidea.util.files.psiFile
 import nl.hannahsten.texifyidea.util.name
 import nl.hannahsten.texifyidea.util.parentOfType
@@ -45,7 +45,7 @@ class SumatraForwardSearchListener(
             val psiFile = runConfig.mainFile?.psiFile(executionEnvironment.project) ?: return@invokeLater
             val document = psiFile.document() ?: return@invokeLater
 
-            val editor = psiFile.openedEditor() ?: return@invokeLater
+            val editor = psiFile.openedTextEditor()?.editor ?: return@invokeLater
 
             if (document != editor.document) {
                 return@invokeLater

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraForwardSearchListener.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraForwardSearchListener.kt
@@ -45,7 +45,7 @@ class SumatraForwardSearchListener(
             val psiFile = runConfig.mainFile?.psiFile(executionEnvironment.project) ?: return@invokeLater
             val document = psiFile.document() ?: return@invokeLater
 
-            val editor = psiFile.openedTextEditor()?.editor ?: return@invokeLater
+            val editor = psiFile.openedTextEditor() ?: return@invokeLater
 
             if (document != editor.document) {
                 return@invokeLater

--- a/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
@@ -1,6 +1,8 @@
 package nl.hannahsten.texifyidea.util.files
 
 import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.roots.ProjectRootManager
@@ -217,11 +219,24 @@ fun PsiFile.commandsInFile(commandName: String? = null): Collection<LatexCommand
 fun PsiFile.environmentsInFile(): Collection<LatexEnvironment> = LatexEnvironmentsIndex.getItems(this)
 
 /**
- * Get the editor of the file if it is currently opened.
+ * Get the editor of the file if it is currently opened. Note that the returned editor does not have to be a text editor,
+ * e.g., when this file is a PDF file, the editor will be a PDF editor and not a text editor.
  *
  * @return null if the file is not opened.
  */
-fun PsiFile.openedTextEditor(): TextEditor? = FileEditorManager.getInstance(project).getSelectedEditor(virtualFile) as? TextEditor
+fun PsiFile.openedEditor(): FileEditor? = FileEditorManager.getInstance(project).getSelectedEditor(virtualFile)
+
+/**
+ * Get the text editor instance of the (text) file if it is currently opened.
+ *
+ * @return null if the file is not opened in a text editor.
+ */
+fun PsiFile.openedTextEditor(): Editor? = openedEditor()?.let {
+    when (it) {
+        is TextEditor -> it.editor
+        else -> null
+    }
+}
 
 /**
  * Get all the definitions in the file.

--- a/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
@@ -1,6 +1,8 @@
 package nl.hannahsten.texifyidea.util.files
 
 import com.intellij.openapi.editor.Document
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiDocumentManager
@@ -219,7 +221,7 @@ fun PsiFile.environmentsInFile(): Collection<LatexEnvironment> = LatexEnvironmen
  *
  * @return null if the file is not opened.
  */
-fun PsiFile.openedEditor() = virtualFile.openedEditor(project)
+fun PsiFile.openedTextEditor(): TextEditor? = FileEditorManager.getInstance(project).getSelectedEditor(virtualFile) as? TextEditor
 
 /**
  * Get all the definitions in the file.

--- a/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
@@ -1,7 +1,6 @@
 package nl.hannahsten.texifyidea.util.files
 
 import com.intellij.openapi.editor.Document
-import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiDocumentManager
@@ -217,8 +216,10 @@ fun PsiFile.environmentsInFile(): Collection<LatexEnvironment> = LatexEnvironmen
 
 /**
  * Get the editor of the file if it is currently opened.
+ *
+ * @return null if the file is not opened.
  */
-fun PsiFile.openedEditor() = FileEditorManager.getInstance(project).selectedTextEditor
+fun PsiFile.openedEditor() = virtualFile.openedEditor(project)
 
 /**
  * Get all the definitions in the file.

--- a/src/nl/hannahsten/texifyidea/util/files/VirtualFile.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/VirtualFile.kt
@@ -1,8 +1,5 @@
 package nl.hannahsten.texifyidea.util.files
 
-import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.fileEditor.FileEditorManager
-import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.InvalidVirtualFileAccessException
@@ -19,16 +16,6 @@ import java.io.File
 fun VirtualFile.psiFile(project: Project): PsiFile? {
     if (!this.isValid) return null
     return PsiManager.getInstance(project).findFile(this)
-}
-
-/**
- * Get the editor of the file if it is currently opened.
- *
- * @return null if the file is not opened.
- */
-fun VirtualFile.openedEditor(project: Project): Editor? {
-    val textEditor = FileEditorManager.getInstance(project).getSelectedEditor(this) as? TextEditor
-    return textEditor?.editor
 }
 
 fun VirtualFile.findVirtualFileByAbsoluteOrRelativePath(filePath: String): VirtualFile? {

--- a/src/nl/hannahsten/texifyidea/util/files/VirtualFile.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/VirtualFile.kt
@@ -1,5 +1,8 @@
 package nl.hannahsten.texifyidea.util.files
 
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.InvalidVirtualFileAccessException
@@ -16,6 +19,16 @@ import java.io.File
 fun VirtualFile.psiFile(project: Project): PsiFile? {
     if (!this.isValid) return null
     return PsiManager.getInstance(project).findFile(this)
+}
+
+/**
+ * Get the editor of the file if it is currently opened.
+ *
+ * @return null if the file is not opened.
+ */
+fun VirtualFile.openedEditor(project: Project): Editor? {
+    val textEditor = FileEditorManager.getInstance(project).getSelectedEditor(this) as? TextEditor
+    return textEditor?.editor
 }
 
 fun VirtualFile.findVirtualFileByAbsoluteOrRelativePath(filePath: String): VirtualFile? {


### PR DESCRIPTION
#### Summary of additions and changes

* Fixes a bug in `PsiFile#openedEditor()`. This opened the editor currently selected in the IDE, which often wasn't the editor of the file we were requesting. 
* Fixed the forward search code that relied on this method working incorrectly.
* This method is also used in some other places where it looks like we assume that it does what the comments claim it does (and what it didn't always do before). I don't expect any of this to malfunction now, but the tests don't cover it because they always have only one editor (or there are no tests at all), so no guarantees. I suppose that if there's some case where it doesn't work anymore, it's rare, and it might be another four years before someone stumbles upon it.