### PR TITLE
Use smart psi element pointers in fileset cache to avoid returning invalid files

### DIFF
--- a/src/nl/hannahsten/texifyidea/lang/LatexPackage.kt
+++ b/src/nl/hannahsten/texifyidea/lang/LatexPackage.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.lang
 
+import com.intellij.codeInsight.intention.FileModifier
 import com.intellij.openapi.vfs.VirtualFile
 import nl.hannahsten.texifyidea.file.StyleFileType
 import nl.hannahsten.texifyidea.util.files.removeFileExtension
@@ -7,6 +8,7 @@ import nl.hannahsten.texifyidea.util.files.removeFileExtension
 /**
  * @author Hannah Schellekens
  */
+@FileModifier.SafeTypeForPreview
 open class LatexPackage @JvmOverloads constructor(
     val name: String,
     vararg val parameters: String = emptyArray(),


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2903

#### Summary of additions and changes

* Use SmartPsiElementPointer to avoid storing files which have become invalid, e.g. after installing a plugin which doesn't require a restart. Attemping to modify psi of invalid files will result in the "because: different providers" exception.

#### How to test this pull request


    Use align but without importing amsmath
    Install a plugin which doesn't need a restart (e.g. pdf viewer or Statistic)
    Use the inspection quickfix to insert usepackage


