### PR TITLE
Fix some intention previews

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -138,6 +138,8 @@ tasks.runIde {
 
     // Set to true to generate hprof files on unload fails
     systemProperty("ide.plugins.snapshot.on.unload.fail", "false")
+    // Some warning asked for this to be set explicitly
+    systemProperty("idea.log.path", file("build/idea-sandbox/system/log").absolutePath)
 }
 
 tasks.test {

--- a/resources/intentionDescriptions/LatexLanguageInjectionIntention/after.tex.template
+++ b/resources/intentionDescriptions/LatexLanguageInjectionIntention/after.tex.template
@@ -1,0 +1,3 @@
+%! language = Latex
+\begin{lstlisting}
+\end{lstlisting}

--- a/resources/intentionDescriptions/LatexLanguageInjectionIntention/before.tex.template
+++ b/resources/intentionDescriptions/LatexLanguageInjectionIntention/before.tex.template
@@ -1,0 +1,2 @@
+\begin{lstlisting}
+\end{lstlisting}

--- a/src/nl/hannahsten/texifyidea/intentions/LatexAddLabelIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexAddLabelIntention.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.intentions
 
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.RangeMarker
 import com.intellij.openapi.project.Project
@@ -16,7 +17,7 @@ import nl.hannahsten.texifyidea.psi.LatexPsiHelper
 import nl.hannahsten.texifyidea.util.labels.findLatexAndBibtexLabelStringsInFileSet
 import kotlin.math.max
 
-abstract class LatexAddLabelIntention : TexifyIntentionBase("Add label") {
+abstract class LatexAddLabelIntention(name: String) : TexifyIntentionBase(name) {
 
     /**
      * This class handles the rename of a label parameter after insertion
@@ -111,4 +112,10 @@ abstract class LatexAddLabelIntention : TexifyIntentionBase("Add label") {
     }
 
     override fun startInWriteAction() = true
+
+    // Not clear to me why the default implementation does not work, but this avoids the "Intention preview fallback is used for action" error
+    override fun generatePreview(project: Project, editor: Editor, file: PsiFile): IntentionPreviewInfo {
+        invoke(project, editor, file)
+        return IntentionPreviewInfo.DIFF
+    }
 }

--- a/src/nl/hannahsten/texifyidea/intentions/LatexAddLabelToCommandIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexAddLabelToCommandIntention.kt
@@ -23,7 +23,7 @@ import nl.hannahsten.texifyidea.util.magic.CommandMagic
  * @author Hannah Schellekens
  */
 open class LatexAddLabelToCommandIntention(val command: SmartPsiElementPointer<LatexCommands>? = null) :
-    LatexAddLabelIntention() {
+    LatexAddLabelIntention("Add label to command") {
 
     override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean {
         if (file?.isLatexFile() == false) {

--- a/src/nl/hannahsten/texifyidea/intentions/LatexAddLabelToEnvironmentIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexAddLabelToEnvironmentIntention.kt
@@ -18,7 +18,7 @@ import nl.hannahsten.texifyidea.util.formatAsLabel
 import nl.hannahsten.texifyidea.util.magic.EnvironmentMagic
 
 open class LatexAddLabelToEnvironmentIntention(val environment: SmartPsiElementPointer<LatexEnvironment>? = null) :
-    LatexAddLabelIntention() {
+    LatexAddLabelIntention("Add label to environment") {
 
     override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean {
         if (file?.isLatexFile() == false) {

--- a/src/nl/hannahsten/texifyidea/intentions/LatexLanguageInjectionIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexLanguageInjectionIntention.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.intentions
 
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
 import com.intellij.lang.Language
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Editor
@@ -10,8 +11,8 @@ import com.intellij.psi.injection.Injectable
 import com.intellij.ui.ColoredListCellRenderer
 import com.intellij.ui.components.JBList
 import com.intellij.util.ui.EmptyIcon
-import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.file.LatexFile
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.lang.magic.DefaultMagicKeys
 import nl.hannahsten.texifyidea.lang.magic.MutableMagicComment
 import nl.hannahsten.texifyidea.lang.magic.addMagicComment
@@ -50,14 +51,28 @@ class LatexLanguageInjectionIntention : TexifyIntentionBase("Inject language") {
             return
         }
 
-        val element = file.findElementAt(editor.caretModel.offset) ?: return
-
         chooseLanguage(editor) { language ->
-            val comment = MutableMagicComment<String, String>().apply { addValue(DefaultMagicKeys.INJECT_LANGUAGE, language.id) }
             WriteCommandAction.runWriteCommandAction(project) {
-                element.firstParentOfType(LatexEnvironment::class)?.addMagicComment(comment)
+                inject(file, editor, language)
             }
         }
+    }
+
+    override fun generatePreview(project: Project, editor: Editor, file: PsiFile): IntentionPreviewInfo {
+        // Choose random language for the preview, as we cannot show a popup
+        val language = injectableLanguages().firstOrNull() ?: return IntentionPreviewInfo.EMPTY
+        inject(file, editor, language)
+        return IntentionPreviewInfo.DIFF
+    }
+
+    private fun inject(
+        file: PsiFile,
+        editor: Editor,
+        language: Injectable
+    ) {
+        val element = file.findElementAt(editor.caretModel.offset)
+        val comment = MutableMagicComment<String, String>().apply { addValue(DefaultMagicKeys.INJECT_LANGUAGE, language.id) }
+        element?.firstParentOfType(LatexEnvironment::class)?.addMagicComment(comment)
     }
 
     private fun chooseLanguage(editor: Editor, onChosen: (language: Injectable) -> Unit) {

--- a/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
@@ -224,7 +224,9 @@ fun PsiFile.environmentsInFile(): Collection<LatexEnvironment> = LatexEnvironmen
  *
  * @return null if the file is not opened.
  */
-fun PsiFile.openedEditor(): FileEditor? = FileEditorManager.getInstance(project).getSelectedEditor(virtualFile)
+fun PsiFile.openedEditor(): FileEditor? {
+    return FileEditorManager.getInstance(project).getSelectedEditor(virtualFile ?: return null)
+}
 
 /**
  * Get the text editor instance of the (text) file if it is currently opened.

--- a/test/nl/hannahsten/texifyidea/intentions/LatexAddLabelIntentionTest.kt
+++ b/test/nl/hannahsten/texifyidea/intentions/LatexAddLabelIntentionTest.kt
@@ -20,7 +20,7 @@ class LatexAddLabelIntentionTest : BasePlatformTestCase() {
         )
         val intentions = myFixture.availableIntentions
         writeCommand(myFixture.project) {
-            intentions.first { i -> i.text == "Add label" }.invoke(myFixture.project, myFixture.editor, myFixture.file)
+            intentions.first { i -> i.text == "Add label to command" }.invoke(myFixture.project, myFixture.editor, myFixture.file)
         }
         myFixture.checkResult(
             """
@@ -42,7 +42,7 @@ class LatexAddLabelIntentionTest : BasePlatformTestCase() {
         )
         val intentions = myFixture.availableIntentions
         writeCommand(myFixture.project) {
-            intentions.first { i -> i.text == "Add label" }.invoke(myFixture.project, myFixture.editor, myFixture.file)
+            intentions.first { i -> i.text == "Add label to command" }.invoke(myFixture.project, myFixture.editor, myFixture.file)
         }
         myFixture.checkResult(
             """
@@ -64,7 +64,7 @@ class LatexAddLabelIntentionTest : BasePlatformTestCase() {
         )
         val intentions = myFixture.availableIntentions
         writeCommand(myFixture.project) {
-            intentions.first { i -> i.text == "Add label" }.invoke(myFixture.project, myFixture.editor, myFixture.file)
+            intentions.first { i -> i.text == "Add label to command" }.invoke(myFixture.project, myFixture.editor, myFixture.file)
         }
         myFixture.checkResult(
             """
@@ -92,7 +92,7 @@ class LatexAddLabelIntentionTest : BasePlatformTestCase() {
         TemplateManagerImpl.setTemplateTesting(myFixture.projectDisposable)
         val intentions = myFixture.availableIntentions
         writeCommand(myFixture.project) {
-            intentions.first { i -> i.text == "Add label" }.invoke(myFixture.project, myFixture.editor, myFixture.file)
+            intentions.first { i -> i.text == "Add label to command" }.invoke(myFixture.project, myFixture.editor, myFixture.file)
         }
         myFixture.checkResult(
             """
@@ -117,7 +117,7 @@ class LatexAddLabelIntentionTest : BasePlatformTestCase() {
         )
         val intentions = myFixture.availableIntentions
         writeCommand(myFixture.project) {
-            intentions.first { i -> i.text == "Add label" }.invoke(myFixture.project, myFixture.editor, myFixture.file)
+            intentions.first { i -> i.text == "Add label to environment" }.invoke(myFixture.project, myFixture.editor, myFixture.file)
         }
         myFixture.checkResult(
             """


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2742

#### Summary of additions and changes

* Some previews were not working, fixed with overriding default behaviour

#### How to test this pull request

Ctrl+Q on the intention in the popup should bring up a preview

`\section{blub}`
