### PR TITLE
Fold footnotes

### DIFF
--- a/resources/META-INF/extensions/editor/editor.xml
+++ b/resources/META-INF/extensions/editor/editor.xml
@@ -3,6 +3,7 @@
         <lang.foldingBuilder language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.folding.LatexMathSymbolFoldingBuilder"/>
         <lang.foldingBuilder language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.folding.LatexEnvironmentFoldingBuilder"/>
         <lang.foldingBuilder language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.folding.LatexImportFoldingBuilder"/>
+        <lang.foldingBuilder language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.folding.LatexFootnoteFoldingBuilder"/>
         <lang.foldingBuilder language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.folding.LatexSectionFoldingBuilder"/>
         <lang.foldingBuilder language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.folding.LatexEscapedSymbolFoldingBuilder"/>
         <lang.foldingBuilder language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.folding.LatexSymbolFoldingBuilder"/>

--- a/src/nl/hannahsten/texifyidea/editor/folding/LatexFootnoteFoldingBuilder.kt
+++ b/src/nl/hannahsten/texifyidea/editor/folding/LatexFootnoteFoldingBuilder.kt
@@ -10,11 +10,8 @@ import com.intellij.psi.PsiElement
 import com.intellij.refactoring.suggested.endOffset
 import com.intellij.refactoring.suggested.startOffset
 import nl.hannahsten.texifyidea.psi.LatexCommands
-import nl.hannahsten.texifyidea.psi.LatexEnvironment
 import nl.hannahsten.texifyidea.psi.LatexRequiredParam
-import nl.hannahsten.texifyidea.psi.LatexRequiredParamContent
 import nl.hannahsten.texifyidea.util.childrenOfType
-import nl.hannahsten.texifyidea.util.endOffset
 import nl.hannahsten.texifyidea.util.firstChildOfType
 
 /**

--- a/src/nl/hannahsten/texifyidea/editor/folding/LatexFootnoteFoldingBuilder.kt
+++ b/src/nl/hannahsten/texifyidea/editor/folding/LatexFootnoteFoldingBuilder.kt
@@ -32,9 +32,10 @@ class LatexFootnoteFoldingBuilder : FoldingBuilderEx(), DumbAware {
 
     override fun buildFoldRegions(root: PsiElement, document: Document, quick: Boolean): Array<FoldingDescriptor> {
         val descriptors = ArrayList<FoldingDescriptor>()
-        val environments = root.childrenOfType(LatexCommands::class).filter { it.commandToken.text == "\\footnote" }.map {
-            it.firstChildOfType(LatexRequiredParam::class)
-        }.filterNotNull()
+        val environments =
+            root.childrenOfType(LatexCommands::class).filter { it.commandToken.text == "\\footnote" }.mapNotNull {
+                it.firstChildOfType(LatexRequiredParam::class)
+            }
 
         for (environment in environments) {
             descriptors.add(FoldingDescriptor(environment.originalElement, TextRange(environment.startOffset + 1, environment.endOffset - 1)))

--- a/src/nl/hannahsten/texifyidea/editor/folding/LatexFootnoteFoldingBuilder.kt
+++ b/src/nl/hannahsten/texifyidea/editor/folding/LatexFootnoteFoldingBuilder.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.refactoring.suggested.endOffset
 import com.intellij.refactoring.suggested.startOffset
-import nl.hannahsten.texifyidea.LatexLanguage
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexRequiredParam
 import nl.hannahsten.texifyidea.util.childrenOfType
@@ -40,7 +39,7 @@ class LatexFootnoteFoldingBuilder : FoldingBuilderEx(), DumbAware {
             }
 
         for (environment in parameters) {
-            if (environment.language == LatexLanguage && environment.endOffset - 1 > environment.startOffset + 1)
+            if (environment.endOffset - 1 > environment.startOffset + 1)
                 descriptors.add(FoldingDescriptor(environment.originalElement, TextRange(environment.startOffset + 1, environment.endOffset - 1)))
         }
 

--- a/src/nl/hannahsten/texifyidea/editor/folding/LatexFootnoteFoldingBuilder.kt
+++ b/src/nl/hannahsten/texifyidea/editor/folding/LatexFootnoteFoldingBuilder.kt
@@ -1,0 +1,48 @@
+package nl.hannahsten.texifyidea.editor.folding
+
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.FoldingBuilderEx
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.refactoring.suggested.endOffset
+import com.intellij.refactoring.suggested.startOffset
+import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.psi.LatexEnvironment
+import nl.hannahsten.texifyidea.psi.LatexRequiredParam
+import nl.hannahsten.texifyidea.psi.LatexRequiredParamContent
+import nl.hannahsten.texifyidea.util.childrenOfType
+import nl.hannahsten.texifyidea.util.endOffset
+import nl.hannahsten.texifyidea.util.firstChildOfType
+
+/**
+ * Adds folding regions for LaTeX environments.
+ *
+ * Enables folding of `\footnote{}`.
+ *
+ * @author jojo2357
+ */
+class LatexFootnoteFoldingBuilder : FoldingBuilderEx(), DumbAware {
+
+    override fun isCollapsedByDefault(node: ASTNode) = true
+
+    override fun getPlaceholderText(node: ASTNode): String {
+        val parsedText = node.text.substring(1).trim()
+        return if (parsedText.length > 8) parsedText.substring(0, 8) + "..." else parsedText.substring(0, parsedText.length - 1)
+    }
+
+    override fun buildFoldRegions(root: PsiElement, document: Document, quick: Boolean): Array<FoldingDescriptor> {
+        val descriptors = ArrayList<FoldingDescriptor>()
+        val environments = root.childrenOfType(LatexCommands::class).filter { it.commandToken.text == "\\footnote" }.map {
+            it.firstChildOfType(LatexRequiredParam::class)
+        }.filterNotNull()
+
+        for (environment in environments) {
+            descriptors.add(FoldingDescriptor(environment.originalElement, TextRange(environment.startOffset + 1, environment.endOffset - 1)))
+        }
+
+        return descriptors.toTypedArray()
+    }
+}

--- a/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
@@ -474,4 +474,11 @@ object CommandMagic {
         "luaexec" to false,
         "lstinline" to true
     )
+
+    /**
+     *
+     */
+    val foldableFootnotes = listOf(
+        FOOTNOTE.cmd
+    )
 }

--- a/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
@@ -479,6 +479,6 @@ object CommandMagic {
      *
      */
     val foldableFootnotes = listOf(
-        FOOTNOTE.cmd
+        FOOTNOTE.cmd, FOOTCITE.cmd
     )
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2782 

#### Summary of additions and changes

* Add a footnotes folder.

Seeing how there is not currently a registry of "footnote-like" commands, it is hardcoded for \footnote only

#### How to test this pull request

```latex
\footnote{this is a footnote}
```

Note to collapse anything in IDEA can be done with a shortcut, or from the right click menu
