### PR TITLE
Don't wrap urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+* Don't wrap urls when formatting.
 
 ### Fixed
 

--- a/resources/META-INF/extensions/editor/editor.xml
+++ b/resources/META-INF/extensions/editor/editor.xml
@@ -12,6 +12,7 @@
         <lang.formatter language="Latex" implementationClass="nl.hannahsten.texifyidea.formatting.LatexFormattingModelBuilder"/>
         <lang.formatter language="Bibtex" implementationClass="nl.hannahsten.texifyidea.formatting.BibtexFormattingModelBuilder"/>
         <lang.formatter.restriction implementation="nl.hannahsten.texifyidea.formatting.LatexLanguageFormattingRestriction"/>
+        <lang.lineWrapStrategy language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.LatexLineWrapStrategy"/>
         <codeInsight.fillParagraph language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.LatexParagraphFillHandler"/>
         <completion.contributor language="Latex" implementationClass="nl.hannahsten.texifyidea.completion.LatexCompletionContributor"/>
         <completion.contributor language="Bibtex" implementationClass="nl.hannahsten.texifyidea.completion.BibtexCompletionContributor"/>

--- a/src/nl/hannahsten/texifyidea/editor/LatexLineWrapStrategy.kt
+++ b/src/nl/hannahsten/texifyidea/editor/LatexLineWrapStrategy.kt
@@ -20,6 +20,7 @@ import nl.hannahsten.texifyidea.util.firstParentOfType
 class LatexLineWrapStrategy : PsiAwareDefaultLineWrapPositionStrategy(true, *enabledTypes) {
 
     companion object {
+
         // The types that are allowed to be wrapped.
         // (I think only lowest level elements count, unless a parent element contains only one child?)
         val enabledTypes = arrayOf(

--- a/src/nl/hannahsten/texifyidea/editor/LatexLineWrapStrategy.kt
+++ b/src/nl/hannahsten/texifyidea/editor/LatexLineWrapStrategy.kt
@@ -1,0 +1,56 @@
+package nl.hannahsten.texifyidea.editor
+
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.PsiAwareDefaultLineWrapPositionStrategy
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.refactoring.suggested.startOffset
+import nl.hannahsten.texifyidea.psi.LatexTypes
+
+/**
+ * Based on JavaLineWrapPositionStrategy.
+ *
+ * @author Thomas
+ */
+class LatexLineWrapStrategy : PsiAwareDefaultLineWrapPositionStrategy(true, *enabledTypes) {
+
+    companion object {
+        // The types that are allowed to be wrapped.
+        // (I think only lowest level elements count, unless a parent element contains only one child?)
+        // RAW_TEXT_TOKEN is excluded, to automatically exclude urls in \url and \href
+        val enabledTypes = arrayOf(
+            LatexTypes.COMMENT_TOKEN,
+            LatexTypes.REQUIRED_PARAM_CONTENT,
+            LatexTypes.NORMAL_TEXT_WORD,
+        )
+    }
+
+    override fun doCalculateWrapPosition(
+        document: Document,
+        project: Project?,
+        element: PsiElement,
+        startOffset: Int,
+        endOffset: Int,
+        maxPreferredOffset: Int,
+        isSoftWrap: Boolean
+    ): Int {
+        val wrapPosition = super.doCalculateWrapPosition(document, project, element, startOffset, endOffset, maxPreferredOffset, isSoftWrap)
+
+        // Don't wrap urls
+        val text = element.text
+        @Suppress("HttpUrlsUsage")
+        val urlStartInParent = text.indexOfAny(setOf("http://", "https://", "ftp://", "file://", "mailto:"))
+        if (urlStartInParent == -1) {
+            return wrapPosition
+        }
+
+        // Best guess at url end
+        val url = text.subSequence(urlStartInParent, text.length).takeWhile { it.isWhitespace().not() }
+        val urlEnd = startOffset + urlStartInParent + url.length
+        val isInUrl = wrapPosition in element.startOffset + urlStartInParent..urlEnd
+        if (!isInUrl || text.substring(urlEnd).isBlank()) return wrapPosition
+        // We can still wrap after the url
+        // todo same for \href
+        return urlEnd
+    }
+}

--- a/test/nl/hannahsten/texifyidea/formatting/LatexFormattingTest.kt
+++ b/test/nl/hannahsten/texifyidea/formatting/LatexFormattingTest.kt
@@ -2,7 +2,6 @@ package nl.hannahsten.texifyidea.formatting
 
 import com.intellij.application.options.CodeStyle
 import com.intellij.psi.codeStyle.CodeStyleManager
-import com.intellij.psi.codeStyle.CodeStyleSettingsManager
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.settings.codestyle.LatexCodeStyleSettings
@@ -315,43 +314,6 @@ fun Int?.ifPositiveAddTwo(): Int =
             Don't indent this if turned off.
             Don't indent this either<caret>
             \end{document}
-        """.trimIndent()
-        myFixture.checkResult(expected)
-    }
-
-    fun testComments() {
-        val text = """
-            % Calculated protections are able to develop anxious insurances when they prick notes and relate identities and rejects<caret>
-        """.trimIndent()
-        myFixture.configureByText(LatexFileType, text)
-        val settings = CodeStyle.createTestSettings(CodeStyle.getSettings(project))
-        CodeStyleSettingsManager.getInstance(project).setTemporarySettings(settings)
-//        settings.WRAP_ON_TYPING = CommonCodeStyleSettings.WrapOnTyping.WRAP.intValue
-        settings.defaultRightMargin = 50
-        settings.WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN = true
-
-        // For some reason this doesn't work, typing and using wrap on typing is the closest workaround
-        myFixture.performEditorAction("ReformatCode")
-        myFixture.type(".")
-        val expected = """
-            % Calculated protections are able to develop 
-            % anxious insurances when they prick notes and relate identities and rejects.
-        """.trimIndent()
-        myFixture.checkResult(expected)
-    }
-
-    fun testUrlWrap() {
-        val text = """
-            \href{https://the-very-very-long.url}{unreasonable long <caret>}
-        """.trimIndent()
-        myFixture.configureByText(LatexFileType, text)
-        val settings = CodeStyle.createTestSettings(CodeStyle.getSettings(project))
-        CodeStyleSettingsManager.getInstance(project).setTemporarySettings(settings)
-        settings.defaultRightMargin = 30
-        settings.WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN = true
-        myFixture.type("URL")
-        val expected = """
-            \href{https://the-very-very-long.url}{unreasonable long URL}
         """.trimIndent()
         myFixture.checkResult(expected)
     }

--- a/test/nl/hannahsten/texifyidea/formatting/LatexLineWrapStrategyTest.kt
+++ b/test/nl/hannahsten/texifyidea/formatting/LatexLineWrapStrategyTest.kt
@@ -1,0 +1,65 @@
+package nl.hannahsten.texifyidea.formatting
+
+import com.intellij.application.options.CodeStyle
+import com.intellij.psi.codeStyle.CodeStyleSettingsManager
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import nl.hannahsten.texifyidea.file.LatexFileType
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
+
+class LatexLineWrapStrategyTest : BasePlatformTestCase() {
+
+    private fun setUpTest() {
+        val settings = CodeStyle.createTestSettings(CodeStyle.getSettings(project))
+        settings.defaultRightMargin = 30
+        settings.getCommonSettings(LatexLanguage).WRAP_LONG_LINES = true
+        CodeStyleSettingsManager.getInstance(project).setTemporarySettings(settings)
+    }
+
+    fun testCommentWrap() {
+        setUpTest()
+        val text = """
+            %     https://Petra-indicates-clears-to relate the selection's systems.
+        """.trimIndent()
+        myFixture.configureByText(LatexFileType, text)
+        myFixture.performEditorAction("ReformatCode")
+        val expected = """
+            %     https://Petra-indicates-clears-to
+            % relate the selection's 
+            % systems.
+        """.trimIndent()
+        myFixture.checkResult(expected)
+    }
+
+    fun testHrefWrap() {
+        setUpTest()
+        val text = """
+            \section{This includes permissions.}
+            \href{https://the-very-very-long.url}{This includes} permissions.
+        """.trimIndent()
+        myFixture.configureByText(LatexFileType, text)
+        myFixture.performEditorAction("ReformatCode")
+        val expected = """
+            \section{This includes 
+            permissions.}
+            \href{https://the-very-very-long.url}{This includes}
+            permissions.
+        """.trimIndent()
+        myFixture.checkResult(expected)
+    }
+
+    fun testUrlWrap() {
+        val text = """
+            \href{https://the-very-very-long.url}{unreasonable long <caret>}
+        """.trimIndent()
+        myFixture.configureByText(LatexFileType, text)
+        val settings = CodeStyle.createTestSettings(CodeStyle.getSettings(project))
+        CodeStyleSettingsManager.getInstance(project).setTemporarySettings(settings)
+        settings.defaultRightMargin = 30
+        settings.WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN = true
+        myFixture.type("URL")
+        val expected = """
+            \href{https://the-very-very-long.url}{unreasonable long URL}
+        """.trimIndent()
+        myFixture.checkResult(expected)
+    }
+}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2725

#### Summary of additions and changes

* Add line wrapping strategy to wrap after urls in \url-like commands and comments

#### How to test this pull request

Set line width to 30 and reformat:
```latex
\section{This includes permissions.}
\href{https://the-very-very-long.url}{This includes} permissions and basements.
% https://the-very-very-long-long.url with long text
% and the https://the-very-very-long.url
It appears to rely more inspiring during
% On average 59 precisely inbound
Petra indicates clears to relate the selection's systems.
```
