### PR TITLE
Fold Comments Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+* Fold blocks of comments, by @jojo2357
+* Highlight comment environment as a comment, by @jojo2357
 
 ### Fixed
 

--- a/resources/META-INF/extensions/editor/editor.xml
+++ b/resources/META-INF/extensions/editor/editor.xml
@@ -4,6 +4,7 @@
         <lang.foldingBuilder language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.folding.LatexEnvironmentFoldingBuilder"/>
         <lang.foldingBuilder language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.folding.LatexImportFoldingBuilder"/>
         <lang.foldingBuilder language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.folding.LatexFootnoteFoldingBuilder"/>
+        <lang.foldingBuilder language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.folding.LatexCommentFoldingBuilder"/>
         <lang.foldingBuilder language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.folding.LatexSectionFoldingBuilder"/>
         <lang.foldingBuilder language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.folding.LatexEscapedSymbolFoldingBuilder"/>
         <lang.foldingBuilder language="Latex" implementationClass="nl.hannahsten.texifyidea.editor.folding.LatexSymbolFoldingBuilder"/>

--- a/src/nl/hannahsten/texifyidea/editor/folding/LatexCommentFoldingBuilder.kt
+++ b/src/nl/hannahsten/texifyidea/editor/folding/LatexCommentFoldingBuilder.kt
@@ -1,0 +1,92 @@
+package nl.hannahsten.texifyidea.editor.folding
+
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.FoldingBuilderEx
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.refactoring.suggested.endOffset
+import com.intellij.refactoring.suggested.startOffset
+import nl.hannahsten.texifyidea.util.childrenOfType
+
+/**
+ * Adds folding regions for LaTeX environments.
+ *
+ * Enables folding of `\footnote{}`.
+ *
+ * @author jojo2357
+ */
+class LatexCommentFoldingBuilder : FoldingBuilderEx(), DumbAware {
+
+    override fun isCollapsedByDefault(node: ASTNode) = false
+
+    override fun getPlaceholderText(node: ASTNode): String {
+        val parsedText = node.text.trim()
+        return if (parsedText.length > 8) parsedText.substring(0, 8) + "..."
+        else parsedText.substring(
+            0,
+            parsedText.length - 1
+        )
+    }
+
+    override fun buildFoldRegions(root: PsiElement, document: Document, quick: Boolean): Array<FoldingDescriptor> {
+        val descriptors = ArrayList<FoldingDescriptor>()
+        val comments = root.childrenOfType(PsiComment::class)
+        val whitespaces = root.childrenOfType(PsiWhiteSpace::class)
+
+        val whitespaceLocations = ArrayList(whitespaces.map { TextRange(it.startOffset, it.endOffset) })
+
+        // meld friends
+        for (i in whitespaceLocations.size - 1 downTo 1) {
+            if (whitespaceLocations[i].startOffset == whitespaceLocations[i - 1].endOffset) {
+                whitespaceLocations[i - 1] =
+                    TextRange(whitespaceLocations[i - 1].startOffset, whitespaceLocations[i].endOffset)
+                whitespaceLocations.removeAt(i)
+            }
+        }
+
+        var collectedTextRange: TextRange? = null
+        var parentCollapse: PsiElement? = null
+
+        for (comment in comments) {
+            if (collectedTextRange == null) {
+                collectedTextRange = TextRange(comment.startOffset, comment.endOffset)
+                parentCollapse = comment.originalElement
+            }
+            else {
+                if (whitespaceLocations.any { it.startOffset == collectedTextRange!!.endOffset && it.endOffset == comment.startOffset }) {
+                    collectedTextRange = TextRange(collectedTextRange.startOffset, comment.endOffset)
+                }
+                else {
+                    parentCollapse?.let {
+                        descriptors.add(
+                            FoldingDescriptor(
+                                parentCollapse!!,
+                                TextRange(collectedTextRange!!.startOffset, collectedTextRange!!.endOffset)
+                            )
+                        )
+                    }
+                    collectedTextRange = TextRange(comment.startOffset, comment.endOffset)
+                    parentCollapse = comment.originalElement
+                }
+            }
+            if (!whitespaceLocations.any { it.startOffset == collectedTextRange.endOffset }) {
+                if (collectedTextRange.endOffset > collectedTextRange.startOffset)
+                    parentCollapse?.let {
+                        descriptors.add(
+                            FoldingDescriptor(
+                                parentCollapse,
+                                TextRange(collectedTextRange.startOffset, collectedTextRange.endOffset)
+                            )
+                        )
+                    }
+            }
+        }
+
+        return descriptors.toTypedArray()
+    }
+}

--- a/src/nl/hannahsten/texifyidea/editor/folding/LatexCommentFoldingBuilder.kt
+++ b/src/nl/hannahsten/texifyidea/editor/folding/LatexCommentFoldingBuilder.kt
@@ -55,7 +55,7 @@ class LatexCommentFoldingBuilder : FoldingBuilderEx(), DumbAware {
                 parentCollapse = comment.originalElement
             }
             else {
-                // If the next comment follows directly after the previous one (and was broken by whitespace) add it to the sequence
+                // If the next comment follows directly after the previous one (and was broken by whitespace) add the next comment to the sequence
                 if (whitespaceLocations.any { it.startOffset == collectedTextRange!!.endOffset && it.endOffset == comment.startOffset }) {
                     collectedTextRange = TextRange(collectedTextRange.startOffset, comment.endOffset)
                 }
@@ -69,18 +69,6 @@ class LatexCommentFoldingBuilder : FoldingBuilderEx(), DumbAware {
                     collectedTextRange = TextRange(comment.startOffset, comment.endOffset)
                     parentCollapse = comment.originalElement
                 }
-            }
-            // if no whitespace exists at the end of this block we are building,
-            if (!whitespaceLocations.any { it.startOffset == collectedTextRange!!.endOffset }) {
-                // And we have accumulated at least something,
-                if (collectedTextRange.endOffset > collectedTextRange.startOffset)
-                // finish the collapse
-                    parentCollapse?.let {
-                        descriptors.add(buildDescriptor(parentCollapse, collectedTextRange))
-                    }
-                // and discard the built objects
-                parentCollapse = null
-                collectedTextRange = null
             }
         }
 

--- a/src/nl/hannahsten/texifyidea/editor/folding/LatexCommentFoldingBuilder.kt
+++ b/src/nl/hannahsten/texifyidea/editor/folding/LatexCommentFoldingBuilder.kt
@@ -16,7 +16,7 @@ import nl.hannahsten.texifyidea.util.childrenOfType
 /**
  * Adds folding regions for LaTeX environments.
  *
- * Enables folding of `\footnote{}`.
+ * Enables folding of comments.
  *
  * @author jojo2357
  */

--- a/src/nl/hannahsten/texifyidea/editor/folding/LatexCommentFoldingBuilder.kt
+++ b/src/nl/hannahsten/texifyidea/editor/folding/LatexCommentFoldingBuilder.kt
@@ -74,17 +74,33 @@ class LatexCommentFoldingBuilder : FoldingBuilderEx(), DumbAware {
                     parentCollapse = comment.originalElement
                 }
             }
-            if (!whitespaceLocations.any { it.startOffset == collectedTextRange.endOffset }) {
+            if (!whitespaceLocations.any { it.startOffset == collectedTextRange!!.endOffset }) {
                 if (collectedTextRange.endOffset > collectedTextRange.startOffset)
                     parentCollapse?.let {
                         descriptors.add(
                             FoldingDescriptor(
-                                parentCollapse,
-                                TextRange(collectedTextRange.startOffset, collectedTextRange.endOffset)
+                                parentCollapse!!,
+                                TextRange(collectedTextRange!!.startOffset, collectedTextRange!!.endOffset)
                             )
                         )
                     }
+                parentCollapse = null
+                collectedTextRange = null
             }
+        }
+
+        if (parentCollapse != null && collectedTextRange != null) {
+            if (collectedTextRange.endOffset > collectedTextRange.startOffset)
+                parentCollapse.let {
+                    descriptors.add(
+                        FoldingDescriptor(
+                            parentCollapse!!,
+                            TextRange(collectedTextRange!!.startOffset, collectedTextRange!!.endOffset)
+                        )
+                    )
+                }
+            parentCollapse = null
+            collectedTextRange = null
         }
 
         return descriptors.toTypedArray()

--- a/src/nl/hannahsten/texifyidea/highlighting/LatexAnnotator.kt
+++ b/src/nl/hannahsten/texifyidea/highlighting/LatexAnnotator.kt
@@ -58,6 +58,12 @@ open class LatexAnnotator : Annotator {
         else if (psiElement is LatexCommands) {
             annotateCommands(psiElement, annotationHolder)
         }
+        else if (psiElement.isComment()) {
+            annotationHolder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+                .range(psiElement.textRange)
+                .textAttributes(LatexSyntaxHighlighter.COMMENT)
+                .create()
+        }
     }
 
     /**
@@ -157,7 +163,7 @@ open class LatexAnnotator : Annotator {
         annotationHolder: AnnotationHolder
     ) {
         for (
-            element in optionalParamElement.optionalParamContentList
+        element in optionalParamElement.optionalParamContentList
         ) {
             if (element !is LatexOptionalParamContent) {
                 continue
@@ -206,6 +212,7 @@ open class LatexAnnotator : Annotator {
             in CommandMagic.bibliographyItems -> {
                 LatexSyntaxHighlighter.BIBLIOGRAPHY_DEFINITION
             }
+
             else -> return
         }
 

--- a/src/nl/hannahsten/texifyidea/highlighting/LatexAnnotator.kt
+++ b/src/nl/hannahsten/texifyidea/highlighting/LatexAnnotator.kt
@@ -163,7 +163,7 @@ open class LatexAnnotator : Annotator {
         annotationHolder: AnnotationHolder
     ) {
         for (
-        element in optionalParamElement.optionalParamContentList
+            element in optionalParamElement.optionalParamContentList
         ) {
             if (element !is LatexOptionalParamContent) {
                 continue

--- a/test/nl/hannahsten/texifyidea/editor/LatexFoldingTest.kt
+++ b/test/nl/hannahsten/texifyidea/editor/LatexFoldingTest.kt
@@ -41,4 +41,8 @@ class LatexFoldingTest : BasePlatformTestCase() {
     fun testCustomFoldingRegions() {
         myFixture.testFolding("$testDataPath/custom-regions.tex")
     }
+
+    fun testCommentFolding() {
+        myFixture.testFolding("$testDataPath/comments.tex")
+    }
 }

--- a/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
@@ -90,7 +90,7 @@ class LatexParserTest : BasePlatformTestCase() {
         myFixture.configureByText(
             LatexFileType,
             """
-            % Not a preamble option, so treat like usual           
+            <info descr="null">% Not a preamble option, so treat like usual</info>
             \begin{frame}
                 \only<1>{<info descr="null">${'$'}<info textAttributesKey=LATEX_INLINE_MATH>a_1${'$'}</info></info>}
             \end{frame}

--- a/test/resources/editor/folding/comments.tex
+++ b/test/resources/editor/folding/comments.tex
@@ -1,0 +1,9 @@
+<fold text='% First ...'>% First comment
+% Second comment</fold>
+
+Text.
+<fold text='% First ...'>% First comment
+
+% Second comment after newline</fold>
+Text.
+% Single comment

--- a/test/resources/editor/folding/comments.tex
+++ b/test/resources/editor/folding/comments.tex
@@ -6,4 +6,4 @@ Text.
 
 % Second comment after newline</fold>
 Text.
-% Single comment
+<fold text='% Single...'>% Single comment</fold>


### PR DESCRIPTION
Fix #2965 
Fix #2963 

#### Summary of additions and changes

* Added a folder for comments

This works by pulling all of the comments and all of the whitespaces. 

Then, it fuses adjacent whitespace ranges (not sure if required), then it finds each comment and attempts to find a whitespace that fully connects the comment block to another comment block. 

If so, it will increment the fold range to include the separating whitespace and the following comment and continue until there is not a continuous whitespace or no more comments.

#### How to test this pull request

```latex
% This is a
% block of comment
```

use ctrl + - to collapse the block (windows keybind, may be different for others)