### PR TITLE
Add \newminted code blocks as verbatim environments

### DIFF
--- a/gen/nl/hannahsten/texifyidea/grammar/LatexLexer.java
+++ b/gen/nl/hannahsten/texifyidea/grammar/LatexLexer.java
@@ -1546,7 +1546,7 @@ public class LatexLexer implements FlexLexer {
           case 43: 
             { yypopState();
             // toString to fix comparisons of charsequence subsequences with string
-            if (EnvironmentMagic.verbatim.contains(yytext().toString())) {
+            if (EnvironmentMagic.isProbablyVerbatim(yytext().toString())) {
                 yypushState(VERBATIM_START);
             }
             else if (yytext().toString().equals("algorithmic")) {
@@ -1603,7 +1603,7 @@ public class LatexLexer implements FlexLexer {
           case 52: 
             { // Pop current state
         yypopState();
-        if (EnvironmentMagic.verbatim.contains(yytext().toString())) {
+        if (EnvironmentMagic.isProbablyVerbatim(yytext().toString())) {
             // Pop verbatim state
             yypopState();
             return NORMAL_TEXT_WORD;

--- a/src/nl/hannahsten/texifyidea/grammar/LatexLexer.flex
+++ b/src/nl/hannahsten/texifyidea/grammar/LatexLexer.flex
@@ -205,7 +205,7 @@ END_PSEUDOCODE_BLOCK="\\EndFor" | "\\EndIf" | "\\EndWhile" | "\\Until" | "\\EndL
     {NORMAL_TEXT_WORD}  {
             yypopState();
             // toString to fix comparisons of charsequence subsequences with string
-            if (EnvironmentMagic.verbatim.contains(yytext().toString())) {
+            if (EnvironmentMagic.isProbablyVerbatim(yytext().toString())) {
                 yypushState(VERBATIM_START);
             }
             else if (yytext().toString().equals("algorithmic")) {
@@ -257,7 +257,7 @@ END_PSEUDOCODE_BLOCK="\\EndFor" | "\\EndIf" | "\\EndWhile" | "\\Until" | "\\EndL
     {NORMAL_TEXT_WORD}  {
         // Pop current state
         yypopState();
-        if (EnvironmentMagic.verbatim.contains(yytext().toString())) {
+        if (EnvironmentMagic.isProbablyVerbatim(yytext().toString())) {
             // Pop verbatim state
             yypopState();
             return NORMAL_TEXT_WORD;

--- a/src/nl/hannahsten/texifyidea/intentions/LatexInsertFormatterCommentsIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexInsertFormatterCommentsIntention.kt
@@ -18,7 +18,7 @@ class LatexInsertFormatterCommentsIntention : TexifyIntentionBase("Insert commen
             ?.parentOfType(LatexBeginCommand::class)
             ?.environmentName()
             ?: return false
-        return EnvironmentMagic.verbatim.any { it == beginName }
+        return EnvironmentMagic.isProbablyVerbatim(beginName)
     }
 
     override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {

--- a/src/nl/hannahsten/texifyidea/psi/LatexLanguageInjector.kt
+++ b/src/nl/hannahsten/texifyidea/psi/LatexLanguageInjector.kt
@@ -12,6 +12,7 @@ import nl.hannahsten.texifyidea.util.camelCase
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.magic.EnvironmentMagic
 import nl.hannahsten.texifyidea.util.parentOfType
+import nl.hannahsten.texifyidea.util.remove
 import java.util.*
 
 /**
@@ -34,10 +35,17 @@ class LatexLanguageInjector : LanguageInjector {
                 host.environmentName == "lstlisting" -> {
                     host.beginCommand.optionalParameterMap.toStringMap().getOrDefault("language", null)
                 }
-                else -> {
+                host.environmentName in EnvironmentMagic.languageInjections.keys -> {
                     EnvironmentMagic.languageInjections[host.environmentName]
                 }
-            }
+                host.environmentName.endsWith("code", ignoreCase = false) -> {
+                    // Environment may have been defined with the \newminted shortcut (see minted documentation)
+                    host.environmentName.remove("code")
+                }
+                else -> {
+                    null
+                }
+            } ?: return
 
             val language = findLanguage(languageId) ?: return
 

--- a/src/nl/hannahsten/texifyidea/psi/LatexParserUtil.kt
+++ b/src/nl/hannahsten/texifyidea/psi/LatexParserUtil.kt
@@ -25,7 +25,7 @@ class LatexParserUtil : GeneratedParserUtilBase() {
 
             val env = beginText.subSequence(nameStart, nameEnd).toString()
 
-            if (env !in EnvironmentMagic.verbatim) return false
+            if (!EnvironmentMagic.isProbablyVerbatim(env)) return false
 
             val startIndex = builder.currentOffset
             // Exclude the last newline, so it will stay a whitespace,

--- a/src/nl/hannahsten/texifyidea/util/magic/EnvironmentMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/EnvironmentMagic.kt
@@ -36,6 +36,18 @@ object EnvironmentMagic {
     )
 
     /**
+     * Do a guess whether the environment is a verbatim environment.
+     * Note: used in the lexer, so it should be fast.
+     */
+    @JvmStatic
+    fun isProbablyVerbatim(environmentName: String): Boolean {
+        // It might use \newminted environments, which always end in code
+        // There are other environments that have 'code' in their name, if they are all verbatim environments is unclear
+        // See https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2847#issuecomment-1347941386
+        return verbatim.contains(environmentName) || environmentName.endsWith("code")
+    }
+
+    /**
      * Environments that always contain a certain language.
      *
      * Maps the name of the environment to the registered Language id.


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2847

#### Summary of additions and changes

* Environments defined with \newminted will end with `code` so are easy to auto-detect for the lexer, and inject language.

#### How to test this pull request

```latex
\documentclass{article}
\usepackage{minted}
\newminted{kotlin}{linenos}
\begin{document}
    \begin{kotlincode}
        val blub = 3
        fun getBlub() {
            return 3 // a comment {
        }
    \end{kotlincode}
\end{document}
```

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: