### PR TITLE
Provide resolution magic for newtxmath

### DIFF
--- a/src/nl/hannahsten/texifyidea/lang/LatexPackage.kt
+++ b/src/nl/hannahsten/texifyidea/lang/LatexPackage.kt
@@ -66,6 +66,7 @@ open class LatexPackage @JvmOverloads constructor(
         val MATHTOOLS = LatexPackage("mathtools")
         val MULTIND = LatexPackage("multind")
         val NATBIB = LatexPackage("natbib")
+        val NEWTXMATH = LatexPackage("newtxmath")
         val NTHEOREM = LatexPackage("ntheorem")
         val PDFCOMMENT = LatexPackage("pdfcomment")
         val PYTHONTEX = LatexPackage("pythontex")

--- a/src/nl/hannahsten/texifyidea/util/magic/PackageMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/PackageMagic.kt
@@ -52,7 +52,8 @@ object PackageMagic {
         LatexPackage.GRAPHICX to setOf(LatexPackage.GRAPHICS),
         LatexPackage.XCOLOR to setOf(LatexPackage.COLOR),
         LatexPackage.PDFCOMMENT to setOf(LatexPackage.HYPERREF),
-        LatexPackage.ALGORITHM2E to setOf(LatexPackage.ALGPSEUDOCODE), // This is not true, but loading any of these two (incompatible) packages is sufficient as they provide the same commands (roughly)
+        LatexPackage.ALGORITHM2E to setOf(LatexPackage.ALGPSEUDOCODE), // Not true, but algorithm2e provides roughly the same commands
+        LatexPackage.NEWTXMATH to setOf(LatexPackage.AMSSYMB, LatexPackage.STMARYRD), // Not true, but newtxmath provides roughly the same commands
     )
 
     /**


### PR DESCRIPTION
Fixes #2925.

In the thread of #2925 I said that pointing `newtx` to `amssymb` and `stmaryrd` did not resolve the issue when using `acmart`, but that's because `acmart` loads `newtxmath`, not `newtx`. Which makes sense, because it's specifically `newtxmath` that provides the commands we're interested in for this issue.

### Summary of additions and changes
* Use magic to show that `newtxmath` is equivalent to `amssymb` and `stmaryrd`

### How to test this pull request
Each of the following snippets should show 0 warnings and 0 errors in the IDE.

* _Baseline: Already worked before this PR_
  ```latex
  \documentclass{article}

  \usepackage{amssymb}
  \usepackage{stmaryrd}

  \begin{document}
      $\llbracket$

      $\nexists$
  \end{document}
  ```
* _Direct: Check if newtxmath is considered the same as amssymb and stmaryrd_
  ```latex
  \documentclass{article}

  \usepackage{newtxmath}

  \begin{document}
      $\llbracket$

      $\nexists$
  \end{document}
  ```
* _Indirect: Check if TeXiFy understands that newtx loads newtxmath_
  ```latex
  \documentclass{article}

  \usepackage{newtx}

  \begin{document}
      $\llbracket$

      $\nexists$
  \end{document}
  ```

* _Very indirect: Check if TeXiFy understands that acmart loads newtxmath_
  ```latex
  \documentclass{acmart}

  \begin{document}
      $\llbracket$

      $\nexists$
  \end{document}
  ```

### Wiki
- [x] Updated the wiki: _I found no pages related to these changes_