### PR TITLE
Add setting to configure default folding of imports

### DIFF
--- a/resources/META-INF/extensions/editor/editor.xml
+++ b/resources/META-INF/extensions/editor/editor.xml
@@ -9,6 +9,9 @@
         <lang.foldingBuilder language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.folding.LatexSymbolFoldingBuilder"/>
         <lang.foldingBuilder language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.folding.LatexCustomFoldingBuilder"/>
         <lang.foldingBuilder language="Bibtex" implementationClass="nl.hannahsten.texifyidea.editor.folding.BibtexEntryFoldingBuilder"/>
+        <codeFoldingOptionsProvider instance="nl.hannahsten.texifyidea.editor.folding.LatexCodeFoldingOptionsProvider" />
+        <applicationService serviceImplementation="nl.hannahsten.texifyidea.editor.folding.LatexCodeFoldingSettings" />
+
         <lang.formatter language="Latex" implementationClass="nl.hannahsten.texifyidea.formatting.LatexFormattingModelBuilder"/>
         <lang.formatter language="Bibtex" implementationClass="nl.hannahsten.texifyidea.formatting.BibtexFormattingModelBuilder"/>
         <lang.formatter.restriction implementation="nl.hannahsten.texifyidea.formatting.LatexLanguageFormattingRestriction"/>

--- a/src/nl/hannahsten/texifyidea/editor/folding/LatexCodeFoldingOptionsProvider.kt
+++ b/src/nl/hannahsten/texifyidea/editor/folding/LatexCodeFoldingOptionsProvider.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.options.BeanConfigurable
  * Settings > Editor > General > Code Folding settings for LaTeX.
  */
 class LatexCodeFoldingOptionsProvider : CodeFoldingOptionsProvider, BeanConfigurable<LatexCodeFoldingSettings>(LatexCodeFoldingSettings.getInstance(), "LaTeX") {
+
     init {
         val settings = instance
         if (settings != null) {

--- a/src/nl/hannahsten/texifyidea/editor/folding/LatexCodeFoldingOptionsProvider.kt
+++ b/src/nl/hannahsten/texifyidea/editor/folding/LatexCodeFoldingOptionsProvider.kt
@@ -1,0 +1,16 @@
+package nl.hannahsten.texifyidea.editor.folding
+
+import com.intellij.application.options.editor.CodeFoldingOptionsProvider
+import com.intellij.openapi.options.BeanConfigurable
+
+/**
+ * Settings > Editor > General > Code Folding settings for LaTeX.
+ */
+class LatexCodeFoldingOptionsProvider : CodeFoldingOptionsProvider, BeanConfigurable<LatexCodeFoldingSettings>(LatexCodeFoldingSettings.getInstance(), "LaTeX") {
+    init {
+        val settings = instance
+        if (settings != null) {
+            checkBox("Package imports", settings::collapseImports)
+        }
+    }
+}

--- a/src/nl/hannahsten/texifyidea/editor/folding/LatexCodeFoldingSettings.kt
+++ b/src/nl/hannahsten/texifyidea/editor/folding/LatexCodeFoldingSettings.kt
@@ -1,0 +1,27 @@
+package nl.hannahsten.texifyidea.editor.folding
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
+import com.intellij.util.xmlb.XmlSerializerUtil
+
+/**
+ * Settings for [LatexCodeFoldingOptionsProvider], inspired by RsCodeFoldingSettings from the Rust plugin.
+ * Other languages appear to mostly use editor.xml, so we use it as well.
+ * Note: in the debug instance, this file is at build/idea-sandbox/config/options/editor.xml.
+ */
+@State(name = "LatexCodeFoldingSettings", storages = [Storage("editor.xml")])
+class LatexCodeFoldingSettings : PersistentStateComponent<LatexCodeFoldingSettings> {
+
+    var collapseImports: Boolean = true
+
+    override fun getState() = this
+
+    override fun loadState(state: LatexCodeFoldingSettings) = XmlSerializerUtil.copyBean(state, this)
+
+    companion object {
+        fun getInstance(): LatexCodeFoldingSettings = service()
+    }
+
+}

--- a/src/nl/hannahsten/texifyidea/editor/folding/LatexCodeFoldingSettings.kt
+++ b/src/nl/hannahsten/texifyidea/editor/folding/LatexCodeFoldingSettings.kt
@@ -21,7 +21,7 @@ class LatexCodeFoldingSettings : PersistentStateComponent<LatexCodeFoldingSettin
     override fun loadState(state: LatexCodeFoldingSettings) = XmlSerializerUtil.copyBean(state, this)
 
     companion object {
+
         fun getInstance(): LatexCodeFoldingSettings = service()
     }
-
 }

--- a/src/nl/hannahsten/texifyidea/editor/folding/LatexImportFoldingBuilder.kt
+++ b/src/nl/hannahsten/texifyidea/editor/folding/LatexImportFoldingBuilder.kt
@@ -10,11 +10,13 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.refactoring.suggested.endOffset
 import com.intellij.refactoring.suggested.startOffset
+import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexNoMathContent
 import nl.hannahsten.texifyidea.util.allCommands
 import nl.hannahsten.texifyidea.util.firstChildOfType
 import nl.hannahsten.texifyidea.util.magic.PatternMagic
+import nl.hannahsten.texifyidea.util.magic.cmd
 import nl.hannahsten.texifyidea.util.parentOfType
 
 /**
@@ -27,18 +29,17 @@ open class LatexImportFoldingBuilder : FoldingBuilderEx() {
 
     companion object {
 
-        private val includesSet = setOf("\\usepackage", "\\RequirePackage")
-        private val includesArray = includesSet.toTypedArray()
+        private val includesSet = setOf(LatexGenericRegularCommand.USEPACKAGE.cmd, LatexGenericRegularCommand.REQUIREPACKAGE.cmd)
     }
 
-    override fun isCollapsedByDefault(node: ASTNode) = true
+    override fun isCollapsedByDefault(node: ASTNode) = LatexCodeFoldingSettings.getInstance().collapseImports
 
     override fun getPlaceholderText(node: ASTNode) = if (node.text.contains("RequirePackage")) "\\RequirePackage{...}" else "\\usepackage{...}"
 
     override fun buildFoldRegions(root: PsiElement, document: Document, quick: Boolean): Array<FoldingDescriptor> {
         val descriptors = ArrayList<FoldingDescriptor>()
         val covered = HashSet<LatexCommands>()
-        val commands = root.allCommands().filter { it.name in includesArray }
+        val commands = root.allCommands().filter { it.name in includesSet }
 
         for (command in commands) {
             // Do not cover commands twice.


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2854

#### Summary of additions and changes

* Add setting to configure default folding of imports. I used Editor > General > Code Folding

#### How to test this pull request

Disable setting, open a file you haven't opened before after last restart

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: