### PR TITLE
Fix bug when resolving \subimport

### DIFF
--- a/src/nl/hannahsten/texifyidea/util/files/ImportPackage.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/ImportPackage.kt
@@ -5,6 +5,8 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
 import com.intellij.psi.search.GlobalSearchScope
 import nl.hannahsten.texifyidea.index.LatexIncludesIndex
+import nl.hannahsten.texifyidea.lang.commands.LatexCommand
+import nl.hannahsten.texifyidea.lang.commands.RequiredFileArgument
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.reference.InputFileReference
 import nl.hannahsten.texifyidea.util.appendExtension
@@ -85,11 +87,15 @@ fun findRelativeSearchPathsForImportCommands(command: LatexCommands, givenRelati
     var relativeSearchPaths = givenRelativeSearchPaths.toMutableList()
     val allIncludeCommands = LatexIncludesIndex.getItems(command.project)
     // Commands which may include the current file (this is an overestimation, better would be to check for RequiredFileArguments)
-    var includingCommands = allIncludeCommands.filter { includeCommand -> includeCommand.requiredParameters.any { it.contains(command.containingFile.name.removeFileExtension()) } }
-
-    if (includingCommands.isEmpty() && command.name in CommandMagic.relativeImportCommands) {
-        command.containingFile.containingDirectory?.virtualFile?.findFileByRelativePath(command.requiredParameter(0) ?: "")?.let { return listOf(it) }
+    var includingCommands = allIncludeCommands.filter {
+        includeCommand -> includeCommand.requiredParameters.any { it.contains(command.containingFile.name.removeFileExtension()) }
+    }.filter { includeCommand ->
+        // Only consider commands that can include LaTeX files
+        LatexCommand.lookup(includeCommand.name)?.firstOrNull()?.getArgumentsOf(RequiredFileArgument::class.java)?.any { it.supportedExtensions.contains("tex") } == true
     }
+
+    // Assume the containingFile might be a root file - if there are no includingCommands we will not search further anyway
+    val defaultParentDir = command.containingFile.containingDirectory?.virtualFile?.findFileByRelativePath(command.requiredParameter(0) ?: "")
 
     // Avoid endless loop (in case of a file inclusion loop)
     val maxDepth = allIncludeCommands.size
@@ -97,6 +103,10 @@ fun findRelativeSearchPathsForImportCommands(command: LatexCommands, givenRelati
 
     // Final paths
     val absoluteSearchDirs = mutableListOf<VirtualFile>()
+
+    if (defaultParentDir != null) {
+        absoluteSearchDirs.add(defaultParentDir)
+    }
 
     // I think it's a kind of reversed BFS
     while (includingCommands.isNotEmpty() && counter < maxDepth) {

--- a/src/nl/hannahsten/texifyidea/util/files/ImportPackage.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/ImportPackage.kt
@@ -88,7 +88,8 @@ fun findRelativeSearchPathsForImportCommands(command: LatexCommands, givenRelati
     val allIncludeCommands = LatexIncludesIndex.getItems(command.project)
     // Commands which may include the current file (this is an overestimation, better would be to check for RequiredFileArguments)
     var includingCommands = allIncludeCommands.filter {
-        includeCommand -> includeCommand.requiredParameters.any { it.contains(command.containingFile.name.removeFileExtension()) }
+        includeCommand ->
+        includeCommand.requiredParameters.any { it.contains(command.containingFile.name.removeFileExtension()) }
     }.filter { includeCommand ->
         // Only consider commands that can include LaTeX files
         LatexCommand.lookup(includeCommand.name)?.firstOrNull()?.getArgumentsOf(RequiredFileArgument::class.java)?.any { it.supportedExtensions.contains("tex") } == true


### PR DESCRIPTION
…inputs the file in a different file set

<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2750 

#### Summary of additions and changes

* If you have another command in the project inputting a file with the same name as your main file with the \subimport, the code would get confused and just skip it. Now we're still confused but we just try all paths and the first one that resolves wins.

#### How to test this pull request

main.tex
```latex
\documentclass{article}
\usepackage{import}

\input{preamble}

\begin{document}
    \subimport{chapters/}{chapter-one.tex}
\end{document}
```

preamble.tex
```
\usepackage{hyperref}
```

chapters/chapter-one.tex
```
\url{blub}

\input{included.tex}
```

chapters/included.tex

