### PR TITLE
Improve startup performance part 2: stubElementTypeHolder

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -27,6 +27,7 @@
         </list>
       </option>
     </inspection_tool>
+    <inspection_tool class="LiftReturnOrAssignment" enabled="true" level="WARNING" enabled_by_default="true" editorAttributes="WARNING_ATTRIBUTES" />
     <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
       <option name="processCode" value="true" />
       <option name="processLiterals" value="true" />

--- a/gen/nl/hannahsten/texifyidea/psi/LatexNoMathContent.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexNoMathContent.java
@@ -34,7 +34,4 @@ public interface LatexNoMathContent extends PsiElement {
   @Nullable
   LatexRawText getRawText();
 
-  @Nullable
-  PsiElement getCommandIfnextchar();
-
 }

--- a/gen/nl/hannahsten/texifyidea/psi/LatexOptionalParamContent.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexOptionalParamContent.java
@@ -34,7 +34,4 @@ public interface LatexOptionalParamContent extends PsiElement {
   @Nullable
   LatexRawText getRawText();
 
-  @Nullable
-  PsiElement getCommandIfnextchar();
-
 }

--- a/gen/nl/hannahsten/texifyidea/psi/LatexPictureParamContent.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexPictureParamContent.java
@@ -34,7 +34,4 @@ public interface LatexPictureParamContent extends PsiElement {
   @Nullable
   LatexRawText getRawText();
 
-  @Nullable
-  PsiElement getCommandIfnextchar();
-
 }

--- a/gen/nl/hannahsten/texifyidea/psi/LatexRequiredParamContent.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexRequiredParamContent.java
@@ -31,7 +31,4 @@ public interface LatexRequiredParamContent extends PsiElement {
   @Nullable
   LatexRawText getRawText();
 
-  @Nullable
-  PsiElement getCommandIfnextchar();
-
 }

--- a/gen/nl/hannahsten/texifyidea/psi/LatexTypes.java
+++ b/gen/nl/hannahsten/texifyidea/psi/LatexTypes.java
@@ -77,7 +77,7 @@ public interface LatexTypes {
   IElementType OPEN_PAREN = new LatexTokenType("OPEN_PAREN");
   IElementType PIPE = new LatexTokenType("PIPE");
   IElementType QUOTATION_MARK = new LatexTokenType("QUOTATION_MARK");
-  IElementType RAW_TEXT_TOKEN = new LatexTokenType("RAW_TEXT");
+  IElementType RAW_TEXT_TOKEN = new LatexTokenType("RAW_TEXT_TOKEN");
   IElementType STAR = new LatexTokenType("*");
 
   class Factory {

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexNoMathContentImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexNoMathContentImpl.java
@@ -81,10 +81,4 @@ public class LatexNoMathContentImpl extends ASTWrapperPsiElement implements Late
     return PsiTreeUtil.getChildOfType(this, LatexRawText.class);
   }
 
-  @Override
-  @Nullable
-  public PsiElement getCommandIfnextchar() {
-    return findChildByType(COMMAND_IFNEXTCHAR);
-  }
-
 }

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexOptionalParamContentImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexOptionalParamContentImpl.java
@@ -81,10 +81,4 @@ public class LatexOptionalParamContentImpl extends ASTWrapperPsiElement implemen
     return PsiTreeUtil.getChildOfType(this, LatexRawText.class);
   }
 
-  @Override
-  @Nullable
-  public PsiElement getCommandIfnextchar() {
-    return findChildByType(COMMAND_IFNEXTCHAR);
-  }
-
 }

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexPictureParamContentImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexPictureParamContentImpl.java
@@ -81,10 +81,4 @@ public class LatexPictureParamContentImpl extends ASTWrapperPsiElement implement
     return PsiTreeUtil.getChildOfType(this, LatexRawText.class);
   }
 
-  @Override
-  @Nullable
-  public PsiElement getCommandIfnextchar() {
-    return findChildByType(COMMAND_IFNEXTCHAR);
-  }
-
 }

--- a/gen/nl/hannahsten/texifyidea/psi/impl/LatexRequiredParamContentImpl.java
+++ b/gen/nl/hannahsten/texifyidea/psi/impl/LatexRequiredParamContentImpl.java
@@ -75,10 +75,4 @@ public class LatexRequiredParamContentImpl extends ASTWrapperPsiElement implemen
     return PsiTreeUtil.getChildOfType(this, LatexRawText.class);
   }
 
-  @Override
-  @Nullable
-  public PsiElement getCommandIfnextchar() {
-    return findChildByType(COMMAND_IFNEXTCHAR);
-  }
-
 }

--- a/resources/META-INF/extensions/index.xml
+++ b/resources/META-INF/extensions/index.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
-        <stubElementTypeHolder class="nl.hannahsten.texifyidea.psi.LatexTypes"/>
-        <stubElementTypeHolder class="nl.hannahsten.texifyidea.psi.BibtexTypes"/>
+        <stubElementTypeHolder class="nl.hannahsten.texifyidea.psi.LatexStubTypes" externalIdPrefix="nl.hannahsten.texifyidea."/>
+        <stubElementTypeHolder class="nl.hannahsten.texifyidea.psi.BibtexTypes" externalIdPrefix="nl.hannahsten.texifyidea."/>
 
         <stubIndex implementation="nl.hannahsten.texifyidea.index.LatexCommandsIndex"/>
         <stubIndex implementation="nl.hannahsten.texifyidea.index.LatexEnvironmentsIndex"/>

--- a/resources/META-INF/extensions/languages.xml
+++ b/resources/META-INF/extensions/languages.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
-        <lang.parserDefinition language="Latex" implementationClass="nl.hannahsten.texifyidea.LatexParserDefinition"/>
-        <lang.parserDefinition language="Bibtex" implementationClass="nl.hannahsten.texifyidea.BibtexParserDefinition"/>
+        <lang.parserDefinition language="Latex" implementationClass="nl.hannahsten.texifyidea.grammar.LatexParserDefinition"/>
+        <lang.parserDefinition language="Bibtex" implementationClass="nl.hannahsten.texifyidea.grammar.BibtexParserDefinition"/>
         <lang.syntaxHighlighterFactory language="Latex" implementationClass="nl.hannahsten.texifyidea.highlighting.LatexSyntaxHighlighterFactory"/>
         <lang.syntaxHighlighterFactory language="Bibtex" implementationClass="nl.hannahsten.texifyidea.highlighting.BibtexSyntaxHighlighterFactory"/>
         <lang.commenter language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.LatexCommenter"/>

--- a/src/nl/hannahsten/texifyidea/action/reformat/ExternalReformatAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/reformat/ExternalReformatAction.kt
@@ -12,7 +12,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiFileFactory
-import nl.hannahsten.texifyidea.BibtexLanguage
+import nl.hannahsten.texifyidea.grammar.BibtexLanguage
 import nl.hannahsten.texifyidea.psi.LatexPsiHelper
 import nl.hannahsten.texifyidea.util.runWriteCommandAction
 import java.util.concurrent.TimeUnit

--- a/src/nl/hannahsten/texifyidea/completion/BibtexCompletionContributor.kt
+++ b/src/nl/hannahsten/texifyidea/completion/BibtexCompletionContributor.kt
@@ -3,7 +3,7 @@ package nl.hannahsten.texifyidea.completion
 import com.intellij.codeInsight.completion.CompletionContributor
 import com.intellij.codeInsight.completion.CompletionType
 import com.intellij.patterns.PlatformPatterns
-import nl.hannahsten.texifyidea.BibtexLanguage
+import nl.hannahsten.texifyidea.grammar.BibtexLanguage
 import nl.hannahsten.texifyidea.completion.pathcompletion.LatexFileProvider
 import nl.hannahsten.texifyidea.psi.*
 import nl.hannahsten.texifyidea.util.*

--- a/src/nl/hannahsten/texifyidea/completion/LatexCompletionContributor.kt
+++ b/src/nl/hannahsten/texifyidea/completion/LatexCompletionContributor.kt
@@ -6,7 +6,7 @@ import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionType
 import com.intellij.icons.AllIcons
 import com.intellij.patterns.PlatformPatterns
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.completion.pathcompletion.LatexFileProvider
 import nl.hannahsten.texifyidea.completion.pathcompletion.LatexFolderProvider
 import nl.hannahsten.texifyidea.completion.pathcompletion.LatexGraphicsPathProvider

--- a/src/nl/hannahsten/texifyidea/file/BibtexFile.kt
+++ b/src/nl/hannahsten/texifyidea/file/BibtexFile.kt
@@ -2,7 +2,7 @@ package nl.hannahsten.texifyidea.file
 
 import com.intellij.extapi.psi.PsiFileBase
 import com.intellij.psi.FileViewProvider
-import nl.hannahsten.texifyidea.BibtexLanguage
+import nl.hannahsten.texifyidea.grammar.BibtexLanguage
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/file/BibtexFileType.kt
+++ b/src/nl/hannahsten/texifyidea/file/BibtexFileType.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.file
 
 import com.intellij.openapi.fileTypes.LanguageFileType
-import nl.hannahsten.texifyidea.BibtexLanguage
+import nl.hannahsten.texifyidea.grammar.BibtexLanguage
 import nl.hannahsten.texifyidea.TexifyIcons
 
 /**

--- a/src/nl/hannahsten/texifyidea/file/ClassFile.kt
+++ b/src/nl/hannahsten/texifyidea/file/ClassFile.kt
@@ -2,7 +2,7 @@ package nl.hannahsten.texifyidea.file
 
 import com.intellij.extapi.psi.PsiFileBase
 import com.intellij.psi.FileViewProvider
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/file/ClassFileType.kt
+++ b/src/nl/hannahsten/texifyidea/file/ClassFileType.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.file
 
 import com.intellij.openapi.fileTypes.LanguageFileType
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.TexifyIcons
 
 /**

--- a/src/nl/hannahsten/texifyidea/file/LatexFile.kt
+++ b/src/nl/hannahsten/texifyidea/file/LatexFile.kt
@@ -4,7 +4,7 @@ import com.intellij.extapi.psi.PsiFileBase
 import com.intellij.psi.FileViewProvider
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNameIdentifierOwner
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 
 /**
  * @author Sten Wessel

--- a/src/nl/hannahsten/texifyidea/file/LatexFileType.kt
+++ b/src/nl/hannahsten/texifyidea/file/LatexFileType.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.file
 
 import com.intellij.openapi.fileTypes.LanguageFileType
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.TexifyIcons
 
 /**

--- a/src/nl/hannahsten/texifyidea/file/StyleFile.kt
+++ b/src/nl/hannahsten/texifyidea/file/StyleFile.kt
@@ -2,7 +2,7 @@ package nl.hannahsten.texifyidea.file
 
 import com.intellij.extapi.psi.PsiFileBase
 import com.intellij.psi.FileViewProvider
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/file/StyleFileType.kt
+++ b/src/nl/hannahsten/texifyidea/file/StyleFileType.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.file
 
 import com.intellij.openapi.fileTypes.LanguageFileType
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.TexifyIcons
 
 /**

--- a/src/nl/hannahsten/texifyidea/file/TikzFile.kt
+++ b/src/nl/hannahsten/texifyidea/file/TikzFile.kt
@@ -2,7 +2,7 @@ package nl.hannahsten.texifyidea.file
 
 import com.intellij.extapi.psi.PsiFileBase
 import com.intellij.psi.FileViewProvider
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 
 /**
  * @author Thomas Schouten

--- a/src/nl/hannahsten/texifyidea/file/TikzFileType.kt
+++ b/src/nl/hannahsten/texifyidea/file/TikzFileType.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.file
 
 import com.intellij.openapi.fileTypes.LanguageFileType
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.TexifyIcons
 
 /**

--- a/src/nl/hannahsten/texifyidea/formatting/BibtexSpacingRules.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/BibtexSpacingRules.kt
@@ -2,7 +2,7 @@ package nl.hannahsten.texifyidea.formatting
 
 import com.intellij.formatting.Spacing
 import com.intellij.psi.codeStyle.CodeStyleSettings
-import nl.hannahsten.texifyidea.BibtexLanguage
+import nl.hannahsten.texifyidea.grammar.BibtexLanguage
 import nl.hannahsten.texifyidea.psi.BibtexTypes.*
 
 fun createBibtexSpacingBuilder(settings: CodeStyleSettings): TexSpacingBuilder {

--- a/src/nl/hannahsten/texifyidea/formatting/LatexSpacingRules.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexSpacingRules.kt
@@ -2,7 +2,7 @@ package nl.hannahsten.texifyidea.formatting
 
 import com.intellij.formatting.Spacing
 import com.intellij.psi.codeStyle.CodeStyleSettings
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.formatting.spacingrules.leftTableSpaceAlign
 import nl.hannahsten.texifyidea.formatting.spacingrules.rightTableSpaceAlign
 import nl.hannahsten.texifyidea.psi.LatexCommands

--- a/src/nl/hannahsten/texifyidea/grammar/BibtexLanguage.kt
+++ b/src/nl/hannahsten/texifyidea/grammar/BibtexLanguage.kt
@@ -1,4 +1,4 @@
-package nl.hannahsten.texifyidea
+package nl.hannahsten.texifyidea.grammar
 
 import com.intellij.lang.Language
 

--- a/src/nl/hannahsten/texifyidea/grammar/BibtexLexerAdapter.kt
+++ b/src/nl/hannahsten/texifyidea/grammar/BibtexLexerAdapter.kt
@@ -1,4 +1,4 @@
-package nl.hannahsten.texifyidea
+package nl.hannahsten.texifyidea.grammar
 
 import com.intellij.lexer.FlexAdapter
 import nl.hannahsten.texifyidea.grammar.BibtexLexer

--- a/src/nl/hannahsten/texifyidea/grammar/BibtexParserDefinition.kt
+++ b/src/nl/hannahsten/texifyidea/grammar/BibtexParserDefinition.kt
@@ -46,7 +46,7 @@ class BibtexParserDefinition : ParserDefinition {
         val FILE = object : IStubFileElementType<BibtexFileStub>(
             Language.findInstance(BibtexLanguage::class.java)
         ) {
-            override fun getStubVersion(): Int = 10
+            override fun getStubVersion(): Int = 11
         }
     }
 

--- a/src/nl/hannahsten/texifyidea/grammar/BibtexParserDefinition.kt
+++ b/src/nl/hannahsten/texifyidea/grammar/BibtexParserDefinition.kt
@@ -1,4 +1,4 @@
-package nl.hannahsten.texifyidea
+package nl.hannahsten.texifyidea.grammar
 
 import com.intellij.lang.ASTNode
 import com.intellij.lang.Language

--- a/src/nl/hannahsten/texifyidea/grammar/BibtexParserDefinition.kt
+++ b/src/nl/hannahsten/texifyidea/grammar/BibtexParserDefinition.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.FileViewProvider
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import com.intellij.psi.TokenType
 import com.intellij.psi.stubs.PsiFileStubImpl
 import com.intellij.psi.tree.IStubFileElementType
 import com.intellij.psi.tree.TokenSet
@@ -27,11 +26,11 @@ class BibtexParserDefinition : ParserDefinition {
 
     override fun getFileNodeType(): IStubFileElementType<*> = FILE
 
-    override fun getWhitespaceTokens(): TokenSet = WHITE_SPACES
+    override fun getWhitespaceTokens(): TokenSet = BibtexTokenSets.WHITE_SPACES
 
-    override fun getCommentTokens(): TokenSet = COMMENTS
+    override fun getCommentTokens(): TokenSet = BibtexTokenSets.COMMENTS
 
-    override fun getStringLiteralElements(): TokenSet = NORMAL_TEXT
+    override fun getStringLiteralElements(): TokenSet = BibtexTokenSets.NORMAL_TEXT
 
     override fun createElement(astNode: ASTNode): PsiElement = BibtexTypes.Factory.createElement(astNode)
 
@@ -44,9 +43,6 @@ class BibtexParserDefinition : ParserDefinition {
 
     companion object {
 
-        val WHITE_SPACES = TokenSet.create(TokenType.WHITE_SPACE)
-        val COMMENTS = TokenSet.create(BibtexTypes.COMMENT)
-        val NORMAL_TEXT = TokenSet.create(BibtexTypes.NORMAL_TEXT)
         val FILE = object : IStubFileElementType<BibtexFileStub>(
             Language.findInstance(BibtexLanguage::class.java)
         ) {

--- a/src/nl/hannahsten/texifyidea/grammar/BibtexTokenSets.kt
+++ b/src/nl/hannahsten/texifyidea/grammar/BibtexTokenSets.kt
@@ -1,0 +1,17 @@
+package nl.hannahsten.texifyidea.grammar
+
+import com.intellij.psi.TokenType
+import com.intellij.psi.tree.TokenSet
+import nl.hannahsten.texifyidea.psi.BibtexTypes
+
+/**
+ * See [LatexTokenSets].
+ */
+interface BibtexTokenSets {
+
+    companion object {
+        val WHITE_SPACES = TokenSet.create(TokenType.WHITE_SPACE)
+        val COMMENTS = TokenSet.create(BibtexTypes.COMMENT)
+        val NORMAL_TEXT = TokenSet.create(BibtexTypes.NORMAL_TEXT)
+    }
+}

--- a/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
+++ b/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
@@ -33,7 +33,8 @@
     implements("parameter_text")="com.intellij.psi.PsiNameIdentifierOwner"
 
     implements("parameter")="com.intellij.psi.PsiLanguageInjectionHost"
-    // See the lexer
+
+    // Used for displaying something else than the token name in the psi tree
     tokens=[
         WHITE_SPACE='regexp:\s+'
         DISPLAY_MATH_START='\['
@@ -49,12 +50,6 @@
         AMPERSAND='&'
         NORMAL_TEXT_WORD='regexp:[^\s\\{}%\[\]$()|!"=&]+'
         NORMAL_TEXT_CHAR='regexp:[|!"=&-]'
-        // Because any character can follow an \@ifnextchar, which can break the parsing in many ways, together with the first argument it is one token
-        COMMAND_IFNEXTCHAR='regexp:\\@ifnextchar.'
-        RAW_TEXT_TOKEN='RAW_TEXT'
-        BEGIN_PSEUDOCODE_BLOCK='BEGIN_PSEUDOCODE_BLOCK'
-        MIDDLE_PSEUDOCODE_BLOCK='MIDDLE_PSEUDOCODE_BLOCK'
-        END_PSEUDOCODE_BLOCK='END_PSEUDOCODE_BLOCK'
     ]
 }
 
@@ -71,6 +66,7 @@ normal_text ::= (NORMAL_TEXT_WORD | STAR | AMPERSAND | QUOTATION_MARK | OPEN_ANG
 
 environment ::= begin_command environment_content? end_command {
     pin=1
+    elementTypeHolderClass="nl.hannahsten.texifyidea.psi.LatexStubTypes"
     elementTypeClass="nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStubElementType"
     stubClass="nl.hannahsten.texifyidea.index.stub.LatexEnvironmentStub"
     methods=[getEnvironmentName getLabel isValidHost updateText createLiteralTextEscaper]

--- a/src/nl/hannahsten/texifyidea/grammar/LatexLanguage.kt
+++ b/src/nl/hannahsten/texifyidea/grammar/LatexLanguage.kt
@@ -1,4 +1,4 @@
-package nl.hannahsten.texifyidea
+package nl.hannahsten.texifyidea.grammar
 
 import com.intellij.lang.Language
 

--- a/src/nl/hannahsten/texifyidea/grammar/LatexLexerAdapter.kt
+++ b/src/nl/hannahsten/texifyidea/grammar/LatexLexerAdapter.kt
@@ -1,4 +1,4 @@
-package nl.hannahsten.texifyidea
+package nl.hannahsten.texifyidea.grammar
 
 import com.intellij.lexer.FlexAdapter
 import nl.hannahsten.texifyidea.grammar.LatexLexer

--- a/src/nl/hannahsten/texifyidea/grammar/LatexParserDefinition.kt
+++ b/src/nl/hannahsten/texifyidea/grammar/LatexParserDefinition.kt
@@ -1,4 +1,4 @@
-package nl.hannahsten.texifyidea
+package nl.hannahsten.texifyidea.grammar
 
 import com.intellij.lang.ASTNode
 import com.intellij.lang.Language

--- a/src/nl/hannahsten/texifyidea/grammar/LatexParserDefinition.kt
+++ b/src/nl/hannahsten/texifyidea/grammar/LatexParserDefinition.kt
@@ -48,7 +48,7 @@ class LatexParserDefinition : ParserDefinition {
         val FILE: IStubFileElementType<*> = object : IStubFileElementType<LatexFileStub>(
             Language.findInstance(LatexLanguage::class.java)
         ) {
-            override fun getStubVersion(): Int = 49
+            override fun getStubVersion(): Int = 50
         }
     }
 

--- a/src/nl/hannahsten/texifyidea/grammar/LatexParserDefinition.kt
+++ b/src/nl/hannahsten/texifyidea/grammar/LatexParserDefinition.kt
@@ -10,7 +10,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.FileViewProvider
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import com.intellij.psi.TokenType
 import com.intellij.psi.stubs.PsiFileStubImpl
 import com.intellij.psi.tree.IStubFileElementType
 import com.intellij.psi.tree.TokenSet
@@ -29,11 +28,11 @@ class LatexParserDefinition : ParserDefinition {
 
     override fun getFileNodeType(): IStubFileElementType<*> = FILE
 
-    override fun getWhitespaceTokens(): TokenSet = WHITE_SPACES
+    override fun getWhitespaceTokens(): TokenSet = LatexTokenSets.WHITE_SPACES
 
-    override fun getCommentTokens(): TokenSet = COMMENTS
+    override fun getCommentTokens(): TokenSet = LatexTokenSets.COMMENTS
 
-    override fun getStringLiteralElements(): TokenSet = NORMAL_TEXT
+    override fun getStringLiteralElements(): TokenSet = LatexTokenSets.NORMAL_TEXT
 
     override fun createElement(node: ASTNode): PsiElement = LatexTypes.Factory.createElement(node)
 
@@ -46,9 +45,6 @@ class LatexParserDefinition : ParserDefinition {
 
     companion object {
 
-        val WHITE_SPACES = TokenSet.create(TokenType.WHITE_SPACE)
-        val COMMENTS = TokenSet.create(LatexTypes.COMMENT_TOKEN)
-        val NORMAL_TEXT = TokenSet.create(LatexTypes.NORMAL_TEXT)
         val FILE: IStubFileElementType<*> = object : IStubFileElementType<LatexFileStub>(
             Language.findInstance(LatexLanguage::class.java)
         ) {

--- a/src/nl/hannahsten/texifyidea/grammar/LatexTokenSets.kt
+++ b/src/nl/hannahsten/texifyidea/grammar/LatexTokenSets.kt
@@ -1,0 +1,17 @@
+package nl.hannahsten.texifyidea.grammar
+
+import com.intellij.psi.TokenType
+import com.intellij.psi.tree.TokenSet
+import nl.hannahsten.texifyidea.psi.LatexTypes
+
+/**
+ * Lazy loading of token sets to speed up startup, see https://plugins.jetbrains.com/docs/intellij/lexer-and-parser-definition.html#define-a-parser
+ */
+interface LatexTokenSets {
+
+    companion object {
+        val WHITE_SPACES = TokenSet.create(TokenType.WHITE_SPACE)
+        val COMMENTS = TokenSet.create(LatexTypes.COMMENT_TOKEN)
+        val NORMAL_TEXT = TokenSet.create(LatexTypes.NORMAL_TEXT)
+    }
+}

--- a/src/nl/hannahsten/texifyidea/highlighting/BibtexSyntaxHighlighter.kt
+++ b/src/nl/hannahsten/texifyidea/highlighting/BibtexSyntaxHighlighter.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.colors.TextAttributesKey.createTextAttributesKey
 import com.intellij.openapi.fileTypes.SyntaxHighlighterBase
 import com.intellij.psi.tree.IElementType
-import nl.hannahsten.texifyidea.BibtexLexerAdapter
+import nl.hannahsten.texifyidea.grammar.BibtexLexerAdapter
 import nl.hannahsten.texifyidea.psi.BibtexTypes
 
 /**

--- a/src/nl/hannahsten/texifyidea/highlighting/LatexSyntaxHighlighter.kt
+++ b/src/nl/hannahsten/texifyidea/highlighting/LatexSyntaxHighlighter.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.fileTypes.SyntaxHighlighterBase
 import com.intellij.psi.tree.IElementType
 import com.intellij.psi.tree.TokenSet
-import nl.hannahsten.texifyidea.LatexLexerAdapter
+import nl.hannahsten.texifyidea.grammar.LatexLexerAdapter
 import nl.hannahsten.texifyidea.psi.LatexTypes
 
 /**

--- a/src/nl/hannahsten/texifyidea/index/LatexCommandsIndex.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexCommandsIndex.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.index
 
 import com.intellij.psi.stubs.StringStubIndexExtension
-import nl.hannahsten.texifyidea.LatexParserDefinition
+import nl.hannahsten.texifyidea.grammar.LatexParserDefinition
 import nl.hannahsten.texifyidea.psi.LatexCommands
 
 /**

--- a/src/nl/hannahsten/texifyidea/index/LatexDefinitionIndex.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexDefinitionIndex.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.index
 
 import com.intellij.psi.stubs.StringStubIndexExtension
-import nl.hannahsten.texifyidea.LatexParserDefinition
+import nl.hannahsten.texifyidea.grammar.LatexParserDefinition
 import nl.hannahsten.texifyidea.psi.LatexCommands
 
 /**

--- a/src/nl/hannahsten/texifyidea/index/LatexEnvironmentsIndex.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexEnvironmentsIndex.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.index
 
 import com.intellij.psi.stubs.StringStubIndexExtension
-import nl.hannahsten.texifyidea.LatexParserDefinition
+import nl.hannahsten.texifyidea.grammar.LatexParserDefinition
 import nl.hannahsten.texifyidea.psi.LatexEnvironment
 
 /**

--- a/src/nl/hannahsten/texifyidea/index/LatexGlossaryEntryIndex.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexGlossaryEntryIndex.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.index
 
 import com.intellij.psi.stubs.StringStubIndexExtension
-import nl.hannahsten.texifyidea.LatexParserDefinition
+import nl.hannahsten.texifyidea.grammar.LatexParserDefinition
 import nl.hannahsten.texifyidea.psi.LatexCommands
 
 /**

--- a/src/nl/hannahsten/texifyidea/index/LatexIncludesIndex.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexIncludesIndex.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.index
 
 import com.intellij.psi.stubs.StringStubIndexExtension
-import nl.hannahsten.texifyidea.LatexParserDefinition
+import nl.hannahsten.texifyidea.grammar.LatexParserDefinition
 import nl.hannahsten.texifyidea.psi.LatexCommands
 
 /**

--- a/src/nl/hannahsten/texifyidea/index/LatexMagicCommentIndex.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexMagicCommentIndex.kt
@@ -2,7 +2,7 @@ package nl.hannahsten.texifyidea.index
 
 import com.intellij.psi.stubs.StringStubIndexExtension
 import com.intellij.psi.stubs.StubIndexKey
-import nl.hannahsten.texifyidea.LatexParserDefinition
+import nl.hannahsten.texifyidea.grammar.LatexParserDefinition
 import nl.hannahsten.texifyidea.psi.LatexMagicComment
 
 class LatexMagicCommentIndex : StringStubIndexExtension<LatexMagicComment>() {

--- a/src/nl/hannahsten/texifyidea/index/LatexParameterLabeledCommandsIndex.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexParameterLabeledCommandsIndex.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.index
 
 import com.intellij.psi.stubs.StringStubIndexExtension
-import nl.hannahsten.texifyidea.LatexParserDefinition
+import nl.hannahsten.texifyidea.grammar.LatexParserDefinition
 import nl.hannahsten.texifyidea.psi.LatexCommands
 
 /**

--- a/src/nl/hannahsten/texifyidea/index/LatexParameterLabeledEnvironmentsIndex.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexParameterLabeledEnvironmentsIndex.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.index
 
 import com.intellij.psi.stubs.StringStubIndexExtension
-import nl.hannahsten.texifyidea.LatexParserDefinition
+import nl.hannahsten.texifyidea.grammar.LatexParserDefinition
 import nl.hannahsten.texifyidea.psi.LatexEnvironment
 
 /**

--- a/src/nl/hannahsten/texifyidea/index/stub/BibtexEntryStubElementType.kt
+++ b/src/nl/hannahsten/texifyidea/index/stub/BibtexEntryStubElementType.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.index.stub
 
 import com.intellij.psi.stubs.*
-import nl.hannahsten.texifyidea.BibtexLanguage
+import nl.hannahsten.texifyidea.grammar.BibtexLanguage
 import nl.hannahsten.texifyidea.index.BibtexEntryIndex
 import nl.hannahsten.texifyidea.psi.BibtexEntry
 import nl.hannahsten.texifyidea.psi.impl.BibtexEntryImpl

--- a/src/nl/hannahsten/texifyidea/index/stub/LatexCommandsStubElementType.kt
+++ b/src/nl/hannahsten/texifyidea/index/stub/LatexCommandsStubElementType.kt
@@ -3,7 +3,7 @@ package nl.hannahsten.texifyidea.index.stub
 import com.intellij.openapi.project.Project
 import com.intellij.psi.stubs.*
 import com.intellij.testFramework.LightVirtualFile
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.index.*
 import nl.hannahsten.texifyidea.index.file.LatexIndexableSetContributor
 import nl.hannahsten.texifyidea.psi.LatexCommands

--- a/src/nl/hannahsten/texifyidea/index/stub/LatexEnvironmentStubElementType.kt
+++ b/src/nl/hannahsten/texifyidea/index/stub/LatexEnvironmentStubElementType.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.index.stub
 
 import com.intellij.psi.stubs.*
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.index.LatexEnvironmentsIndex
 import nl.hannahsten.texifyidea.index.LatexParameterLabeledEnvironmentsIndex
 import nl.hannahsten.texifyidea.index.indexSinkOccurrence

--- a/src/nl/hannahsten/texifyidea/index/stub/LatexMagicCommentStubElementType.kt
+++ b/src/nl/hannahsten/texifyidea/index/stub/LatexMagicCommentStubElementType.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.index.stub
 
 import com.intellij.psi.stubs.*
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.index.LatexMagicCommentIndex
 import nl.hannahsten.texifyidea.index.indexSinkOccurrence
 import nl.hannahsten.texifyidea.psi.LatexMagicComment

--- a/src/nl/hannahsten/texifyidea/inspections/LatexSpellcheckingStrategy.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/LatexSpellcheckingStrategy.kt
@@ -5,7 +5,7 @@ import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.spellchecker.tokenizer.SpellcheckingStrategy
 import com.intellij.spellchecker.tokenizer.Tokenizer
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.lang.commands.Argument
 import nl.hannahsten.texifyidea.lang.commands.Argument.Type
 import nl.hannahsten.texifyidea.lang.commands.LatexMathCommand

--- a/src/nl/hannahsten/texifyidea/intentions/LatexLanguageInjectionIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexLanguageInjectionIntention.kt
@@ -10,7 +10,7 @@ import com.intellij.psi.injection.Injectable
 import com.intellij.ui.ColoredListCellRenderer
 import com.intellij.ui.components.JBList
 import com.intellij.util.ui.EmptyIcon
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.file.LatexFile
 import nl.hannahsten.texifyidea.lang.magic.DefaultMagicKeys
 import nl.hannahsten.texifyidea.lang.magic.MutableMagicComment

--- a/src/nl/hannahsten/texifyidea/psi/BibtexElementType.kt
+++ b/src/nl/hannahsten/texifyidea/psi/BibtexElementType.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.psi
 
 import com.intellij.psi.tree.IElementType
-import nl.hannahsten.texifyidea.BibtexLanguage
+import nl.hannahsten.texifyidea.grammar.BibtexLanguage
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/psi/BibtexIdUtil.kt
+++ b/src/nl/hannahsten/texifyidea/psi/BibtexIdUtil.kt
@@ -3,7 +3,7 @@ package nl.hannahsten.texifyidea.psi
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.search.GlobalSearchScope
-import nl.hannahsten.texifyidea.BibtexLanguage
+import nl.hannahsten.texifyidea.grammar.BibtexLanguage
 import nl.hannahsten.texifyidea.index.BibtexEntryIndex
 import nl.hannahsten.texifyidea.util.firstParentOfType
 import nl.hannahsten.texifyidea.util.remove

--- a/src/nl/hannahsten/texifyidea/psi/BibtexTokenType.kt
+++ b/src/nl/hannahsten/texifyidea/psi/BibtexTokenType.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.psi
 
 import com.intellij.psi.tree.IElementType
-import nl.hannahsten.texifyidea.BibtexLanguage
+import nl.hannahsten.texifyidea.grammar.BibtexLanguage
 
 /**
  * @author Hannah Schellekens

--- a/src/nl/hannahsten/texifyidea/psi/LatexElementType.kt
+++ b/src/nl/hannahsten/texifyidea/psi/LatexElementType.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.psi
 
 import com.intellij.psi.tree.IElementType
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import org.jetbrains.annotations.NonNls
 
 /**

--- a/src/nl/hannahsten/texifyidea/psi/LatexEnvironmentManipulator.kt
+++ b/src/nl/hannahsten/texifyidea/psi/LatexEnvironmentManipulator.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.AbstractElementManipulator
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.util.PsiTreeUtil
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.psi.impl.LatexEnvironmentImpl
 
 /**

--- a/src/nl/hannahsten/texifyidea/psi/LatexPsiHelper.kt
+++ b/src/nl/hannahsten/texifyidea/psi/LatexPsiHelper.kt
@@ -6,7 +6,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.impl.source.tree.LeafPsiElement
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.psi.LatexTypes.*
 import nl.hannahsten.texifyidea.util.Log
 import nl.hannahsten.texifyidea.util.childrenOfType

--- a/src/nl/hannahsten/texifyidea/psi/LatexTokenType.kt
+++ b/src/nl/hannahsten/texifyidea/psi/LatexTokenType.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.psi
 
 import com.intellij.psi.tree.IElementType
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import org.jetbrains.annotations.NonNls
 
 /**

--- a/src/nl/hannahsten/texifyidea/refactoring/inlinefile/LatexInlineFileHandler.kt
+++ b/src/nl/hannahsten/texifyidea/refactoring/inlinefile/LatexInlineFileHandler.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiUtilBase.getElementAtCaret
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.file.LatexFile
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.reference.InputFileReference

--- a/src/nl/hannahsten/texifyidea/reference/BibtexUsagesProvider.kt
+++ b/src/nl/hannahsten/texifyidea/reference/BibtexUsagesProvider.kt
@@ -6,7 +6,7 @@ import com.intellij.lang.findUsages.FindUsagesProvider
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNameIdentifierOwner
 import com.intellij.psi.tree.TokenSet
-import nl.hannahsten.texifyidea.BibtexLexerAdapter
+import nl.hannahsten.texifyidea.grammar.BibtexLexerAdapter
 import nl.hannahsten.texifyidea.psi.BibtexTypes
 
 class BibtexUsagesProvider : FindUsagesProvider {

--- a/src/nl/hannahsten/texifyidea/reference/LatexUsagesProvider.kt
+++ b/src/nl/hannahsten/texifyidea/reference/LatexUsagesProvider.kt
@@ -6,7 +6,7 @@ import com.intellij.lang.findUsages.FindUsagesProvider
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNameIdentifierOwner
 import com.intellij.psi.tree.TokenSet
-import nl.hannahsten.texifyidea.LatexLexerAdapter
+import nl.hannahsten.texifyidea.grammar.LatexLexerAdapter
 import nl.hannahsten.texifyidea.psi.LatexTypes
 
 class LatexUsagesProvider : FindUsagesProvider {

--- a/src/nl/hannahsten/texifyidea/settings/codestyle/BibtexCodeStyleSettings.kt
+++ b/src/nl/hannahsten/texifyidea/settings/codestyle/BibtexCodeStyleSettings.kt
@@ -2,6 +2,6 @@ package nl.hannahsten.texifyidea.settings.codestyle
 
 import com.intellij.psi.codeStyle.CodeStyleSettings
 import com.intellij.psi.codeStyle.CustomCodeStyleSettings
-import nl.hannahsten.texifyidea.BibtexLanguage
+import nl.hannahsten.texifyidea.grammar.BibtexLanguage
 
 class BibtexCodeStyleSettings(container: CodeStyleSettings) : CustomCodeStyleSettings(BibtexLanguage.id, container)

--- a/src/nl/hannahsten/texifyidea/settings/codestyle/BibtexCodeStyleSettingsProvider.kt
+++ b/src/nl/hannahsten/texifyidea/settings/codestyle/BibtexCodeStyleSettingsProvider.kt
@@ -6,7 +6,7 @@ import com.intellij.application.options.TabbedLanguageCodeStylePanel
 import com.intellij.psi.codeStyle.CodeStyleConfigurable
 import com.intellij.psi.codeStyle.CodeStyleSettings
 import com.intellij.psi.codeStyle.CodeStyleSettingsProvider
-import nl.hannahsten.texifyidea.BibtexLanguage
+import nl.hannahsten.texifyidea.grammar.BibtexLanguage
 
 class BibtexCodeStyleSettingsProvider : CodeStyleSettingsProvider() {
 

--- a/src/nl/hannahsten/texifyidea/settings/codestyle/BibtexLanguageCodeStyleSettingsProvider.kt
+++ b/src/nl/hannahsten/texifyidea/settings/codestyle/BibtexLanguageCodeStyleSettingsProvider.kt
@@ -5,7 +5,7 @@ import com.intellij.lang.Language
 import com.intellij.psi.codeStyle.CodeStyleSettingsCustomizable
 import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider
 import com.intellij.psi.codeStyle.extractor.values.Value
-import nl.hannahsten.texifyidea.BibtexLanguage
+import nl.hannahsten.texifyidea.grammar.BibtexLanguage
 import nl.hannahsten.texifyidea.util.magic.GeneralMagic
 import nl.hannahsten.texifyidea.util.removeHtmlTags
 

--- a/src/nl/hannahsten/texifyidea/settings/codestyle/LatexCodeStyleSettings.kt
+++ b/src/nl/hannahsten/texifyidea/settings/codestyle/LatexCodeStyleSettings.kt
@@ -2,7 +2,7 @@ package nl.hannahsten.texifyidea.settings.codestyle
 
 import com.intellij.psi.codeStyle.CodeStyleSettings
 import com.intellij.psi.codeStyle.CustomCodeStyleSettings
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
 import nl.hannahsten.texifyidea.util.magic.cmd
 

--- a/src/nl/hannahsten/texifyidea/settings/codestyle/LatexCodeStyleSettingsProvider.kt
+++ b/src/nl/hannahsten/texifyidea/settings/codestyle/LatexCodeStyleSettingsProvider.kt
@@ -6,7 +6,7 @@ import com.intellij.application.options.TabbedLanguageCodeStylePanel
 import com.intellij.psi.codeStyle.CodeStyleConfigurable
 import com.intellij.psi.codeStyle.CodeStyleSettings
 import com.intellij.psi.codeStyle.CodeStyleSettingsProvider
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 
 /**
  * Provides the LaTeX code style settings.

--- a/src/nl/hannahsten/texifyidea/settings/codestyle/LatexGenerationSettingsProvider.kt
+++ b/src/nl/hannahsten/texifyidea/settings/codestyle/LatexGenerationSettingsProvider.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.codeStyle.CodeStyleSettingsProvider
 import com.intellij.psi.codeStyle.DisplayPriority
 import com.intellij.ui.IdeBorderFactory
 import com.intellij.util.ui.JBInsets
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import javax.swing.BoxLayout
 import javax.swing.JComponent
 import javax.swing.JPanel

--- a/src/nl/hannahsten/texifyidea/settings/codestyle/LatexLanguageCodeStyleSettingsProvider.kt
+++ b/src/nl/hannahsten/texifyidea/settings/codestyle/LatexLanguageCodeStyleSettingsProvider.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.codeStyle.CodeStyleSettingsCustomizable.WrappingOrBraceO
 import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider
 import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider.SettingsType.*
 import com.intellij.psi.codeStyle.extractor.values.Value.VAR_KIND.RIGHT_MARGIN
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.util.magic.GeneralMagic
 import nl.hannahsten.texifyidea.util.removeHtmlTags
 

--- a/src/nl/hannahsten/texifyidea/settings/sdk/LatexProjectSdkSetupValidator.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/LatexProjectSdkSetupValidator.kt
@@ -11,7 +11,7 @@ import com.intellij.openapi.roots.ui.configuration.SdkPopupFactory
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiManager
 import com.intellij.ui.EditorNotificationPanel
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.modules.LatexModuleType
 

--- a/src/nl/hannahsten/texifyidea/structure/bibtex/BibtexBreadcrumbsInfo.kt
+++ b/src/nl/hannahsten/texifyidea/structure/bibtex/BibtexBreadcrumbsInfo.kt
@@ -2,7 +2,7 @@ package nl.hannahsten.texifyidea.structure.bibtex
 
 import com.intellij.psi.PsiElement
 import com.intellij.ui.breadcrumbs.BreadcrumbsProvider
-import nl.hannahsten.texifyidea.BibtexLanguage
+import nl.hannahsten.texifyidea.grammar.BibtexLanguage
 import nl.hannahsten.texifyidea.psi.BibtexEntry
 import nl.hannahsten.texifyidea.psi.BibtexId
 import nl.hannahsten.texifyidea.psi.BibtexKey

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexBreadcrumbsInfo.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexBreadcrumbsInfo.kt
@@ -2,7 +2,7 @@ package nl.hannahsten.texifyidea.structure.latex
 
 import com.intellij.psi.PsiElement
 import com.intellij.ui.breadcrumbs.BreadcrumbsProvider
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexEnvironment
 import nl.hannahsten.texifyidea.util.name

--- a/src/nl/hannahsten/texifyidea/util/Psi.kt
+++ b/src/nl/hannahsten/texifyidea/util/Psi.kt
@@ -10,8 +10,8 @@ import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.nextLeaf
 import com.intellij.util.ProcessingContext
-import nl.hannahsten.texifyidea.BibtexLanguage
-import nl.hannahsten.texifyidea.LatexLanguage
+import nl.hannahsten.texifyidea.grammar.BibtexLanguage
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.lang.DefaultEnvironment
 import nl.hannahsten.texifyidea.lang.Environment
 import nl.hannahsten.texifyidea.lang.magic.TextBasedMagicCommentParser

--- a/test/nl/hannahsten/texifyidea/psi/LatexParserToPsiTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/LatexParserToPsiTest.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.psi
 
 import com.intellij.testFramework.ParsingTestCase
-import nl.hannahsten.texifyidea.LatexParserDefinition
+import nl.hannahsten.texifyidea.grammar.LatexParserDefinition
 
 class LatexParserToPsiTest : ParsingTestCase("", "tex", LatexParserDefinition()) {
 


### PR DESCRIPTION
Specify externalIdPrefix for stubElementTypeHolder as recommended by the docs.
However, there is a problem, this is the documentation:

> To speed up IDE loading, it's recommended that this extension is used for interfaces containing only IStubElementType (or ObjectStubSerializer) constants, and all other language's element types are kept in a separate interface that can be loaded later.

However, in the Grammar-Kit preamble you can only specify one elementTypeHolderClass, so inevitably both the stub and the non-stub types will end up in the same class.
I've checked some other plugins but haven't found yet how this is fixable without manually editing generated files.

https://intellij-support.jetbrains.com/hc/en-us/community/posts/9408724267666-Using-externalIdPrefix-for-a-stubElementTypeHolder-generated-by-Grammar-Kit