### PR TITLE
Fix #2928: check if file is writable

### DIFF
--- a/src/nl/hannahsten/texifyidea/action/InsertEditorAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/InsertEditorAction.kt
@@ -52,7 +52,9 @@ open class InsertEditorAction(
         // Don't touch any file content that is not related to TeXiFy
         if (file.psiFile(project)?.findElementAt(start)?.isLatexOrBibtex() == false) return
 
-        runWriteAction(project) { insert(document, start, end, editor.caretModel) }
+        if (file.isWritable) {
+            runWriteAction(project) { insert(document, start, end, editor.caretModel) }
+        }
     }
 
     private fun insert(document: Document, start: Int, end: Int, caretModel: CaretModel) {

--- a/src/nl/hannahsten/texifyidea/action/LatexToggleStarAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/LatexToggleStarAction.kt
@@ -32,7 +32,9 @@ class LatexToggleStarAction : EditorAction("Toggle Star", TexifyIcons.TOGGLE_STA
 
         val commands = getParentOfType(element, LatexCommands::class.java) ?: return
 
-        runWriteAction(project) { toggleStar(editor, psiFile, commands) }
+        if (file.isWritable) {
+            runWriteAction(project) { toggleStar(editor, psiFile, commands) }
+        }
     }
 
     /**

--- a/src/nl/hannahsten/texifyidea/util/Packages.kt
+++ b/src/nl/hannahsten/texifyidea/util/Packages.kt
@@ -45,6 +45,7 @@ object PackageUtils {
      */
     @JvmStatic
     fun insertUsepackage(file: PsiFile, packageName: String, parameters: String?) {
+        if (!file.isWritable) return
 
         if (!TexifySettings.getInstance().automaticDependencyCheck) {
             return


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2928 

#### Summary of additions and changes

* Check if a file is writable before writing to it.

#### How to test this pull request

- Create a file and add some text.
- Make the file read-only (e.g., with `chmod 440 file`.
- Open the file in the IDE.
- Select some text in the file and run the strikethrough action.