### PR TITLE
Generate preview for unicode inspection, fixes #3008

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+* Add inspection preview for the unicode inspection.
 
 ### Fixed
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspection.kt
@@ -204,12 +204,14 @@ class LatexUnicodeInspection : TexifyInspectionBase() {
             }
 
             // Fill in replacement
+            // To improve this, this should be done by replacing psi elements using LatexPsiHelper
             val range = descriptor.textRangeInElement.shiftRight(element.textOffset)
             document?.replaceString(range.startOffset, range.endOffset, replacement)
         }
 
         /**
          * Extend the heuristics implemented in [LocalQuickFix.generatePreview] that predict that the fix can not be applied.
+         * We cannot use the automatically generated preview because in the applyFix we sometimes show a UI element, which breaks the preview
          */
         override fun generatePreview(project: Project, previewDescriptor: ProblemDescriptor): IntentionPreviewInfo {
             val replacement = getReplacementFromProblemDescriptor(previewDescriptor) ?: return IntentionPreviewInfo.EMPTY

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspection.kt
@@ -208,12 +208,11 @@ class LatexUnicodeInspection : TexifyInspectionBase() {
         }
 
         /**
-         * Generate the preview info explicitly because [HintManager.showErrorHint] crashes when called from the preview
-         * editor. We only perform the same check here that triggers the hint to be shown when attempting to apply the fix.
+         * Extend the heuristics implemented in [LocalQuickFix.generatePreview] that predict that the fix can not be applied.
          */
         override fun generatePreview(project: Project, previewDescriptor: ProblemDescriptor): IntentionPreviewInfo {
             val replacement = getReplacementFromProblemDescriptor(previewDescriptor)
-            return if (replacement == null) IntentionPreviewInfo.EMPTY else IntentionPreviewInfo.DIFF
+            return if (replacement == null) IntentionPreviewInfo.EMPTY else super.generatePreview(project, previewDescriptor)
         }
 
         private fun getReplacementFromProblemDescriptor(descriptor: ProblemDescriptor): String? {


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3008 

#### Summary of additions and changes

* Explicitly generate the preview of the fix, because the `applyFix` uses `showErrorHint` which crashes when called from the preview editor but by default `applyFix` is used to generate the preview.

#### How to test this pull request

```latex
$3x^2 Ξ A$
$¨ A$
```

Use <kbd>Alt</kbd> + <kbd>Enter</kbd> on the inspection. This used to give an exception while loading the preview.

![image](https://user-images.githubusercontent.com/15669080/234775848-c477b564-e1ab-45eb-b582-e614be33ba91.png)
