### PR TITLE
Full compatibility for Sumatra custom path

### DIFF
--- a/src/nl/hannahsten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
@@ -46,7 +46,7 @@ open class ConfigureInverseSearchAction : AnAction(
                 // First kill Sumatra to avoid having two instances open of which only one has the correct setting
                 Runtime.getRuntime().exec("taskkill /IM SumatraPDF.exe")
 
-                var path = PathManager.getBinPath()
+                val path = PathManager.getBinPath()
                 var name = ApplicationNamesInfo.getInstance().scriptName
 
                 // If we can find a 64-bits Java, then we can start (the equivalent of) idea64.exe since that will use the 64-bits Java

--- a/src/nl/hannahsten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
@@ -6,10 +6,8 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationNamesInfo
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.ui.DialogBuilder
-import nl.hannahsten.texifyidea.run.linuxpdfviewer.InternalPdfViewer
 import nl.hannahsten.texifyidea.run.sumatra.SumatraAvailabilityChecker
-import nl.hannahsten.texifyidea.util.runCommandWithoutReturn
-import nl.hannahsten.texifyidea.util.selectedRunConfig
+import nl.hannahsten.texifyidea.util.runCommandWithExitCode
 import javax.swing.JLabel
 import javax.swing.SwingConstants
 
@@ -48,6 +46,7 @@ open class ConfigureInverseSearchAction : AnAction(
 
                 val path = PathManager.getBinPath()
                 var name = ApplicationNamesInfo.getInstance().scriptName
+                val sumatraWorkingDir = SumatraAvailabilityChecker.getSumatraWorkingCustomDir()
 
                 // If we can find a 64-bits Java, then we can start (the equivalent of) idea64.exe since that will use the 64-bits Java
                 // see issue 104 and https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/809
@@ -56,10 +55,10 @@ open class ConfigureInverseSearchAction : AnAction(
                     // We will assume that since the user is using a 64-bit IDEA that name64 exists, this is at least true for idea64.exe and pycharm64.exe on Windows
                     name += "64"
                     // We also remove an extra "" because it opens an empty IDEA instance when present
-                    runCommandWithoutReturn("cmd.exe", "/C", "start", "SumatraPDF", "-inverse-search", "\"$path\\$name.exe\" --line %l \"%f\"", workingDirectory = SumatraAvailabilityChecker.getSumatraWorkingCustomDir())
+                    runCommandWithExitCode("cmd.exe", "/C", "start", "SumatraPDF", "-inverse-search", "\"$path\\$name.exe\" --line %l \"%f\"", workingDirectory = sumatraWorkingDir, nonBlocking = true)
                 }
                 else {
-                    runCommandWithoutReturn("cmd.exe", "/C", "start", "SumatraPDF", "-inverse-search", "\"$path\\$name.exe\" \"\" --line %l \"%f\"", workingDirectory = SumatraAvailabilityChecker.getSumatraWorkingCustomDir())
+                    runCommandWithExitCode("cmd.exe", "/C", "start", "SumatraPDF", "-inverse-search", "\"$path\\$name.exe\" \"\" --line %l \"%f\"", workingDirectory = sumatraWorkingDir, nonBlocking = true)
                 }
 
                 dialogWrapper.close(0)
@@ -70,6 +69,6 @@ open class ConfigureInverseSearchAction : AnAction(
     }
 
     override fun update(e: AnActionEvent) {
-        e.presentation.isEnabledAndVisible = e.project?.selectedRunConfig()?.pdfViewer == InternalPdfViewer.SUMATRA
+        e.presentation.isEnabledAndVisible = SumatraAvailabilityChecker.getSumatraAvailability()
     }
 }

--- a/src/nl/hannahsten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
@@ -6,7 +6,10 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationNamesInfo
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.ui.DialogBuilder
+import nl.hannahsten.texifyidea.run.linuxpdfviewer.InternalPdfViewer
 import nl.hannahsten.texifyidea.run.sumatra.SumatraAvailabilityChecker
+import nl.hannahsten.texifyidea.util.runCommandWithoutReturn
+import nl.hannahsten.texifyidea.util.selectedRunConfig
 import javax.swing.JLabel
 import javax.swing.SwingConstants
 
@@ -43,7 +46,7 @@ open class ConfigureInverseSearchAction : AnAction(
                 // First kill Sumatra to avoid having two instances open of which only one has the correct setting
                 Runtime.getRuntime().exec("taskkill /IM SumatraPDF.exe")
 
-                val path = PathManager.getBinPath()
+                var path = PathManager.getBinPath()
                 var name = ApplicationNamesInfo.getInstance().scriptName
 
                 // If we can find a 64-bits Java, then we can start (the equivalent of) idea64.exe since that will use the 64-bits Java
@@ -53,10 +56,10 @@ open class ConfigureInverseSearchAction : AnAction(
                     // We will assume that since the user is using a 64-bit IDEA that name64 exists, this is at least true for idea64.exe and pycharm64.exe on Windows
                     name += "64"
                     // We also remove an extra "" because it opens an empty IDEA instance when present
-                    Runtime.getRuntime().exec("cmd.exe /c start SumatraPDF -inverse-search \"\\\"$path\\$name.exe\\\" --line %l \\\"%f\\\"\"")
+                    runCommandWithoutReturn("cmd.exe", "/C", "start", "SumatraPDF", "-inverse-search", "\"$path\\$name.exe\" --line %l \"%f\"", workingDirectory = SumatraAvailabilityChecker.getSumatraWorkingCustomDir())
                 }
                 else {
-                    Runtime.getRuntime().exec("cmd.exe /c start SumatraPDF -inverse-search \"\\\"$path\\$name.exe\\\" \\\"\\\" --line %l \\\"%f\\\"\"")
+                    runCommandWithoutReturn("cmd.exe", "/C", "start", "SumatraPDF", "-inverse-search", "\"$path\\$name.exe\" \"\" --line %l \"%f\"", workingDirectory = SumatraAvailabilityChecker.getSumatraWorkingCustomDir())
                 }
 
                 dialogWrapper.close(0)
@@ -67,6 +70,6 @@ open class ConfigureInverseSearchAction : AnAction(
     }
 
     override fun update(e: AnActionEvent) {
-        e.presentation.isEnabledAndVisible = SumatraAvailabilityChecker.getSumatraAvailability()
+        e.presentation.isEnabledAndVisible = e.project?.selectedRunConfig()?.pdfViewer == InternalPdfViewer.SUMATRA
     }
 }

--- a/src/nl/hannahsten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationNamesInfo
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.ui.DialogBuilder
-import nl.hannahsten.texifyidea.run.sumatra.isSumatraAvailable
+import nl.hannahsten.texifyidea.run.sumatra.SumatraAvailabilityChecker
 import javax.swing.JLabel
 import javax.swing.SwingConstants
 
@@ -67,6 +67,6 @@ open class ConfigureInverseSearchAction : AnAction(
     }
 
     override fun update(e: AnActionEvent) {
-        e.presentation.isEnabledAndVisible = isSumatraAvailable
+        e.presentation.isEnabledAndVisible = SumatraAvailabilityChecker.getSumatraAvailability()
     }
 }

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexCommandLineState.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexCommandLineState.kt
@@ -24,7 +24,7 @@ import nl.hannahsten.texifyidea.run.linuxpdfviewer.ViewerForwardSearch
 import nl.hannahsten.texifyidea.run.makeindex.RunMakeindexListener
 import nl.hannahsten.texifyidea.run.pdfviewer.ExternalPdfViewer
 import nl.hannahsten.texifyidea.run.sumatra.SumatraForwardSearchListener
-import nl.hannahsten.texifyidea.run.sumatra.isSumatraAvailable
+import nl.hannahsten.texifyidea.run.sumatra.SumatraAvailabilityChecker
 import nl.hannahsten.texifyidea.util.files.commandsInFileSet
 import nl.hannahsten.texifyidea.util.files.psiFile
 import nl.hannahsten.texifyidea.util.includedPackages
@@ -237,9 +237,9 @@ open class LatexCommandLineState(environment: ExecutionEnvironment, private val 
             handler.addProcessListener(OpenCustomPdfViewerListener(commandList.toTypedArray(), runConfig = runConfig))
         }
         // Do nothing if the user selected that they do not want a viewer to open.
-        else if (runConfig.pdfViewer == InternalPdfViewer.NONE && runConfig.sumatraPath == null) return
+        else if (runConfig.pdfViewer == InternalPdfViewer.NONE) return
         // Sumatra does not support DVI
-        else if ((runConfig.sumatraPath != null || (runConfig.pdfViewer == InternalPdfViewer.SUMATRA && isSumatraAvailable)) && runConfig.outputFormat == LatexCompiler.Format.PDF) {
+        else if (((runConfig.pdfViewer == InternalPdfViewer.SUMATRA && SumatraAvailabilityChecker.getSumatraAvailability())) && runConfig.outputFormat == LatexCompiler.Format.PDF) {
             // Open Sumatra after compilation & execute inverse search.
             handler.addProcessListener(SumatraForwardSearchListener(runConfig, environment))
         }

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
@@ -86,6 +86,7 @@ class LatexRunConfiguration constructor(
     var compiler: LatexCompiler? = null
     var compilerPath: String? = null
     var sumatraPath: String? = null
+    var enableSumatraPath: Boolean? = false
     var pdfViewer: PdfViewer? = null
     var viewerCommand: String? = null
 
@@ -201,6 +202,12 @@ class LatexRunConfiguration constructor(
         if (mainFile == null) {
             throw RuntimeConfigurationError("Run configuration is invalid: no valid main LaTeX file selected")
         }
+
+        // Updates the SumatraAvailabilityChecker with the path in sumatraPath after change.
+        // Also checks if the path leads to a correct directory containing Sumatra.
+        if (!SumatraAvailabilityChecker.isSumatraPathAvailable(sumatraPath).second && enableSumatraPath == true) {
+            throw RuntimeConfigurationError("Run configuration is invalid: custom Sumatra path doesn't point to a valid directory")
+        }
     }
 
     @Throws(ExecutionException::class)
@@ -243,9 +250,8 @@ class LatexRunConfiguration constructor(
         // Read SumatraPDF custom path
         val sumatraPathRead = parent.getChildText(SUMATRA_PATH)
         this.sumatraPath = if (sumatraPathRead.isNullOrEmpty()) null else sumatraPathRead
-        if (this.sumatraPath != null) {
-            SumatraAvailabilityChecker.isSumatraPathAvailable(this.sumatraPath)
-        }
+        // Updates the SumatraAvailabilityChecker at startup
+        SumatraAvailabilityChecker.isSumatraPathAvailable(this.sumatraPath)
 
         // Read pdf viewer.
         val viewerName = parent.getChildText(PDF_VIEWER)

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
@@ -34,6 +34,7 @@ import nl.hannahsten.texifyidea.run.latex.ui.LatexSettingsEditor
 import nl.hannahsten.texifyidea.run.linuxpdfviewer.InternalPdfViewer
 import nl.hannahsten.texifyidea.run.pdfviewer.ExternalPdfViewers
 import nl.hannahsten.texifyidea.run.pdfviewer.PdfViewer
+import nl.hannahsten.texifyidea.run.sumatra.SumatraAvailabilityChecker
 import nl.hannahsten.texifyidea.settings.TexifySettings
 import nl.hannahsten.texifyidea.settings.sdk.LatexSdkUtil
 import nl.hannahsten.texifyidea.util.allCommands
@@ -242,6 +243,9 @@ class LatexRunConfiguration constructor(
         // Read SumatraPDF custom path
         val sumatraPathRead = parent.getChildText(SUMATRA_PATH)
         this.sumatraPath = if (sumatraPathRead.isNullOrEmpty()) null else sumatraPathRead
+        if (this.sumatraPath != null) {
+            SumatraAvailabilityChecker.isSumatraPathAvailable(this.sumatraPath)
+        }
 
         // Read pdf viewer.
         val viewerName = parent.getChildText(PDF_VIEWER)

--- a/src/nl/hannahsten/texifyidea/run/latex/ui/LatexSettingsEditor.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/ui/LatexSettingsEditor.kt
@@ -1,7 +1,6 @@
 package nl.hannahsten.texifyidea.run.latex.ui
 
 import com.intellij.execution.configuration.EnvironmentVariablesComponent
-import com.intellij.icons.AllIcons
 import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.fileChooser.FileTypeDescriptor
 import com.intellij.openapi.options.ConfigurationException
@@ -398,29 +397,14 @@ class LatexSettingsEditor(private var project: Project?) : SettingsEditor<LatexR
     private fun addSumatraPathField(panel: JPanel) {
         class PathInputVerifier : InputVerifier() {
 
-            @Deprecated("Deprecated in Java")
-            override fun shouldYieldFocus(input: JComponent?): Boolean {
-                if (!verify(input)) {
-                    DialogBuilder().apply {
-                        setTitle("SumatraPDF Custom Path Invalid")
-                        setCenterPanel(
-                            JLabel(
-                                "<html>Custom Path given in run configuration of SumatraPDF doesn't contain SumatraPDF.exe. Input a valid path or leave it empty.</html>",
-                                AllIcons.General.WarningDialog,
-                                SwingConstants.LEADING
-                            )
-                        )
-                        show()
-                    }
-                }
-
-                updatePdfViewerComboBox()
-
-                return true
-            }
-
             override fun verify(input: JComponent?): Boolean {
-                return SumatraAvailabilityChecker.isSumatraPathAvailable((input as ExtendableTextField).text).first
+                // This line updates the availability checker with the custom sumatra path
+                // Useful when updating the ComboBox to let the user pick Sumatra as PDFViewer when directly
+                // inputting a valid custom path (no need to save the run configuration and opening it again to change PDFViewer)
+                // InternalPdfViewer will be updated because it calls SumatraAvailabilityChecker.getSumatraAvailability()
+                SumatraAvailabilityChecker.isSumatraPathAvailable((input as ExtendableTextField).text)
+                updatePdfViewerComboBox()
+                return true
             }
         }
 

--- a/src/nl/hannahsten/texifyidea/run/latex/ui/LatexSettingsEditor.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/ui/LatexSettingsEditor.kt
@@ -380,14 +380,6 @@ class LatexSettingsEditor(private var project: Project?) : SettingsEditor<LatexR
         panel.add(compilerPath)
     }
 
-    private fun makeObj(item: PdfViewer): Any? {
-        return object : Any() {
-            override fun toString(): String {
-                return item.displayName!!
-            }
-        }
-    }
-
     private fun updatePdfViewerComboBox() {
         val viewers = InternalPdfViewer.availableSubset().filter { it != InternalPdfViewer.NONE } +
             ExternalPdfViewers.getExternalPdfViewers() +

--- a/src/nl/hannahsten/texifyidea/run/latex/ui/LatexSettingsEditor.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/ui/LatexSettingsEditor.kt
@@ -380,12 +380,23 @@ class LatexSettingsEditor(private var project: Project?) : SettingsEditor<LatexR
         panel.add(compilerPath)
     }
 
+    private fun makeObj(item: PdfViewer): Any? {
+        return object : Any() {
+            override fun toString(): String {
+                return item.displayName!!
+            }
+        }
+    }
+
     private fun updatePdfViewerComboBox() {
         val viewers = InternalPdfViewer.availableSubset().filter { it != InternalPdfViewer.NONE } +
             ExternalPdfViewers.getExternalPdfViewers() +
             listOf(InternalPdfViewer.NONE)
 
-        pdfViewer.component = ComboBox(viewers.toTypedArray())
+        pdfViewer.component.removeAllItems()
+        for (i in viewers.indices) {
+            (pdfViewer.component as ComboBox<PdfViewer>).addItem(viewers[i])
+        }
         pdfViewer.updateUI()
     }
 

--- a/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/InternalPdfViewer.kt
+++ b/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/InternalPdfViewer.kt
@@ -6,8 +6,8 @@ import nl.hannahsten.texifyidea.run.linuxpdfviewer.okular.OkularConversation
 import nl.hannahsten.texifyidea.run.linuxpdfviewer.skim.SkimConversation
 import nl.hannahsten.texifyidea.run.linuxpdfviewer.zathura.ZathuraConversation
 import nl.hannahsten.texifyidea.run.pdfviewer.PdfViewer
+import nl.hannahsten.texifyidea.run.sumatra.SumatraAvailabilityChecker
 import nl.hannahsten.texifyidea.run.sumatra.SumatraConversation
-import nl.hannahsten.texifyidea.run.sumatra.isSumatraAvailable
 import nl.hannahsten.texifyidea.util.runCommand
 
 /**
@@ -30,7 +30,7 @@ enum class InternalPdfViewer(
     SUMATRA("sumatra", "Sumatra", SumatraConversation()),
     NONE("", "No PDF viewer", null);
 
-    override fun isAvailable(): Boolean = availability[this] ?: false
+    override fun isAvailable(): Boolean = availability()[this] ?: false
 
     /**
      * Check if the viewer is installed and available from the path.
@@ -41,7 +41,7 @@ enum class InternalPdfViewer(
             true
         }
         else if (SystemInfo.isWindows && this == SUMATRA) {
-            isSumatraAvailable
+            SumatraAvailabilityChecker.getSumatraAvailability()
         }
         // Only support Evince and Okular on Linux, although they can be installed on other systems like Mac.
         else if (SystemInfo.isLinux) {
@@ -64,8 +64,8 @@ enum class InternalPdfViewer(
 
     companion object {
 
-        private val availability: Map<InternalPdfViewer, Boolean> by lazy {
-            values().associateWith {
+        private fun availability(): Map<InternalPdfViewer, Boolean> {
+            return values().associateWith {
                 it.checkAvailability()
             }
         }

--- a/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/InternalPdfViewer.kt
+++ b/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/InternalPdfViewer.kt
@@ -27,7 +27,7 @@ enum class InternalPdfViewer(
     OKULAR("okular", "Okular", OkularConversation),
     ZATHURA("zathura", "Zathura", ZathuraConversation),
     SKIM("skim", "Skim", SkimConversation),
-    SUMATRA("sumatra", "Sumatra", SumatraConversation()),
+    SUMATRA("sumatra", "Sumatra", SumatraConversation),
     NONE("", "No PDF viewer", null);
 
     override fun isAvailable(): Boolean = availability()[this] ?: false

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraAvailabilityChecker.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraAvailabilityChecker.kt
@@ -1,0 +1,86 @@
+package nl.hannahsten.texifyidea.run.sumatra
+
+import com.intellij.openapi.util.SystemInfo
+import com.pretty_tools.dde.client.DDEClientConversation
+import nl.hannahsten.texifyidea.util.Log
+import nl.hannahsten.texifyidea.util.runCommand
+import nl.hannahsten.texifyidea.util.runCommandWithExitCode
+import java.io.File
+
+/**
+ * Indicates whether SumatraPDF is installed and DDE communication is enabled.
+ *
+ * Is computed once at initialization (for performance), which means that the IDE needs to be restarted when users
+ * install SumatraPDF while running TeXiFy.
+ */
+object SumatraAvailabilityChecker {
+
+    private var isSumatraAvailable: Boolean = false
+
+    private var sumatraWorkingCustomDir: File? = null
+
+    private val isSumatraAvailableInit: Boolean by lazy {
+        if (!SystemInfo.isWindows || !isSumatraInstalled()) return@lazy false
+
+        // Try if native bindings are available
+        try {
+            DDEClientConversation()
+        }
+        catch (e: UnsatisfiedLinkError) {
+            Log.info("Native library DLLs could not be found.")
+            return@lazy false
+        }
+        catch (e: NoClassDefFoundError) {
+            Log.info("Native library DLLs could not be found.")
+            return@lazy false
+        }
+
+        true
+    }
+
+    init {
+        isSumatraAvailable = isSumatraAvailableInit
+    }
+
+    fun getSumatraAvailability(): Boolean {
+        return isSumatraAvailable
+    }
+
+    fun getSumatraWorkingCustomDir(): File? {
+        return sumatraWorkingCustomDir
+    }
+
+    /**
+     * Checks if Sumatra can be found in a global PATH or in a directory (with sumatraCustomPath)
+     * Verifies that sumatraCustomPath is a directory, non-null and non-empty before checking in the directory for Sumatra.
+     */
+    fun isSumatraPathAvailable(sumatraCustomPath: String? = null, assignNewAvailability: Boolean = true): Pair<Boolean, File?> {
+        var workingDir: File? = null
+        if (!sumatraCustomPath.isNullOrEmpty() && File(sumatraCustomPath).isDirectory) {
+            workingDir = File(sumatraCustomPath)
+        }
+
+        val availabilityParams = Pair(runCommandWithExitCode("where", "SumatraPDF", workingDirectory = workingDir).second == 0, workingDir)
+
+        if (assignNewAvailability && !isSumatraAvailableInit) {
+            isSumatraAvailable = availabilityParams.first
+            if (isSumatraAvailable && workingDir != null) {
+                sumatraWorkingCustomDir = workingDir
+            }
+        }
+
+        return availabilityParams
+    }
+
+    private fun isSumatraInstalled(): Boolean {
+        // Try some SumatraPDF registry keys
+        // For some reason this first one isn't always present anymore, it used to be
+        val regQuery1 = runCommand("reg", "query", "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\SumatraPDF.exe", "/ve")?.startsWith("ERROR:") == false
+        val regQuery2 = runCommand("reg", "query", "HKEY_LOCAL_MACHINE\\SOFTWARE\\Classes\\SumatraPDF.pdf", "/ve")?.startsWith("ERROR:") == false
+
+        if (regQuery1 || regQuery2) return true
+
+        // Try if Sumatra is in PATH
+        return isSumatraPathAvailable(sumatraCustomPath = null, assignNewAvailability = false).first
+    }
+}

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraConversation.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraConversation.kt
@@ -16,7 +16,8 @@ import java.io.File
  * Is computed once at initialization (for performance), which means that the IDE needs to be restarted when users
  * install SumatraPDF while running TeXiFy.
  */
-object SumatraAvailabilityChecker{
+object SumatraAvailabilityChecker {
+
     private var isSumatraAvailable: Boolean = false
 
     private val isSumatraAvailableInit: Boolean by lazy {
@@ -42,7 +43,7 @@ object SumatraAvailabilityChecker{
         isSumatraAvailable = isSumatraAvailableInit
     }
 
-    fun getSumatraAvailability(): Boolean{
+    fun getSumatraAvailability(): Boolean {
         return isSumatraAvailable
     }
 
@@ -58,7 +59,7 @@ object SumatraAvailabilityChecker{
 
         val availabilityParams = Pair(runCommandWithExitCode("where", "SumatraPDF", workingDirectory = workingDir).second == 0, workingDir)
 
-        if (assignNewAvailability && !isSumatraAvailableInit){
+        if (assignNewAvailability && !isSumatraAvailableInit) {
             isSumatraAvailable = availabilityParams.first
         }
 
@@ -74,7 +75,7 @@ object SumatraAvailabilityChecker{
         if (regQuery1 || regQuery2) return true
 
         // Try if Sumatra is in PATH
-        return isSumatraPathAvailable(sumatraCustomPath=null, assignNewAvailability=false).first
+        return isSumatraPathAvailable(sumatraCustomPath = null, assignNewAvailability = false).first
     }
 }
 

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraConversation.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraConversation.kt
@@ -34,15 +34,14 @@ object SumatraConversation : ViewerConversation() {
     /**
      * Open a file in SumatraPDF, starting it if it is not running yet.
      */
-    fun openFile(pdfFilePath: String, newWindow: Boolean = false, focus: Boolean = false, forceRefresh: Boolean = false, sumatraPath: String? = null) {
+    fun openFile(pdfFilePath: String, newWindow: Boolean = false, focus: Boolean = false, forceRefresh: Boolean = false) {
         try {
             execute("Open(\"$pdfFilePath\", ${newWindow.bit}, ${focus.bit}, ${forceRefresh.bit})")
         }
         catch (e: TeXception) {
-            // Added checks when sumatraPath doesn't exist (not a directory), so Windows popup error doesn't appear
-            val (_, workingDir) = SumatraAvailabilityChecker.isSumatraPathAvailable(sumatraPath)
+            // Added check when Sumatra doesn't exist (not a directory), so Windows popup error doesn't appear
             if (SumatraAvailabilityChecker.getSumatraAvailability()) {
-                runCommandWithExitCode("cmd.exe", "/C", "start", "SumatraPDF", "-reuse-instance", pdfFilePath, workingDirectory = workingDir, nonBlocking = true)
+                runCommandWithExitCode("cmd.exe", "/C", "start", "SumatraPDF", "-reuse-instance", pdfFilePath, workingDirectory = SumatraAvailabilityChecker.getSumatraWorkingCustomDir(), nonBlocking = true)
             }
         }
     }

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraConversation.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraConversation.kt
@@ -16,48 +16,66 @@ import java.io.File
  * Is computed once at initialization (for performance), which means that the IDE needs to be restarted when users
  * install SumatraPDF while running TeXiFy.
  */
-val isSumatraAvailable: Boolean by lazy {
-    if (!SystemInfo.isWindows || !isSumatraInstalled()) return@lazy false
+object SumatraAvailabilityChecker{
+    private var isSumatraAvailable: Boolean = false
 
-    // Try if native bindings are available
-    try {
-        DDEClientConversation()
-    }
-    catch (e: UnsatisfiedLinkError) {
-        Log.info("Native library DLLs could not be found.")
-        return@lazy false
-    }
-    catch (e: NoClassDefFoundError) {
-        Log.info("Native library DLLs could not be found.")
-        return@lazy false
-    }
+    private val isSumatraAvailableInit: Boolean by lazy {
+        if (!SystemInfo.isWindows || !isSumatraInstalled()) return@lazy false
 
-    true
-}
+        // Try if native bindings are available
+        try {
+            DDEClientConversation()
+        }
+        catch (e: UnsatisfiedLinkError) {
+            Log.info("Native library DLLs could not be found.")
+            return@lazy false
+        }
+        catch (e: NoClassDefFoundError) {
+            Log.info("Native library DLLs could not be found.")
+            return@lazy false
+        }
 
-/**
- * Checks if Sumatra can be found in a global PATH or in a directory (with sumatraCustomPath)
- * Verifies that sumatraCustomPath is a directory, non-null and non-empty before checking in the directory for Sumatra.
- */
-private fun isSumatraPathAvailable(sumatraCustomPath: String? = null): Pair<Boolean, File?> {
-    var workingDir: File? = null
-    if (!sumatraCustomPath.isNullOrEmpty() && File(sumatraCustomPath).isDirectory) {
-        workingDir = File(sumatraCustomPath)
+        true
     }
 
-    return Pair(runCommandWithExitCode("where", "SumatraPDF", workingDirectory = workingDir).second == 0, workingDir)
-}
+    init {
+        isSumatraAvailable = isSumatraAvailableInit
+    }
 
-private fun isSumatraInstalled(): Boolean {
-    // Try some SumatraPDF registry keys
-    // For some reason this first one isn't always present anymore, it used to be
-    val regQuery1 = runCommand("reg", "query", "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\SumatraPDF.exe", "/ve")?.startsWith("ERROR:") == false
-    val regQuery2 = runCommand("reg", "query", "HKEY_LOCAL_MACHINE\\SOFTWARE\\Classes\\SumatraPDF.pdf", "/ve")?.startsWith("ERROR:") == false
+    fun getSumatraAvailability(): Boolean{
+        return isSumatraAvailable
+    }
 
-    if (regQuery1 || regQuery2) return true
+    /**
+     * Checks if Sumatra can be found in a global PATH or in a directory (with sumatraCustomPath)
+     * Verifies that sumatraCustomPath is a directory, non-null and non-empty before checking in the directory for Sumatra.
+     */
+    fun isSumatraPathAvailable(sumatraCustomPath: String? = null, assignNewAvailability: Boolean = true): Pair<Boolean, File?> {
+        var workingDir: File? = null
+        if (!sumatraCustomPath.isNullOrEmpty() && File(sumatraCustomPath).isDirectory) {
+            workingDir = File(sumatraCustomPath)
+        }
 
-    // Try if Sumatra is in PATH
-    return isSumatraPathAvailable().first
+        val availabilityParams = Pair(runCommandWithExitCode("where", "SumatraPDF", workingDirectory = workingDir).second == 0, workingDir)
+
+        if (assignNewAvailability && !isSumatraAvailableInit){
+            isSumatraAvailable = availabilityParams.first
+        }
+
+        return availabilityParams
+    }
+
+    private fun isSumatraInstalled(): Boolean {
+        // Try some SumatraPDF registry keys
+        // For some reason this first one isn't always present anymore, it used to be
+        val regQuery1 = runCommand("reg", "query", "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\SumatraPDF.exe", "/ve")?.startsWith("ERROR:") == false
+        val regQuery2 = runCommand("reg", "query", "HKEY_LOCAL_MACHINE\\SOFTWARE\\Classes\\SumatraPDF.pdf", "/ve")?.startsWith("ERROR:") == false
+
+        if (regQuery1 || regQuery2) return true
+
+        // Try if Sumatra is in PATH
+        return isSumatraPathAvailable(sumatraCustomPath=null, assignNewAvailability=false).first
+    }
 }
 
 /**
@@ -75,7 +93,7 @@ class SumatraConversation : ViewerConversation() {
     private var conversation: DDEClientConversation? = null
 
     init {
-        if (isSumatraAvailable) {
+        if (SumatraAvailabilityChecker.getSumatraAvailability()) {
             try {
                 conversation = DDEClientConversation()
             }
@@ -94,8 +112,8 @@ class SumatraConversation : ViewerConversation() {
         }
         catch (e: TeXception) {
             // Added checks when sumatraPath doesn't exist (not a directory), so Windows popup error doesn't appear
-            val (pathAvailable, workingDir) = isSumatraPathAvailable(sumatraPath)
-            if (isSumatraAvailable || pathAvailable) {
+            val (_, workingDir) = SumatraAvailabilityChecker.isSumatraPathAvailable(sumatraPath)
+            if (SumatraAvailabilityChecker.getSumatraAvailability()) {
                 runCommand("cmd.exe", "/C", "start", "SumatraPDF", "-reuse-instance", pdfFilePath, workingDirectory = workingDir)
             }
         }

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraForwardSearchListener.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraForwardSearchListener.kt
@@ -30,7 +30,7 @@ class SumatraForwardSearchListener(
 
     override fun processTerminated(event: ProcessEvent) {
         // First check if the user provided a custom path to SumatraPDF, if not, check if it is installed
-        if (event.exitCode == 0 && (runConfig.sumatraPath != null || isSumatraAvailable)) {
+        if (event.exitCode == 0 && (runConfig.sumatraPath != null || SumatraAvailabilityChecker.getSumatraAvailability())) {
             try {
                 SumatraConversation().openFile(runConfig.outputFilePath, sumatraPath = runConfig.sumatraPath)
             }

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraForwardSearchListener.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraForwardSearchListener.kt
@@ -32,7 +32,7 @@ class SumatraForwardSearchListener(
         // First check if the user provided a custom path to SumatraPDF, if not, check if it is installed
         if (event.exitCode == 0 && (runConfig.sumatraPath != null || SumatraAvailabilityChecker.getSumatraAvailability())) {
             try {
-                SumatraConversation().openFile(runConfig.outputFilePath, sumatraPath = runConfig.sumatraPath)
+                SumatraConversation.openFile(runConfig.outputFilePath, sumatraPath = runConfig.sumatraPath)
             }
             catch (ignored: TeXception) {
             }
@@ -68,7 +68,7 @@ class SumatraForwardSearchListener(
                     // Otherwise the person is out of luck ¯\_(ツ)_/¯
                     Thread.sleep(1250)
                     // Never focus, because forward search will work fine without focus, and the user might want to continue typing after doing forward search/compiling
-                    SumatraConversation().forwardSearch(sourceFilePath = psiFile.virtualFile.path, line = line, focus = false)
+                    SumatraConversation.forwardSearch(sourceFilePath = psiFile.virtualFile.path, line = line, focus = false)
                 }
                 catch (ignored: TeXception) {
                 }

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraForwardSearchListener.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraForwardSearchListener.kt
@@ -30,9 +30,9 @@ class SumatraForwardSearchListener(
 
     override fun processTerminated(event: ProcessEvent) {
         // First check if the user provided a custom path to SumatraPDF, if not, check if it is installed
-        if (event.exitCode == 0 && (runConfig.sumatraPath != null || SumatraAvailabilityChecker.getSumatraAvailability())) {
+        if (event.exitCode == 0 && SumatraAvailabilityChecker.getSumatraAvailability()) {
             try {
-                SumatraConversation.openFile(runConfig.outputFilePath, sumatraPath = runConfig.sumatraPath)
+                SumatraConversation.openFile(runConfig.outputFilePath)
             }
             catch (ignored: TeXception) {
             }

--- a/src/nl/hannahsten/texifyidea/util/SystemEnvironment.kt
+++ b/src/nl/hannahsten/texifyidea/util/SystemEnvironment.kt
@@ -110,3 +110,20 @@ fun runCommandWithExitCode(vararg commands: String, workingDirectory: File? = nu
         }
     }
 }
+
+fun runCommandWithoutReturn(vararg commands: String, workingDirectory: File? = null) {
+    Log.debug("Executing in ${workingDirectory ?: "current working directory"} ${GeneralCommandLine(*commands).commandLineString}")
+    try {
+        GeneralCommandLine(*commands)
+            .withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE)
+            .withWorkDirectory(workingDirectory)
+            .createProcess()
+    }
+    catch (e: IOException) {
+        Log.debug(e.message ?: "Unknown IOException occurred")
+    }
+    catch (e: ProcessNotCreatedException) {
+        Log.debug(e.message ?: "Unknown ProcessNotCreatedException occurred")
+        // e.g. if the command is just trying if a program can be run or not, and it's not the case
+    }
+}


### PR DESCRIPTION
Fix #2737

#### Summary of additions and changes
Added full support when inputting a custom Sumatra path, so that it appears in PDF Viewer ComboBox, and making it work with Forward Search and the Configure Inverse Search.
1. Changed isSumatraAvailable in SumatraConversation to a singleton object that checks if Sumatra is available.
2. Added an InputVerifier on the TextField of Custom Sumatra Path that checks the validity of the path, and updates the value of isSumatraAvailable and updates the items in the PDF Viewer ComboBox.
3. Changed the availability in the InternalPdfViewer to a function so that it can be changed during execution.
4. Removed the lines checking if the Sumatra Custom Path was null in addOpenViewerListener so that the user can select which PDF Viewer to open, even if a Sumatra Custom Path is present.
5. Added support for inverse search action for custom SumatraPath
6. Added support for loading custom SumatraPath at startup
7. Redone update of the PdfViewerComboBox to eliminate errors
8. Changed SumatraConversation from a class to a singleton object to better match InternalPdfViewers and to don't allow multiple instances of SumatraConversation to be opened by multiple parts of the program (Sumatra link conversation is constant over the scope of the program).
9. Added a run function that doesn't wait for a return of the program executed (useful for setting up Inverse search)

In brief : when inputting a correct custom Sumatra path (valid path and that contains SumatraPDF.exe), after clicking away from the TextBox, Sumatra automatically appears in the ComboBox of PDF Viewer. And then, making it work with Forward Search and the Configure Inverse Search.


#### How to test this pull request

Open TeXiFy with only global PATH set to Sumatra (afterwards, do the same with registry keys)
Under LaTeX configuration, under "PDF viewer", "Sumatra" should appear.
Under Tools/LaTeX, option to "Configure Inverse Search" should work as normal.
Forward search should work as normal.

Set no PATH and no registry keys to Sumatra.
Set custom path to Sumatra in Run Configuration to real Sumatra install and click away from the text box.
Under "PDF viewer", "Sumatra" should appear.
Set custom path to Sumatra in Run Configuration to a real folder that doesn't contain Sumatra  and click away from the text box.
Under "PDF viewer", "Sumatra" shouldn't appear and an error popup should appear.
Set custom path to Sumatra in Run Configuration to a folder that doesn't exist and click away from the text box.
Under "PDF viewer", "Sumatra" shouldn't appear and an error popup should appear.

Select a "PDF viewer" of your choice under LaTeX configuration, under "PDF viewer".
Run LaTeX project, the PDF viewer selected should open (even if Sumatra is in the Path).