### PR TITLE
Revert accidental removal of inline math paired delimiter

### DIFF
--- a/src/nl/hannahsten/texifyidea/highlighting/LatexPairedBraceMatcher.kt
+++ b/src/nl/hannahsten/texifyidea/highlighting/LatexPairedBraceMatcher.kt
@@ -15,7 +15,7 @@ class LatexPairedBraceMatcher : PairedBraceMatcher {
 
         private val bracePairs = arrayOf(
             BracePair(LatexTypes.DISPLAY_MATH_START, LatexTypes.DISPLAY_MATH_END, true),
-//            BracePair(LatexTypes.INLINE_MATH_START, LatexTypes.INLINE_MATH_END, true),
+            BracePair(LatexTypes.INLINE_MATH_START, LatexTypes.INLINE_MATH_END, true),
             BracePair(LatexTypes.BEGIN_TOKEN, LatexTypes.END_TOKEN, false),
             BracePair(LatexTypes.OPEN_PAREN, LatexTypes.CLOSE_PAREN, false),
             BracePair(LatexTypes.OPEN_BRACE, LatexTypes.CLOSE_BRACE, false),

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
@@ -339,7 +339,7 @@ class LatexRunConfiguration constructor(
         // Read bibliography run configurations, which is a list of ids
         val bibRunConfigElt = parent.getChildText(BIB_RUN_CONFIG)
         // Assume the list is of the form [id 1,id 2]
-        this.bibRunConfigIds = bibRunConfigElt.drop(1).dropLast(1).split(", ").toMutableSet()
+        this.bibRunConfigIds = bibRunConfigElt?.drop(1)?.dropLast(1)?.split(", ")?.toMutableSet() ?: mutableSetOf()
 
         // Read makeindex run configurations
         val makeindexRunConfigElt = parent.getChildText(MAKEINDEX_RUN_CONFIG)

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexChapterPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexChapterPresentation.kt
@@ -1,8 +1,10 @@
 package nl.hannahsten.texifyidea.structure.latex
 
 import nl.hannahsten.texifyidea.TexifyIcons
+import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.structure.EditableHintPresentation
+import nl.hannahsten.texifyidea.util.magic.cmd
 
 /**
  * @author Hannah Schellekens
@@ -13,11 +15,11 @@ class LatexChapterPresentation(chapterCommand: LatexCommands) : EditableHintPres
     private var hint = ""
 
     init {
-        if (chapterCommand.commandToken.text != "\\chapter") {
+        if (chapterCommand.name != LatexGenericRegularCommand.CHAPTER.cmd) {
             throw IllegalArgumentException("command is no \\chapter-command")
         }
 
-        this.chapterName = chapterCommand.requiredParameters[0]
+        this.chapterName = chapterCommand.requiredParameters.getOrElse(0) { "No chapter name" }
     }
 
     override fun getPresentableText() = chapterName

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexPresentationFactory.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexPresentationFactory.kt
@@ -2,9 +2,14 @@ package nl.hannahsten.texifyidea.structure.latex
 
 import com.intellij.navigation.ItemPresentation
 import nl.hannahsten.texifyidea.TexifyIcons
+import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand.*
+import nl.hannahsten.texifyidea.lang.commands.LatexMathtoolsRegularCommand.*
+import nl.hannahsten.texifyidea.lang.commands.LatexNewDefinitionCommand.NEWCOMMAND
+import nl.hannahsten.texifyidea.lang.commands.LatexXparseCommand
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.util.getIncludeCommands
 import nl.hannahsten.texifyidea.util.labels.getLabelDefinitionCommands
+import nl.hannahsten.texifyidea.util.magic.cmd
 
 /**
  * @author Hannah Schellekens
@@ -18,19 +23,19 @@ object LatexPresentationFactory {
             return LatexLabelPresentation(commands)
         }
         return when (commands.name) {
-            "\\part" -> LatexPartPresentation(commands)
-            "\\chapter" -> LatexChapterPresentation(commands)
-            "\\section" -> LatexSectionPresentation(commands)
-            "\\subsection" -> LatexSubSectionPresentation(commands)
-            "\\subsubsection" -> LatexSubSubSectionPresentation(commands)
-            "\\paragraph" -> LatexParagraphPresentation(commands)
-            "\\subparagraph" -> LatexSubParagraphPresentation(commands)
-            "\\newcommand", "\\DeclareMathOperator", "\\NewDocumentCommand" -> LatexNewCommandPresentation(commands)
-            "\\DeclarePairedDelimiter", "\\DeclarePairedDelimiterX", "\\DeclarePairedDelimiterXPP" -> LatexPairedDelimiterPresentation(
+            PART.cmd -> LatexPartPresentation(commands)
+            CHAPTER.cmd -> LatexChapterPresentation(commands)
+            SECTION.cmd -> LatexSectionPresentation(commands)
+            SUBSECTION.cmd -> LatexSubSectionPresentation(commands)
+            SUBSUBSECTION.cmd -> LatexSubSubSectionPresentation(commands)
+            PARAGRAPH.cmd -> LatexParagraphPresentation(commands)
+            SUBPARAGRAPH.cmd -> LatexSubParagraphPresentation(commands)
+            NEWCOMMAND.cmd, DECLARE_MATH_OPERATOR.cmd, LatexXparseCommand.NEWDOCUMENTCOMMAND.cmd -> LatexNewCommandPresentation(commands)
+            DECLARE_PAIRED_DELIMITER.cmd, DECLARE_PAIRED_DELIMITER_X.cmd, DECLARE_PAIRED_DELIMITER_XPP.cmd -> LatexPairedDelimiterPresentation(
                 commands
             )
-            "\\label" -> LatexLabelPresentation(commands)
-            "\\bibitem" -> BibitemPresentation(commands)
+            LABEL.cmd -> LatexLabelPresentation(commands)
+            BIBITEM.cmd -> BibitemPresentation(commands)
             in getIncludeCommands() -> LatexIncludePresentation(commands)
             else -> LatexOtherCommandPresentation(commands, TexifyIcons.DOT_COMMAND)
         }

--- a/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandlerTest.kt
+++ b/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandlerTest.kt
@@ -17,6 +17,12 @@ class LatexTypedHandlerTest : BasePlatformTestCase() {
         myFixture.checkResult("$\\xi$<caret>")
     }
 
+    fun testRobustInlineMath() {
+        myFixture.configureByText(LatexFileType, "")
+        myFixture.type("\\(")
+        myFixture.checkResult("\\(\\)")
+    }
+
     fun testVerbatim() {
         myFixture.configureByText(
             LatexFileType,


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2788
Fix #2843 NPE 
Fix #2871 IOOB in structure view

#### Summary of additions and changes

* Mistakenly introduced in #2362
