### PR TITLE
Update since version to 231

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginVersion = 0.7.28
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*
 #    means that the first possible build is the next branch number after xyz, so e.g.
 #    a since build of 173.* is equal to 181
-pluginSinceBuild = 223
+pluginSinceBuild = 231
 
 # Token for releasing to Jetbrains using the Gradle intellij/publishPlugin task, for more information see the Gradle build file.
 intellijPublishToken=mytoken


### PR DESCRIPTION
Fix #2992 
The ProjectActivity class, which replaced StartupActivity deprecated in 231, is apparently not present in IDEA 223.
The inspection that usually warns for this, didn't do its work this time.
