### PR TITLE
Detect and open user-installed SumatraPDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 * Add inspection preview for the unicode inspection.
+* Add partial support for detecting non-global installations of SumatraPDF.
 
 ### Fixed
 

--- a/resources/nl/hannahsten/texifyidea/ipsum/texify.txt
+++ b/resources/nl/hannahsten/texifyidea/ipsum/texify.txt
@@ -3,7 +3,7 @@ NOUN_SINGULAR
 accident
 age
 algorithm
-anwser
+answer
 apartment
 appearance
 apple
@@ -226,7 +226,7 @@ NOUN_PLURAL
 activities
 agencies
 algorithms
-anwsers
+answers
 appearances
 appearances
 applications
@@ -570,7 +570,7 @@ INFINITIVE
 accept
 add
 analyze
-anwser
+answer
 appear
 append
 apply
@@ -696,7 +696,7 @@ preach
 pretend
 prevent
 prick
-procede
+proceed
 produce
 program
 protect
@@ -757,7 +757,7 @@ write
 accepts
 adds
 analyzes
-anwsers
+answers
 appears
 appends
 applies
@@ -881,7 +881,7 @@ preaches
 pretends
 prevents
 pricks
-procedes
+proceeds
 produces
 programs
 protects
@@ -940,7 +940,7 @@ writes
 PAST_PARTICIPLE
 accepted
 analyzed
-anwsered
+answered
 appeared
 appended
 applied
@@ -984,7 +984,6 @@ flown
 focused
 followed
 found
-found
 given
 helped
 impacted
@@ -1003,13 +1002,12 @@ objected
 observed
 penalized
 performed
-proceded
+proceeded
 produced
 provided
 referenced
 refined
 rejected
-related
 related
 reported
 resolved
@@ -1036,7 +1034,7 @@ written
 PRESENT_PARTICIPLE
 accepting
 analyzing
-anwsering
+answering
 appearing
 applying
 asking
@@ -1102,7 +1100,7 @@ painting
 penalizing
 performing
 postponing
-proceding
+proceeding
 producing
 providing
 referencing
@@ -1151,7 +1149,7 @@ calculated
 change
 clear
 cloudy
-comative
+combative
 comfortable
 compelling
 complex
@@ -1174,7 +1172,7 @@ expected
 fabulous
 fascinating
 fast
-feasable
+feasible
 filthy
 fine
 giant
@@ -1189,7 +1187,7 @@ implied
 important
 inbound
 inexpensive
-infeasable
+infeasible
 inspiring
 interesting
 intriguing
@@ -1229,7 +1227,7 @@ rhetorical
 riveting
 sad
 salt
-satisfyling
+satisfying
 selected
 significant
 silent
@@ -1274,7 +1272,6 @@ beautifully
 briefly
 calmly
 carefully
-clearly
 clearly
 coolly
 correctly
@@ -1327,7 +1324,6 @@ shyly
 significantly
 similarly
 somewhat
-specifically
 specifically
 speedily
 subjectively

--- a/src/nl/hannahsten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
@@ -47,7 +47,7 @@ open class ConfigureInverseSearchAction : AnAction(
 
                 val path = PathManager.getBinPath()
                 var name = ApplicationNamesInfo.getInstance().scriptName
-                val sumatraWorkingDir = SumatraAvailabilityChecker.getSumatraWorkingCustomDir()
+                val sumatraWorkingDir = SumatraAvailabilityChecker.sumatraDirectory
 
                 // If we can find a 64-bits Java, then we can start (the equivalent of) idea64.exe since that will use the 64-bits Java
                 // see issue 104 and https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/809
@@ -70,7 +70,7 @@ open class ConfigureInverseSearchAction : AnAction(
     }
 
     override fun update(e: AnActionEvent) {
-        e.presentation.isEnabledAndVisible = SumatraAvailabilityChecker.getSumatraAvailability()
+        e.presentation.isEnabledAndVisible = SumatraAvailabilityChecker.isSumatraAvailable
     }
 
     override fun getActionUpdateThread() = ActionUpdateThread.BGT

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexCommandLineState.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexCommandLineState.kt
@@ -260,7 +260,7 @@ open class LatexCommandLineState(environment: ExecutionEnvironment, private val 
         // Do nothing if the user selected that they do not want a viewer to open.
         else if (runConfig.pdfViewer == InternalPdfViewer.NONE) return
         // Sumatra does not support DVI
-        else if (((runConfig.pdfViewer == InternalPdfViewer.SUMATRA && SumatraAvailabilityChecker.getSumatraAvailability())) && runConfig.outputFormat == LatexCompiler.Format.PDF) {
+        else if (((runConfig.pdfViewer == InternalPdfViewer.SUMATRA && SumatraAvailabilityChecker.isSumatraAvailable)) && runConfig.outputFormat == LatexCompiler.Format.PDF) {
             // Open Sumatra after compilation & execute inverse search.
             handler.addProcessListener(SumatraForwardSearchListener(runConfig, environment))
         }

--- a/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/InternalPdfViewer.kt
+++ b/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/InternalPdfViewer.kt
@@ -39,7 +39,7 @@ enum class InternalPdfViewer(
             true
         }
         else if (SystemInfo.isWindows && this == SUMATRA) {
-            SumatraAvailabilityChecker.getSumatraAvailability()
+            SumatraAvailabilityChecker.isSumatraAvailable
         }
         // Only support Evince and Okular on Linux, although they can be installed on other systems like Mac.
         else if (SystemInfo.isLinux) {

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraAvailabilityChecker.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraAvailabilityChecker.kt
@@ -82,6 +82,18 @@ object SumatraAvailabilityChecker {
      * returns true if the Sumatra registry keys are registered or if Sumatra is in PATH.
      */
     private fun isSumatraInstalled(): Boolean {
+        // Try if Sumatra is in PATH
+        val guessedPaths = listOf(
+            null,
+            "${System.getenv("HOMEDRIVE")}${System.getenv("HOMEPATH")}AppData\\Local\\SumatraPDF",
+            "C:\\Users\\${System.getenv("USERNAME")}\\AppData\\Local\\SumatraPDF",
+        )
+        for (path in guessedPaths) {
+            if (isSumatraPathAvailable(sumatraCustomPath = path, assignNewAvailability = true).first) {
+                return true
+            }
+        }
+
         // Try some SumatraPDF registry keys
         // For some reason this first one isn't always present anymore, it used to be
         val paths = listOf(
@@ -91,7 +103,7 @@ object SumatraAvailabilityChecker {
         )
         for (path in paths) {
             if (runCommand("reg", "query", path, "/ve")?.startsWith("ERROR:") == false) {
-                // todo we still need to update the working directory?
+                // To improve this, we could also update the known installation directory so that we can open Sumatra automatically
                 return true
             }
         }
@@ -105,17 +117,6 @@ object SumatraAvailabilityChecker {
         //[HKEY_CURRENT_USER\Software\Classes\SumatraPDF.pdf\shell\open\command]
         //@="\"C:\\Users\\K\\AppData\\Local\\SumatraPDF\\SumatraPDF.exe\" \"%1\""
 
-        // Try if Sumatra is in PATH
-        val guessedPaths = listOf(
-            null,
-            "${System.getenv("HOMEDRIVE")}${System.getenv("HOMEPATH")}AppData\\Local\\SumatraPDF",
-            "C:\\Users\\${System.getenv("USERNAME")}\\AppData\\Local\\SumatraPDF",
-        )
-        for (path in guessedPaths) {
-            if (isSumatraPathAvailable(sumatraCustomPath = path, assignNewAvailability = true).first) {
-                return true
-            }
-        }
         return false
     }
 }

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraAvailabilityChecker.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraAvailabilityChecker.kt
@@ -108,14 +108,14 @@ object SumatraAvailabilityChecker {
             }
         }
 
-        //https://github.com/sumatrapdfreader/sumatrapdf/discussions/2855#discussioncomment-3336646
+        // https://github.com/sumatrapdfreader/sumatrapdf/discussions/2855#discussioncomment-3336646
 
         // We could also look at the values of the following reg keys to find the install path:
         // [HKEY_CURRENT_USER\Software\Classes\SumatraPDF.pdf\shell\open]
-        //"Icon"="C:\\Users\\K\\AppData\\Local\\SumatraPDF\\SumatraPDF.exe"
+        // "Icon"="C:\\Users\\K\\AppData\\Local\\SumatraPDF\\SumatraPDF.exe"
         //
-        //[HKEY_CURRENT_USER\Software\Classes\SumatraPDF.pdf\shell\open\command]
-        //@="\"C:\\Users\\K\\AppData\\Local\\SumatraPDF\\SumatraPDF.exe\" \"%1\""
+        // [HKEY_CURRENT_USER\Software\Classes\SumatraPDF.pdf\shell\open\command]
+        // @="\"C:\\Users\\K\\AppData\\Local\\SumatraPDF\\SumatraPDF.exe\" \"%1\""
 
         return false
     }

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraConversation.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraConversation.kt
@@ -41,7 +41,6 @@ object SumatraConversation : ViewerConversation() {
         catch (e: TeXception) {
             // Make sure Windows popup error doesn't appear and we will still open Sumatra
             if (SumatraAvailabilityChecker.isSumatraAvailable) {
-                // todo use install path
                 runCommandWithExitCode("cmd.exe", "/C", "start", "SumatraPDF", "-reuse-instance", pdfFilePath, workingDirectory = SumatraAvailabilityChecker.sumatraDirectory, nonBlocking = true)
             }
         }

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraConversation.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraConversation.kt
@@ -21,7 +21,7 @@ object SumatraConversation : ViewerConversation() {
     private var conversation: DDEClientConversation? = null
 
     private fun openConversation() {
-        if (SumatraAvailabilityChecker.getSumatraAvailability() && conversation == null) {
+        if (SumatraAvailabilityChecker.isSumatraAvailable && conversation == null) {
             try {
                 conversation = DDEClientConversation()
             }
@@ -39,9 +39,10 @@ object SumatraConversation : ViewerConversation() {
             execute("Open(\"$pdfFilePath\", ${newWindow.bit}, ${focus.bit}, ${forceRefresh.bit})")
         }
         catch (e: TeXception) {
-            // Added check when Sumatra doesn't exist (not a directory), so Windows popup error doesn't appear
-            if (SumatraAvailabilityChecker.getSumatraAvailability()) {
-                runCommandWithExitCode("cmd.exe", "/C", "start", "SumatraPDF", "-reuse-instance", pdfFilePath, workingDirectory = SumatraAvailabilityChecker.getSumatraWorkingCustomDir(), nonBlocking = true)
+            // Make sure Windows popup error doesn't appear and we will still open Sumatra
+            if (SumatraAvailabilityChecker.isSumatraAvailable) {
+                // todo use install path
+                runCommandWithExitCode("cmd.exe", "/C", "start", "SumatraPDF", "-reuse-instance", pdfFilePath, workingDirectory = SumatraAvailabilityChecker.sumatraDirectory, nonBlocking = true)
             }
         }
     }

--- a/src/nl/hannahsten/texifyidea/run/sumatra/SumatraForwardSearchListener.kt
+++ b/src/nl/hannahsten/texifyidea/run/sumatra/SumatraForwardSearchListener.kt
@@ -30,7 +30,7 @@ class SumatraForwardSearchListener(
 
     override fun processTerminated(event: ProcessEvent) {
         // First check if the user provided a custom path to SumatraPDF, if not, check if it is installed
-        if (event.exitCode == 0 && SumatraAvailabilityChecker.getSumatraAvailability()) {
+        if (event.exitCode == 0 && SumatraAvailabilityChecker.isSumatraAvailable) {
             try {
                 SumatraConversation.openFile(runConfig.outputFilePath)
             }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->


#### Summary of additions and changes

* Until now, we only detect installs "for all users" of Sumatra. Now installs "for this user only" will also be detected by guessing the installation path. Sumatra will be opened after compilation, but forward/inverse search is not supported.

I cannot test it right now, so good luck to Windows users.

