### PR TITLE
Don't use a lazy val with a non-trivial initializer in an object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,16 @@
 ## [Unreleased]
 
 ### Added
+
+### Fixed
+
+## [0.7.26-alpha.3] - 2022-12-07
+
+### Added
 * Add support for inlining user-defined commands, by @jojo2357.
 
 ### Fixed
+* Improve error logging.
 
 ## [0.7.25] - 2022-12-01
 Welcome to TeXiFy IDEA 0.7.25! This release has many additions by @jojo2357, enjoy!
@@ -32,5 +39,6 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Fix some intention previews. ([#2796](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2796))
 * Other small bug fixes and improvements. ([#2776](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2776), [#2774](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2774), [#2765](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2765)-[#2773](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2773))
 
-[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.25...HEAD
+[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.26-alpha.3...HEAD
+[0.7.26-alpha.3]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.25...v0.7.26-alpha.3
 [0.7.25]: https://github.com/Hannah-Sten/TeXiFy-IDEA/commits/v0.7.25

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "10.3.0"
 
     // Vulnerability scanning
-    id("org.owasp.dependencycheck") version "7.3.2"
+    id("org.owasp.dependencycheck") version "7.4.0"
 
     id("org.jetbrains.changelog") version "2.0.0"
 }
@@ -94,13 +94,13 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.1")
 
     // Http requests
-    implementation("io.ktor:ktor-client-core:2.1.3")
-    implementation("io.ktor:ktor-client-cio:2.1.3")
-    implementation("io.ktor:ktor-client-auth:2.1.3")
-    implementation("io.ktor:ktor-client-content-negotiation:2.1.3")
-    implementation("io.ktor:ktor-server-core:2.1.3")
-    implementation("io.ktor:ktor-server-jetty:2.1.3")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:2.1.3")
+    implementation("io.ktor:ktor-client-core:2.2.0")
+    implementation("io.ktor:ktor-client-cio:2.2.0")
+    implementation("io.ktor:ktor-client-auth:2.2.0")
+    implementation("io.ktor:ktor-client-content-negotiation:2.2.0")
+    implementation("io.ktor:ktor-server-core:2.2.0")
+    implementation("io.ktor:ktor-server-jetty:2.2.0")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:2.2.0")
 
     // Comparing versions
     implementation("org.apache.maven:maven-artifact:4.0.0-alpha-2")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.7.26-alpha.1
+pluginVersion = 0.7.26-alpha.3
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspection.kt
@@ -5,6 +5,7 @@ import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
@@ -216,7 +217,9 @@ class LatexUnicodeInspection : TexifyInspectionBase() {
             val document = PsiDocumentManager.getInstance(project).getDocument(element.containingFile)
             if (replacement == null) {
                 if (editor != null) {
-                    HintManager.getInstance().showErrorHint(editor, "Character could not be converted")
+                    runInEdt {
+                        HintManager.getInstance().showErrorHint(editor, "Character could not be converted")
+                    }
                 }
                 return
             }

--- a/src/nl/hannahsten/texifyidea/util/LatexmkRcFileFinder.kt
+++ b/src/nl/hannahsten/texifyidea/util/LatexmkRcFileFinder.kt
@@ -15,42 +15,45 @@ import kotlin.io.path.Path
  */
 object LatexmkRcFileFinder {
 
-    private val systemLatexmkRcFile: VirtualFile? by lazy {
-        val paths = mutableListOf<String?>()
-        // 1
-        if (SystemInfo.isLinux) {
-            paths += listOf(
-                "/opt/local/share/latexmk/",
-                "/usr/local/share/latexmk/",
-                "/usr/local/lib/latexmk/",
-                "/cygdrive/local/share/latexmk/"
-            ).flatMap { listOf(it + "latexMk", it + "latexmkrc") }
-        }
-        else if (SystemInfo.isWindows) {
-            paths += listOf(
-                "C:\\latexmk\\LatexMk",
-                "C:\\latexmk\\latexmkrc"
-            )
-        }
-
-        System.getenv("LATEXMKRCSYS")?.let { paths.add(it) }
-
-        // 2
-        paths += listOf(
-            System.getenv("XDG_CONFIG_HOME")?.let { Path(it, "latexmk", "latexmkrc").toString() },
-            System.getenv("HOME")?.let { Path(it, ".latexmkrc").toString() },
-            System.getenv("USERPROFILE")?.let { Path(it, ".latexmkrc").toString() },
-            System.getenv("HOME")?.let { Path(it, ".config", ".latexmkrc").toString() },
-        )
-
-        paths.filterNotNull()
-            .forEach {
-                LocalFileSystem.getInstance().findFileByIoFile(File(it))?.let { file ->
-                    return@lazy file
-                }
+    // Note: this cannot be a lazy val because then if there is any exception, the stacktrace will not be shown but be hidden by a NoClassDefFoundError
+    private var systemLatexmkRcFile: VirtualFile? = null
+        get() {
+            val paths = mutableListOf<String?>()
+            // 1
+            if (SystemInfo.isLinux) {
+                paths += listOf(
+                    "/opt/local/share/latexmk/",
+                    "/usr/local/share/latexmk/",
+                    "/usr/local/lib/latexmk/",
+                    "/cygdrive/local/share/latexmk/"
+                ).flatMap { listOf(it + "latexMk", it + "latexmkrc") }
+            }
+            else if (SystemInfo.isWindows) {
+                paths += listOf(
+                    "C:\\latexmk\\LatexMk",
+                    "C:\\latexmk\\latexmkrc"
+                )
             }
 
-        null
+            System.getenv("LATEXMKRCSYS")?.let { paths.add(it) }
+
+            // 2
+            paths += listOf(
+                System.getenv("XDG_CONFIG_HOME")?.let { Path(it, "latexmk", "latexmkrc").toString() },
+                System.getenv("HOME")?.let { Path(it, ".latexmkrc").toString() },
+                System.getenv("USERPROFILE")?.let { Path(it, ".latexmkrc").toString() },
+                System.getenv("HOME")?.let { Path(it, ".config", ".latexmkrc").toString() },
+            )
+
+            paths.filterNotNull()
+                .forEach {
+                    LocalFileSystem.getInstance().findFileByIoFile(File(it))?.let { file ->
+                        field = file
+                        return file
+                    }
+                }
+
+            return null
     }
 
     private val isSystemLatexmkRcFilePresent: Boolean = systemLatexmkRcFile != null

--- a/src/nl/hannahsten/texifyidea/util/LatexmkRcFileFinder.kt
+++ b/src/nl/hannahsten/texifyidea/util/LatexmkRcFileFinder.kt
@@ -15,7 +15,7 @@ import kotlin.io.path.Path
  */
 object LatexmkRcFileFinder {
 
-    // Note: this cannot be a lazy val because then if there is any exception, the stacktrace will not be shown but be hidden by a NoClassDefFoundError
+    // Note: this cannot be a lazy val because then if there is any exception, the stacktrace will not be shown but be hidden by a NoClassDefFoundError. This way, we will have an ExceptionInInitializerError with will have the original stacktrace as well.
     private var systemLatexmkRcFile: VirtualFile? = null
         get() {
             val paths = mutableListOf<String?>()

--- a/src/nl/hannahsten/texifyidea/util/LatexmkRcFileFinder.kt
+++ b/src/nl/hannahsten/texifyidea/util/LatexmkRcFileFinder.kt
@@ -54,7 +54,7 @@ object LatexmkRcFileFinder {
                 }
 
             return null
-    }
+        }
 
     private val isSystemLatexmkRcFilePresent: Boolean = systemLatexmkRcFile != null
 

--- a/src/nl/hannahsten/texifyidea/util/Projects.kt
+++ b/src/nl/hannahsten/texifyidea/util/Projects.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.module.ModuleType
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.VirtualFile
@@ -91,8 +92,9 @@ fun Project.currentTextEditor(): TextEditor? {
  * Checks if there is a LaTeX module in this project.
  */
 fun Project.hasLatexModule(): Boolean {
+    if (isDisposed) return false
     return ModuleManager.getInstance(this).modules
-        .any { it.moduleTypeName == LatexModuleType.ID }
+        .any { ModuleType.get(it).id == LatexModuleType.ID }
 }
 
 /**


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2839 well not really, but now at least we will see the actual error
Also: Fix #2836
Fix #2800

#### Summary of additions and changes

* Something weird in the IntelliJ SDK: in this case the error message will be completely hidden if you use a lazy val. Couldn't reproduce it in the intellij plugin template, maybe it has to do with the calling location.
