### PR TITLE
Support @Comment comments in bibtex

### DIFF
--- a/gen/nl/hannahsten/texifyidea/grammar/BibtexLexer.java
+++ b/gen/nl/hannahsten/texifyidea/grammar/BibtexLexer.java
@@ -37,8 +37,10 @@ public class BibtexLexer implements FlexLexer {
   public static final int XXBRACED_STRING = 16;
   public static final int XXPREAMBLE = 18;
   public static final int XXPREAMBLE_STRING = 20;
-  public static final int XXQUOTED_VERBATIM = 22;
-  public static final int XXBRACED_VERBATIM = 24;
+  public static final int XXCOMMENT = 22;
+  public static final int XXCOMMENT_STRING = 24;
+  public static final int XXQUOTED_VERBATIM = 26;
+  public static final int XXBRACED_VERBATIM = 28;
 
   /**
    * ZZ_LEXSTATE[l] is the state in the DFA for the lexical state l
@@ -48,7 +50,7 @@ public class BibtexLexer implements FlexLexer {
    */
   private static final int ZZ_LEXSTATE[] = { 
      0,  0,  1,  1,  2,  2,  3,  3,  4,  4,  5,  5,  6,  6,  7,  7, 
-     8,  8,  9,  9, 10, 10, 11, 11, 12, 12
+     8,  8,  9,  9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14
   };
 
   /** 
@@ -81,14 +83,15 @@ public class BibtexLexer implements FlexLexer {
   private static final int [] ZZ_ACTION = zzUnpackAction();
 
   private static final String ZZ_ACTION_PACKED_0 =
-    "\15\0\1\1\1\2\1\1\1\3\1\4\1\5\2\6"+
+    "\17\0\1\1\1\2\1\1\1\3\1\4\1\5\2\6"+
     "\1\7\1\10\1\11\1\12\1\13\1\14\1\15\1\6"+
     "\1\16\2\17\1\20\1\21\1\22\1\23\1\24\1\25"+
     "\1\3\1\24\1\26\2\24\1\27\1\30\1\3\1\31"+
-    "\1\32\1\33\1\34\1\35\1\36\1\6\1\3\1\37";
+    "\1\32\1\33\1\3\1\34\1\35\1\36\1\37\1\40"+
+    "\1\6\1\3\1\41";
 
   private static int [] zzUnpackAction() {
-    int [] result = new int[55];
+    int [] result = new int[60];
     int offset = 0;
     offset = zzUnpackAction(ZZ_ACTION_PACKED_0, offset, result);
     return result;
@@ -115,14 +118,15 @@ public class BibtexLexer implements FlexLexer {
   private static final String ZZ_ROWMAP_PACKED_0 =
     "\0\0\0\27\0\56\0\105\0\134\0\163\0\212\0\241"+
     "\0\270\0\317\0\346\0\375\0\u0114\0\u012b\0\u0142\0\u0159"+
-    "\0\u0170\0\u012b\0\u012b\0\u0187\0\u019e\0\u012b\0\u012b\0\u012b"+
-    "\0\u012b\0\u012b\0\u012b\0\u012b\0\u01b5\0\u01cc\0\u01e3\0\u01fa"+
-    "\0\u012b\0\u012b\0\u012b\0\u012b\0\u0211\0\u012b\0\u0228\0\u023f"+
-    "\0\u012b\0\u0256\0\u026d\0\u012b\0\u012b\0\u0284\0\u012b\0\u012b"+
-    "\0\u012b\0\u012b\0\u012b\0\u0159\0\u029b\0\u02b2\0\u0187";
+    "\0\u0170\0\u0187\0\u019e\0\u0159\0\u0159\0\u01b5\0\u01cc\0\u0159"+
+    "\0\u0159\0\u0159\0\u0159\0\u0159\0\u0159\0\u0159\0\u01e3\0\u01fa"+
+    "\0\u0211\0\u0228\0\u0159\0\u0159\0\u0159\0\u0159\0\u023f\0\u0159"+
+    "\0\u0256\0\u026d\0\u0159\0\u0284\0\u029b\0\u0159\0\u0159\0\u02b2"+
+    "\0\u0159\0\u0159\0\u0159\0\u0159\0\u0159\0\u0159\0\u0159\0\u0159"+
+    "\0\u0187\0\u02c9\0\u02e0\0\u01b5";
 
   private static int [] zzUnpackRowMap() {
-    int [] result = new int[55];
+    int [] result = new int[60];
     int offset = 0;
     offset = zzUnpackRowMap(ZZ_ROWMAP_PACKED_0, offset, result);
     return result;
@@ -145,38 +149,39 @@ public class BibtexLexer implements FlexLexer {
   private static final int [] ZZ_TRANS = zzUnpackTrans();
 
   private static final String ZZ_TRANS_PACKED_0 =
-    "\1\16\3\17\10\16\1\20\1\16\1\21\1\16\1\17"+
-    "\5\16\2\22\3\17\1\23\11\22\1\21\1\22\1\17"+
-    "\6\22\1\24\2\25\1\17\1\26\1\27\1\22\1\30"+
-    "\1\31\1\32\1\33\1\34\2\24\1\21\1\22\1\17"+
-    "\1\35\2\24\1\36\1\22\1\24\1\37\2\40\1\17"+
-    "\10\22\2\37\1\21\1\22\1\17\4\37\1\22\1\37"+
-    "\1\16\3\17\4\16\1\41\3\16\1\20\1\16\1\21"+
-    "\1\16\1\17\5\16\1\22\1\24\2\25\1\17\1\42"+
-    "\1\27\1\43\1\30\1\22\1\32\1\22\1\44\2\24"+
-    "\1\21\1\22\1\17\4\24\1\22\1\24\13\45\1\46"+
-    "\2\45\1\47\6\45\1\50\14\45\1\51\2\45\1\47"+
-    "\6\45\1\50\1\45\1\52\3\53\1\54\1\55\10\52"+
-    "\1\56\1\52\1\17\6\52\1\24\2\25\1\17\1\42"+
-    "\1\27\4\22\1\33\1\57\2\24\1\21\1\22\1\17"+
-    "\3\24\1\36\1\22\1\24\13\45\1\60\2\45\1\47"+
-    "\6\45\1\50\1\45\13\61\1\62\20\61\1\63\21\61"+
-    "\30\0\3\17\14\0\1\17\23\0\1\64\3\0\3\64"+
-    "\3\0\2\21\2\0\23\21\3\24\11\0\2\24\3\0"+
-    "\4\24\1\0\2\24\2\25\1\17\10\0\2\24\2\0"+
-    "\1\17\4\24\1\0\4\24\11\0\2\24\3\0\1\24"+
-    "\1\65\2\24\1\0\4\24\11\0\2\24\3\0\3\24"+
-    "\1\36\1\0\1\24\3\37\11\0\2\37\3\0\4\37"+
-    "\1\0\2\37\2\40\1\17\10\0\2\37\2\0\1\17"+
-    "\4\37\1\0\1\37\13\45\1\0\11\45\1\50\1\45"+
-    "\2\47\2\45\7\47\1\21\11\47\1\66\1\47\25\45"+
-    "\1\50\1\45\4\52\2\0\12\52\1\0\7\52\3\53"+
-    "\2\0\12\52\1\17\6\52\2\56\2\52\2\21\12\56"+
-    "\1\21\6\56\3\24\11\0\2\24\3\0\2\24\1\67"+
-    "\1\24\1\0\1\24\2\47\2\45\21\47\1\66\1\47";
+    "\1\20\3\21\10\20\1\22\1\20\1\23\1\20\1\21"+
+    "\5\20\2\24\3\21\1\25\11\24\1\23\1\24\1\21"+
+    "\6\24\1\26\2\27\1\21\1\30\1\31\1\24\1\32"+
+    "\1\33\1\34\1\35\1\36\2\26\1\23\1\24\1\21"+
+    "\1\37\2\26\1\40\1\24\1\26\1\41\2\42\1\21"+
+    "\10\24\2\41\1\23\1\24\1\21\4\41\1\24\1\41"+
+    "\1\20\3\21\4\20\1\43\3\20\1\22\1\20\1\23"+
+    "\1\20\1\21\5\20\1\24\1\26\2\27\1\21\1\44"+
+    "\1\31\1\45\1\32\1\24\1\34\1\24\1\46\2\26"+
+    "\1\23\1\24\1\21\4\26\1\24\1\26\13\47\1\50"+
+    "\2\47\1\51\6\47\1\52\14\47\1\53\2\47\1\51"+
+    "\6\47\1\52\1\47\1\54\3\55\1\56\1\57\10\54"+
+    "\1\60\1\54\1\21\6\54\1\26\2\27\1\21\1\44"+
+    "\1\31\4\24\1\35\1\61\2\26\1\23\1\24\1\21"+
+    "\3\26\1\40\1\24\1\26\13\47\1\62\2\47\1\51"+
+    "\6\47\1\52\1\47\4\0\1\63\22\0\5\64\1\65"+
+    "\21\64\13\66\1\67\20\66\1\70\21\66\30\0\3\21"+
+    "\14\0\1\21\23\0\1\71\3\0\3\71\3\0\2\23"+
+    "\2\0\23\23\3\26\11\0\2\26\3\0\4\26\1\0"+
+    "\2\26\2\27\1\21\10\0\2\26\2\0\1\21\4\26"+
+    "\1\0\4\26\11\0\2\26\3\0\1\26\1\72\2\26"+
+    "\1\0\4\26\11\0\2\26\3\0\3\26\1\40\1\0"+
+    "\1\26\3\41\11\0\2\41\3\0\4\41\1\0\2\41"+
+    "\2\42\1\21\10\0\2\41\2\0\1\21\4\41\1\0"+
+    "\1\41\13\47\1\0\11\47\1\52\1\47\2\51\2\47"+
+    "\7\51\1\23\11\51\1\73\1\51\25\47\1\52\1\47"+
+    "\4\54\2\0\12\54\1\0\7\54\3\55\2\0\12\54"+
+    "\1\21\6\54\2\60\2\54\2\23\12\60\1\23\6\60"+
+    "\3\26\11\0\2\26\3\0\2\26\1\74\1\26\1\0"+
+    "\1\26\2\51\2\47\21\51\1\73\1\51";
 
   private static int [] zzUnpackTrans() {
-    int [] result = new int[713];
+    int [] result = new int[759];
     int offset = 0;
     offset = zzUnpackTrans(ZZ_TRANS_PACKED_0, offset, result);
     return result;
@@ -214,12 +219,12 @@ public class BibtexLexer implements FlexLexer {
   private static final int [] ZZ_ATTRIBUTE = zzUnpackAttribute();
 
   private static final String ZZ_ATTRIBUTE_PACKED_0 =
-    "\15\0\1\11\3\1\2\11\2\1\7\11\4\1\4\11"+
-    "\1\1\1\11\2\1\1\11\2\1\2\11\1\1\5\11"+
+    "\17\0\1\11\3\1\2\11\2\1\7\11\4\1\4\11"+
+    "\1\1\1\11\2\1\1\11\2\1\2\11\1\1\10\11"+
     "\4\1";
 
   private static int [] zzUnpackAttribute() {
-    int [] result = new int[55];
+    int [] result = new int[60];
     int offset = 0;
     offset = zzUnpackAttribute(ZZ_ATTRIBUTE_PACKED_0, offset, result);
     return result;
@@ -552,117 +557,117 @@ public class BibtexLexer implements FlexLexer {
             { yybegin(YYINITIAL); return COMMENT_TOKEN;
             } 
             // fall through
-          case 32: break;
+          case 34: break;
           case 2: 
             { return WHITE_SPACE;
             } 
             // fall through
-          case 33: break;
+          case 35: break;
           case 3: 
             { return COMMENT_TOKEN;
             } 
             // fall through
-          case 34: break;
+          case 36: break;
           case 4: 
             { return BAD_CHARACTER;
             } 
             // fall through
-          case 35: break;
+          case 37: break;
           case 5: 
             { yybegin(XXENTRYIDENTIFIER); return OPEN_BRACE;
             } 
             // fall through
-          case 36: break;
+          case 38: break;
           case 6: 
             { return IDENTIFIER;
             } 
             // fall through
-          case 37: break;
+          case 39: break;
           case 7: 
             { if (verbatim) yypushState(XXBRACED_VERBATIM); else yybegin(XXBRACED_STRING); return OPEN_BRACE;
             } 
             // fall through
-          case 38: break;
+          case 40: break;
           case 8: 
             { yybegin(XXAFTERENTRY); return CLOSE_BRACE;
             } 
             // fall through
-          case 39: break;
+          case 41: break;
           case 9: 
             { yybegin(XXAFTERENTRY); return CLOSE_PARENTHESIS;
             } 
             // fall through
-          case 40: break;
+          case 42: break;
           case 10: 
             { return SEPARATOR;
             } 
             // fall through
-          case 41: break;
+          case 43: break;
           case 11: 
             { return ASSIGNMENT;
             } 
             // fall through
-          case 42: break;
+          case 44: break;
           case 12: 
             { return CONCATENATE;
             } 
             // fall through
-          case 43: break;
+          case 45: break;
           case 13: 
             { if (verbatim) yypushState(XXQUOTED_VERBATIM); else yybegin(XXQUOTED_STRING); return QUOTES;
             } 
             // fall through
-          case 44: break;
+          case 46: break;
           case 14: 
             { return NUMBER;
             } 
             // fall through
-          case 45: break;
+          case 47: break;
           case 15: 
             { yybegin(XXENTRY); return IDENTIFIER;
             } 
             // fall through
-          case 46: break;
+          case 48: break;
           case 16: 
             { yybegin(YYINITIAL); return SEPARATOR;
             } 
             // fall through
-          case 47: break;
+          case 49: break;
           case 17: 
             { return OPEN_BRACE;
             } 
             // fall through
-          case 48: break;
+          case 50: break;
           case 18: 
             { return OPEN_PARENTHESIS;
             } 
             // fall through
-          case 49: break;
+          case 51: break;
           case 19: 
             { yybegin(XXQUOTED_STRINGDEF); return QUOTES;
             } 
             // fall through
-          case 50: break;
+          case 52: break;
           case 20: 
             { return NORMAL_TEXT_WORD;
             } 
             // fall through
-          case 51: break;
+          case 53: break;
           case 21: 
             { yybegin(XXENTRY); return END_QUOTES;
             } 
             // fall through
-          case 52: break;
+          case 54: break;
           case 22: 
             { yybegin(XXSTRINGDEF); return END_QUOTES;
             } 
             // fall through
-          case 53: break;
+          case 55: break;
           case 23: 
             { braceCount++; return NORMAL_TEXT_WORD;
             } 
             // fall through
-          case 54: break;
+          case 56: break;
           case 24: 
             { if (braceCount > 0) {
                                     braceCount--;
@@ -673,33 +678,43 @@ public class BibtexLexer implements FlexLexer {
                                   return CLOSE_BRACE;
             } 
             // fall through
-          case 55: break;
+          case 57: break;
           case 25: 
             { yybegin(XXPREAMBLE_STRING); return QUOTES;
             } 
             // fall through
-          case 56: break;
+          case 58: break;
           case 26: 
             { yybegin(XXPREAMBLE); return END_QUOTES;
             } 
             // fall through
-          case 57: break;
-          case 27: 
-            { return RAW_TEXT_TOKEN;
-            } 
-            // fall through
-          case 58: break;
-          case 28: 
-            { yypopState(); verbatim = false; return END_QUOTES;
-            } 
-            // fall through
           case 59: break;
-          case 29: 
-            { yypopState(); verbatim = false; return CLOSE_BRACE;
+          case 27: 
+            { yybegin(XXCOMMENT_STRING); return COMMENT_TOKEN;
             } 
             // fall through
           case 60: break;
+          case 28: 
+            { yybegin(XXAFTERENTRY); return COMMENT_TOKEN;
+            } 
+            // fall through
+          case 61: break;
+          case 29: 
+            { return RAW_TEXT_TOKEN;
+            } 
+            // fall through
+          case 62: break;
           case 30: 
+            { yypopState(); verbatim = false; return END_QUOTES;
+            } 
+            // fall through
+          case 63: break;
+          case 31: 
+            { yypopState(); verbatim = false; return CLOSE_BRACE;
+            } 
+            // fall through
+          case 64: break;
+          case 32: 
             { String sequence = yytext().toString();
                                   if ("@string".equalsIgnoreCase(sequence)) {
                                     yybegin(XXSTRINGDEF);
@@ -707,18 +722,22 @@ public class BibtexLexer implements FlexLexer {
                                   else if ("@preamble".equalsIgnoreCase(sequence)) {
                                     yybegin(XXPREAMBLE);
                                   }
+                                  else if ("@comment".equalsIgnoreCase(sequence)) {
+                                    yybegin(XXCOMMENT);
+                                    return COMMENT_TOKEN;
+                                  }
                                   else {
                                     yybegin(XXAFTERTYPETOKEN);
                                   }
                                   return TYPE_TOKEN;
             } 
             // fall through
-          case 61: break;
-          case 31: 
+          case 65: break;
+          case 33: 
             { verbatim = true; return VERBATIM_IDENTIFIER;
             } 
             // fall through
-          case 62: break;
+          case 66: break;
           default:
             zzScanError(ZZ_NO_MATCH);
           }

--- a/src/nl/hannahsten/texifyidea/grammar/BibtexLexer.flex
+++ b/src/nl/hannahsten/texifyidea/grammar/BibtexLexer.flex
@@ -69,6 +69,8 @@ ANY_CHAR=[^]
 %state XXPREAMBLE
 %state XXPREAMBLE_STRING
 
+%xstate XXCOMMENT
+%xstate XXCOMMENT_STRING
 %xstate XXQUOTED_VERBATIM
 %xstate XXBRACED_VERBATIM
 %%
@@ -86,6 +88,10 @@ ANY_CHAR=[^]
                                   else if ("@preamble".equalsIgnoreCase(sequence)) {
                                     yybegin(XXPREAMBLE);
                                   }
+                                  else if ("@comment".equalsIgnoreCase(sequence)) {
+                                    yybegin(XXCOMMENT);
+                                    return COMMENT_TOKEN;
+                                  }
                                   else {
                                     yybegin(XXAFTERTYPETOKEN);
                                   }
@@ -95,6 +101,15 @@ ANY_CHAR=[^]
 
 <XXAFTERTYPETOKEN> {
     {OPEN_BRACE}                { yybegin(XXENTRYIDENTIFIER); return OPEN_BRACE; }
+}
+
+<XXCOMMENT> {
+    {OPEN_BRACE}                { yybegin(XXCOMMENT_STRING); return COMMENT_TOKEN; }
+}
+
+<XXCOMMENT_STRING> {
+    {CLOSE_BRACE}               { yybegin(XXAFTERENTRY); return COMMENT_TOKEN; }
+    {ANY_CHAR}                  { return COMMENT_TOKEN; }
 }
 
 // Preamble: @preamble{ "some string" }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2970

#### Summary of additions and changes

* Lex `@Comment{...}` as `COMMENT_TOKEN`s in the bibtex lexer.

#### How to test this pull request

```bibtex
@Misc{Wikipedia2011,
    author = {Wikipedia},
    title = {Prolog --- Wikipedia{,} Die freie Enzyklopädie},
    note = {[Online; Stand 22. Oktober 2011]},
    url = {http://de.wikipedia.org/w/index.php?title=Prolog&oldid=94982334},
    year = {2011},
}

@Comment{jabref-meta: databaseType:biblatex;}
```

#### Wiki

<!-- Add link to updated wiki page -->
- [ ] Updated the wiki: