### PR TITLE
Disable LatexBibinputsRelativePathInspection

### DIFF
--- a/resources/META-INF/extensions/inspections/latex/probablebugs/probablebugs.xml
+++ b/resources/META-INF/extensions/inspections/latex/probablebugs/probablebugs.xml
@@ -70,7 +70,7 @@
                          level="ERROR" />
         <localInspection language="Latex" implementationClass="nl.hannahsten.texifyidea.inspections.latex.probablebugs.LatexBibinputsRelativePathInspection"
                          groupPath="LaTeX" groupName="Probable bugs" displayName="Relative path to parent is not allowed when using BIBINPUTS"
-                         enabledByDefault="true"
+                         enabledByDefault="false"
                          level="ERROR" />
         <localInspection language="Latex" implementationClass="nl.hannahsten.texifyidea.inspections.latex.probablebugs.packages.LatexUndefinedCommandInspection"
                          groupPath="LaTeX" groupName="Probable bugs" displayName="Command is not defined"

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexBibinputsRelativePathInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexBibinputsRelativePathInspection.kt
@@ -24,6 +24,8 @@ import nl.hannahsten.texifyidea.util.requiredParameter
  * BIBINPUTS cannot handle paths which start with ../  in the \bibliography command, e.g. \bibliography{../mybib}.
  * Solution: set the BIBINPUTS path to the parent and use \bibliography{mybib} instead (or use a fake subfolder and do \bibliography{fake/../../mybib}
  * See https://tex.stackexchange.com/questions/406024/relative-paths-with-bibinputs
+ *
+ * [Edit March 2023] I cannot reproduce this problem anymore, maybe it was a bug in bibtex that has been fixed?
  */
 class LatexBibinputsRelativePathInspection : TexifyInspectionBase() {
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2885

#### Summary of additions and changes

* I cannot reproduce this problem anymore, maybe it was a bug in bibtex that has been fixed?

#### How to test this pull request

https://github.com/PHPirates/bibtex-mwe/tree/2885

#### Wiki

<!-- Add link to updated wiki page -->
- [x] Updated the wiki: