### PR TITLE
Reformat suggested filename before showing it to the user, instead of afterwards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Fixed
+* Reformat suggested file name before showing it to the user, instead of afterwards.
 
 ## [0.7.26-alpha.4] - 2023-01-05
 

--- a/src/nl/hannahsten/texifyidea/ui/CreateFileDialog.kt
+++ b/src/nl/hannahsten/texifyidea/ui/CreateFileDialog.kt
@@ -14,7 +14,7 @@ import javax.swing.JTextField
  *
  * @param currentFilePath The path of the file we are currently in, e.g., the file from which an intention was triggered
  *      that creates a new file.
- * @param newFileName The name of the new file, with or without the extension.
+ * @param newFileName The name of the new file, with or without the extension. Will be reformatted before being shown to the user.
  * @param newFileFullPath The full path of the new file, without tex extension.
  */
 class CreateFileDialog(private val currentFilePath: String?, private val newFileName: String, var newFileFullPath: String? = null) {
@@ -26,7 +26,7 @@ class CreateFileDialog(private val currentFilePath: String?, private val newFile
             panel.layout = VerticalFlowLayout(VerticalFlowLayout.TOP)
 
             // Field to enter the name of the new file.
-            val nameField = JTextField(newFileName)
+            val nameField = JTextField(newFileName.formatAsFileName())
             // Field to select the folder/location of the new file.
             val pathField = TextFieldWithBrowseButton()
             pathField.text = currentFilePath ?: return@apply
@@ -69,7 +69,8 @@ class CreateFileDialog(private val currentFilePath: String?, private val newFile
                 // Create the directories, if they do not yet exist.
                 File(path).mkdirs()
                 // Format the text from the name field as a file name (e.g. " " -> "-") and remove the (double) tex extension.
-                newFileFullPath = "$path/${nameField.text.substring(pathEndIndex + 1).formatAsFileName()}"
+                // We do not check the filename here, as we already suggested a valid name so if the user decides to change it, it's not our problem.
+                newFileFullPath = "$path/${nameField.text.substring(pathEndIndex + 1)}"
                     .replace(Regex("(\\.tex)+$", RegexOption.IGNORE_CASE), "")
             }
         }

--- a/src/nl/hannahsten/texifyidea/util/Strings.kt
+++ b/src/nl/hannahsten/texifyidea/util/Strings.kt
@@ -160,7 +160,7 @@ fun String.remove(string: String): String = this.replace(string, "")
 fun String.formatAsFileName(): String = this.formatAsFilePath().removeAll("/", "\\")
 
 /**
- * Formats the string as a valid filepath, removing not-allowed characters, in TeX-style with - as separator. Any / or \ characters are not removed.
+ * Formats the string as a valid filepath in our recommended LaTeX style, removing not-allowed characters, in TeX-style with - as separator. Any / or \ characters are not removed.
  */
 fun String.formatAsFilePath(): String {
     val formatted = this.replace(" ", "-")


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2729

