### PR TITLE
Avoid expensive file set checks in run configuration process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@
 
 ### Fixed
 
+## [0.7.28-alpha.3] - 2023-03-25
+
+### Added
+* Add custom highlighting for user-defined commands
+* Add setting to configure default folding of imports
+* Add \newminted code blocks as verbatim environments
+
+### Fixed
+* Improve file set cache to fix exception #2903
+* Fix exception #2950
+* Disable obsolete LatexBibinputsRelativePathInspection
+* Fix bug when resolving \subimport
+
 ## [0.7.28-alpha.1] - 2023-03-11
 
 ### Added
@@ -82,8 +95,9 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Fix some intention previews. ([#2796](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2796))
 * Other small bug fixes and improvements. ([#2776](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2776), [#2774](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2774), [#2765](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2765)-[#2773](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2773))
 
-[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.28-alpha.1...HEAD
+[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.28-alpha.3...HEAD
 [0.7.28-alpha.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.27...v0.7.28-alpha.1
+[0.7.28-alpha.3]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.28-alpha.1...v0.7.28-alpha.3
 [0.7.27]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.27-alpha.2...v0.7.27
 [0.7.27-alpha.2]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.26...v0.7.27-alpha.2
 [0.7.26]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.26-alpha.8...v0.7.26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## [0.7.28-alpha.3] - 2023-03-25
 
 ### Added
+* Improve run configuration performance for TeX Live
 * Add custom highlighting for user-defined commands
 * Add setting to configure default folding of imports
 * Add \newminted code blocks as verbatim environments

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("se.patrikerdes.use-latest-versions") version "0.2.18"
 
     // Used to debug in a different IDE
-    id("de.undercouch.download") version "5.3.1"
+    id("de.undercouch.download") version "5.4.0"
 
     // Test coverage
     id("org.jetbrains.kotlinx.kover") version "0.7.0-ALPHA"
@@ -27,7 +27,7 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "10.3.0"
 
     // Vulnerability scanning
-    id("org.owasp.dependencycheck") version "8.1.2"
+    id("org.owasp.dependencycheck") version "8.2.1"
 
     id("org.jetbrains.changelog") version "2.0.0"
 }
@@ -78,20 +78,20 @@ dependencies {
 
     // D-Bus Java bindings
     implementation("com.github.hypfvieh:dbus-java:3.3.2")
-    implementation("org.slf4j:slf4j-simple:2.0.6")
+    implementation("org.slf4j:slf4j-simple:2.0.7")
 
     // Unzipping tar.xz/tar.bz2 files on Windows containing dtx files
     implementation("org.codehaus.plexus:plexus-component-api:1.0-alpha-33")
     implementation("org.codehaus.plexus:plexus-container-default:2.1.1")
-    implementation("org.codehaus.plexus:plexus-archiver:4.6.2")
+    implementation("org.codehaus.plexus:plexus-archiver:4.6.3")
 
     // Parsing json
     implementation("com.beust:klaxon:5.6")
 
     // Parsing xml
-    implementation("com.fasterxml.jackson.core:jackson-core:2.14.2")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.14.2")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2")
+    implementation("com.fasterxml.jackson.core:jackson-core:2.15.0-rc1")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.0-rc1")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.0-rc1")
 
     // Http requests
     implementation("io.ktor:ktor-client-core:2.2.4")
@@ -103,7 +103,7 @@ dependencies {
     implementation("io.ktor:ktor-serialization-kotlinx-json:2.2.4")
 
     // Comparing versions
-    implementation("org.apache.maven:maven-artifact:4.0.0-alpha-4")
+    implementation("org.apache.maven:maven-artifact:4.0.0-alpha-5")
 
     // LaTeX rendering for preview
     implementation("org.scilab.forge:jlatexmath:1.0.7")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,9 +89,9 @@ dependencies {
     implementation("com.beust:klaxon:5.6")
 
     // Parsing xml
-    implementation("com.fasterxml.jackson.core:jackson-core:2.15.0-rc1")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.0-rc1")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.0-rc1")
+    implementation("com.fasterxml.jackson.core:jackson-core:2.14.2")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.14.2")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2")
 
     // Http requests
     implementation("io.ktor:ktor-client-core:2.2.4")
@@ -249,6 +249,20 @@ ktlint {
 
 tasks.jar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+// https://github.com/ben-manes/gradle-versions-plugin
+fun isNonStable(version: String): Boolean {
+    val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.toUpperCase().contains(it) }
+    val regex = "^[0-9,.v-]+(-r)?$".toRegex()
+    val isStable = stableKeyword || regex.matches(version)
+    return isStable.not()
+}
+
+tasks.dependencyUpdates {
+    rejectVersionIf {
+        isNonStable(candidate.version)
+    }
 }
 
 tasks.useLatestVersions {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.7.28-alpha.1
+pluginVersion = 0.7.28-alpha.3
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/run/FileCleanupListener.kt
+++ b/src/nl/hannahsten/texifyidea/run/FileCleanupListener.kt
@@ -10,8 +10,11 @@ import java.io.File
 
 /**
  * Clean up given files after the process is done.
+ *
+ * @param filesToCleanUp Delete these files.
+ * @param filesToCleanUpIfEmpty Delete these files only if they are an empty directory.
  */
-class FileCleanupListener(private val filesToCleanUp: MutableList<File>) : ProcessListener {
+class FileCleanupListener(private val filesToCleanUp: MutableList<File>, private val filesToCleanUpIfEmpty: Set<File> = setOf()) : ProcessListener {
 
     override fun startNotified(event: ProcessEvent) {
     }
@@ -26,6 +29,13 @@ class FileCleanupListener(private val filesToCleanUp: MutableList<File>) : Proce
             }
         }
         filesToCleanUp.clear()
+
+        // Make sure to delete children first, so that we also delete directories containing only directories
+        for (file in filesToCleanUpIfEmpty.sortedDescending()) {
+            if (file.isDirectory && file.list()?.isEmpty() == true) {
+                file.delete()
+            }
+        }
     }
 
     override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexCommandLineState.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexCommandLineState.kt
@@ -62,8 +62,11 @@ open class LatexCommandLineState(environment: ExecutionEnvironment, private val 
             )
         }
 
-        if (!runConfig.getLatexDistributionType().isMiktex(runConfig.project)) {
+        val createdOutputDirectories = if (!runConfig.getLatexDistributionType().isMiktex(runConfig.project)) {
             runConfig.outputPath.updateOutputSubDirs()
+        }
+        else {
+            setOf()
         }
 
         val handler = createHandler(mainFile, compiler)
@@ -74,7 +77,7 @@ open class LatexCommandLineState(environment: ExecutionEnvironment, private val 
         if (!isLastCompile(isMakeindexNeeded, handler)) return handler
         scheduleBibtexRunIfNeeded(handler)
         schedulePdfViewerIfNeeded(handler)
-        scheduleFileCleanup(runConfig.filesToCleanUp, handler)
+        scheduleFileCleanup(runConfig.filesToCleanUp, createdOutputDirectories, handler)
 
         return handler
     }
@@ -214,9 +217,9 @@ open class LatexCommandLineState(environment: ExecutionEnvironment, private val 
         }
     }
 
-    private fun scheduleFileCleanup(filesToCleanUp: MutableList<File>, handler: KillableProcessHandler) {
+    private fun scheduleFileCleanup(filesToCleanUp: MutableList<File>, filesToCleanUpIfEmpty: Set<File>, handler: KillableProcessHandler) {
         if (runConfig.isLastRunConfig) {
-            handler.addProcessListener(FileCleanupListener(filesToCleanUp))
+            handler.addProcessListener(FileCleanupListener(filesToCleanUp, filesToCleanUpIfEmpty))
         }
     }
 

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexOutputPath.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexOutputPath.kt
@@ -159,7 +159,7 @@ class LatexOutputPath(private val variant: String, var contentRoot: VirtualFile?
             }
             .forEach {
                 val file = File(outPath + it)
-                if(file.mkdirs()) {
+                if (file.mkdirs()) {
                     createdDirectories.add(file)
                 }
             }

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexOutputPath.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexOutputPath.kt
@@ -4,17 +4,12 @@ import com.intellij.execution.ExecutionException
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.runReadAction
-import com.intellij.openapi.project.IndexNotReadyException
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.settings.sdk.LatexSdkUtil
-import nl.hannahsten.texifyidea.util.files.FileUtil
-import nl.hannahsten.texifyidea.util.files.createExcludedDir
-import nl.hannahsten.texifyidea.util.files.psiFile
-import nl.hannahsten.texifyidea.util.files.referencedFileSet
+import nl.hannahsten.texifyidea.util.files.*
 import java.io.File
 
 /**
@@ -142,24 +137,33 @@ class LatexOutputPath(private val variant: String, var contentRoot: VirtualFile?
     }
 
     /**
-     * Copy subdirectories of the source directory to the output directory for includes to work in non-MiKTeX systems
+     * Copy subdirectories of the source directory to the output directory for includes to work in non-MiKTeX systems.
+     *
+     * @return Set of directories that were created and did not exist already.
      */
     @Throws(ExecutionException::class)
-    fun updateOutputSubDirs() {
+    fun updateOutputSubDirs(): Set<File> {
         val includeRoot = mainFile?.parent
-        val outPath = virtualFile?.path ?: return
+        val outPath = virtualFile?.path ?: return emptySet()
 
-        val files: Set<PsiFile>
-        try {
-            files = mainFile?.psiFile(project)?.referencedFileSet() ?: emptySet()
-        }
-        catch (e: IndexNotReadyException) {
-            throw ExecutionException("Please wait until the indices are built.", e)
-        }
+        // We cannot take the time to figure out the file set at this point, because it would take too long (up to 30 seconds for large projects).
+        // However, we really want the most up-to-date directory structure from the source, because compilation would fail if we miss a subdirectory, so we cannot just do this once when generating the run configuration.
+        // Therefore, creating a superset of the directories we need is probably best we can do (and maybe clean them up later)
+        val files: Set<VirtualFile> = includeRoot?.allChildDirectories() ?: emptySet()
+        val createdDirectories = mutableSetOf<File>()
 
         // Create output paths (see issue #70 on GitHub)
         files.asSequence()
-            .mapNotNull { FileUtil.pathRelativeTo(includeRoot?.path ?: return@mapNotNull null, it.virtualFile.parent.path) }
-            .forEach { File(outPath + it).mkdirs() }
+            .mapNotNull {
+                FileUtil.pathRelativeTo(includeRoot?.path ?: return@mapNotNull null, it.path)
+            }
+            .forEach {
+                val file = File(outPath + it)
+                if(file.mkdirs()) {
+                    createdDirectories.add(file)
+                }
+            }
+
+        return createdDirectories
     }
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2968

#### Summary of additions and changes

* Instead of only creating empty output directories for directories in the file set, to improve performance we now create all subdirectories of the source root. 
* Bonus: after compilation, we delete any unnecessary empty directories

#### How to test this pull request

Use pdflatex on TeX Live