### PR TITLE
Various code improvements

### DIFF
--- a/resources/META-INF/extensions/files-and-project.xml
+++ b/resources/META-INF/extensions/files-and-project.xml
@@ -1,6 +1,6 @@
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
-        <moduleType id="LATEX_MODULE_TYPE" implementationClass="nl.hannahsten.texifyidea.modules.LatexModuleType"/>
+        <moduleBuilder builderClass="nl.hannahsten.texifyidea.modules.LatexModuleBuilder" />
         <!-- The fieldName="INSTANCE" is required since 2021.2, if not present then all tests relying on automatic file type detection based on file name will fail if run all together via gradle check, and succeed when run a single test at a time,  -->
         <fileType implementationClass="nl.hannahsten.texifyidea.file.LatexFileType" name="LaTeX source file" language="Latex" extensions="tex;glstex" fieldName="INSTANCE" />
         <fileType implementationClass="nl.hannahsten.texifyidea.file.StyleFileType" name="LaTeX style file" language="Latex" extensions="sty;dbx;bbx;cbx" fieldName="INSTANCE" /> <!-- dbx is a Biblatex Data Model, bbx a Biblatex Style -->

--- a/src/nl/hannahsten/texifyidea/action/analysis/WordCountAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/analysis/WordCountAction.kt
@@ -275,10 +275,6 @@ open class WordCountAction : AnAction(
     private fun isWrongCommand(word: PsiElement): Boolean {
         val command = word.grandparent(7) as? LatexCommands ?: return false
 
-        if (IGNORE_COMMANDS.contains(command.name)) {
-            return true
-        }
-
-        return false
+        return IGNORE_COMMANDS.contains(command.name)
     }
 }

--- a/src/nl/hannahsten/texifyidea/algorithm/BFS.kt
+++ b/src/nl/hannahsten/texifyidea/algorithm/BFS.kt
@@ -222,7 +222,7 @@ class BFS<N>(startNode: N, private val adjacencyFunction: (N) -> List<N>, endNod
      *
      * @author Hannah Schellekens, Dylan ter Veen
      */
-    private inner class BFSNode constructor(
+    private inner class BFSNode(
         /**
          * The original version of the node.
          */

--- a/src/nl/hannahsten/texifyidea/completion/LatexXColorProvider.kt
+++ b/src/nl/hannahsten/texifyidea/completion/LatexXColorProvider.kt
@@ -42,7 +42,7 @@ object LatexXColorProvider : CompletionProvider<CompletionParameters>() {
             }
 
             val colorName = cmd.getRequiredArgumentValueByName("name") ?: continue
-            val color = LatexElementColorProvider.findColor(colorName, file)
+            val color = LatexElementColorProvider().findColor(colorName, file)
             val lookupElement = if (color != null) {
                 LookupElementBuilder.create(colorName).withIcon(ColorIcon(12, color))
             }

--- a/src/nl/hannahsten/texifyidea/editor/postfix/LatexPostFixTemplateProvider.kt
+++ b/src/nl/hannahsten/texifyidea/editor/postfix/LatexPostFixTemplateProvider.kt
@@ -6,7 +6,7 @@ import com.intellij.codeInsight.template.postfix.templates.PostfixTemplateProvid
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiFile
 
-object LatexPostFixTemplateProvider : PostfixTemplateProvider, CompletionContributor() {
+class LatexPostFixTemplateProvider : PostfixTemplateProvider, CompletionContributor() {
 
     private val templates = mutableSetOf<PostfixTemplate>(
         LatexWrapWithGroupPostfixTemplate,

--- a/src/nl/hannahsten/texifyidea/editor/postfix/LatexPostfixTemplateFromPackageProvider.kt
+++ b/src/nl/hannahsten/texifyidea/editor/postfix/LatexPostfixTemplateFromPackageProvider.kt
@@ -26,30 +26,30 @@ abstract class LatexPostfixTemplateFromPackageProvider(private val pack: LatexPa
 
         fun getProvider(pack: LatexPackage?): PostfixTemplateProvider {
             return when (pack) {
-                LatexPackage.AMSMATH -> LatexPostfixTemplateFromAmsMathProvider
-                LatexPackage.AMSFONTS -> LatexPostfixTemplateFromAmsFontsProvider
-                LatexPackage.BM -> LatexPostfixTemplateFromBmProvider
-                else -> LatexPostFixTemplateProvider
+                LatexPackage.AMSMATH -> LatexPostfixTemplateFromAmsMathProvider()
+                LatexPackage.AMSFONTS -> LatexPostfixTemplateFromAmsFontsProvider()
+                LatexPackage.BM -> LatexPostfixTemplateFromBmProvider()
+                else -> LatexPostFixTemplateProvider()
             }
         }
     }
 }
 
-object LatexPostfixTemplateFromAmsMathProvider : LatexPostfixTemplateFromPackageProvider(LatexPackage.AMSMATH) {
+class LatexPostfixTemplateFromAmsMathProvider : LatexPostfixTemplateFromPackageProvider(LatexPackage.AMSMATH) {
 
     override fun getTemplates(): MutableSet<PostfixTemplate> = mutableSetOf(
         LatexWrapWithTextPostfixTemplate
     )
 }
 
-object LatexPostfixTemplateFromAmsFontsProvider : LatexPostfixTemplateFromPackageProvider(LatexPackage.AMSFONTS) {
+class LatexPostfixTemplateFromAmsFontsProvider : LatexPostfixTemplateFromPackageProvider(LatexPackage.AMSFONTS) {
 
     override fun getTemplates(): MutableSet<PostfixTemplate> = mutableSetOf(
         LatexWrapWithMathbbPostfixTemplate
     )
 }
 
-object LatexPostfixTemplateFromBmProvider : LatexPostfixTemplateFromPackageProvider(LatexPackage.BM) {
+class LatexPostfixTemplateFromBmProvider : LatexPostfixTemplateFromPackageProvider(LatexPackage.BM) {
 
     override fun getTemplates(): MutableSet<PostfixTemplate> = mutableSetOf(
         LatexWrapWithBmPostfixTemplate

--- a/src/nl/hannahsten/texifyidea/gutter/LatexElementColorProvider.kt
+++ b/src/nl/hannahsten/texifyidea/gutter/LatexElementColorProvider.kt
@@ -21,7 +21,7 @@ import kotlin.math.min
  *
  * @author Abby
  */
-object LatexElementColorProvider : ElementColorProvider {
+class LatexElementColorProvider : ElementColorProvider {
 
     /**
      * Set the color in the document based on changes in the color picker from the gutter.

--- a/src/nl/hannahsten/texifyidea/index/BibtexEntryIndex.kt
+++ b/src/nl/hannahsten/texifyidea/index/BibtexEntryIndex.kt
@@ -14,18 +14,16 @@ import nl.hannahsten.texifyidea.util.files.referencedFileSet
 /**
  * @author Hannah Schellekens
  */
-object BibtexEntryIndex : StringStubIndexExtension<BibtexEntry>() {
+class BibtexEntryIndex : StringStubIndexExtension<BibtexEntry>() {
 
     /**
      * Get all the indexed [BibtexEntry]s in the project.
      */
-    @JvmStatic
     fun getIndexedEntries(project: Project) = getIndexedEntries(project, GlobalSearchScope.projectScope(project))
 
     /**
      * Get all the indexed [BibtexEntry]s in the given file.
      */
-    @JvmStatic
     fun getIndexedEntries(file: PsiFile) = getIndexedEntries(file.project, GlobalSearchScope.fileScope(file))
 
     /**
@@ -34,7 +32,6 @@ object BibtexEntryIndex : StringStubIndexExtension<BibtexEntry>() {
      * @param baseFile
      *          The file whose file set must be analysed for indexed ids.
      */
-    @JvmStatic
     fun getIndexedEntriesInFileSet(baseFile: PsiFile): Collection<BibtexEntry> {
         val project = baseFile.project
         val searchFiles: MutableSet<VirtualFile> = baseFile.referencedFileSet()
@@ -51,8 +48,7 @@ object BibtexEntryIndex : StringStubIndexExtension<BibtexEntry>() {
     /**
      * Get all the indexed [BibtexEntry]s in the given search scope.
      */
-    @JvmStatic
-    fun getIndexedEntries(project: Project, scope: GlobalSearchScope): Collection<BibtexEntry> {
+    private fun getIndexedEntries(project: Project, scope: GlobalSearchScope): Collection<BibtexEntry> {
         val commands: MutableCollection<BibtexEntry> = ArrayList()
 
         for (key in getKeys(project)) {
@@ -62,13 +58,11 @@ object BibtexEntryIndex : StringStubIndexExtension<BibtexEntry>() {
         return commands
     }
 
-    @JvmStatic
     fun getEntryByName(name: String, project: Project, scope: GlobalSearchScope): Collection<BibtexEntry> {
         return StubIndex.getElements(key, name, project, scope, BibtexEntry::class.java)
     }
 
-    @JvmStatic
-    fun getKeys(project: Project): Array<String> {
+    private fun getKeys(project: Project): Array<String> {
         if (DumbService.isDumb(project)) {
             return emptyArray()
         }

--- a/src/nl/hannahsten/texifyidea/index/BibtexEntryIndexKey.java
+++ b/src/nl/hannahsten/texifyidea/index/BibtexEntryIndexKey.java
@@ -7,6 +7,7 @@ import nl.hannahsten.texifyidea.psi.BibtexEntry;
  * According to the original implementation in BibtexidIndexKey:
  * For some reason, the key of {@link BibtexEntryIndex} must be placed into a java file.
  * Maybe I'm just doing something wrong, though ¯\_(ツ)_/¯.
+ * todo try @JvmStatic
  *
  * @author Felix Berlakovich
  */

--- a/src/nl/hannahsten/texifyidea/index/stub/BibtexEntryStubElementType.kt
+++ b/src/nl/hannahsten/texifyidea/index/stub/BibtexEntryStubElementType.kt
@@ -34,6 +34,6 @@ open class BibtexEntryStubElementType(debugName: String) : IStubElementType<Bibt
     override fun getExternalId() = "texify.bibtex." + super.toString()
 
     override fun indexStub(stub: BibtexEntryStub, sink: IndexSink) {
-        sink.occurrence(BibtexEntryIndex.key, stub.name ?: "")
+        sink.occurrence(BibtexEntryIndex().key, stub.name ?: "")
     }
 }

--- a/src/nl/hannahsten/texifyidea/inspections/bibtex/BibtexDuplicateIdInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/bibtex/BibtexDuplicateIdInspection.kt
@@ -11,8 +11,8 @@ import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.psi.BibtexEntry
 import nl.hannahsten.texifyidea.util.files.commandsInFileSet
 import nl.hannahsten.texifyidea.util.findAtLeast
-import nl.hannahsten.texifyidea.util.labels.findLatexCommandsLabels
 import nl.hannahsten.texifyidea.util.identifier
+import nl.hannahsten.texifyidea.util.labels.findLatexCommandsLabels
 import nl.hannahsten.texifyidea.util.requiredParameter
 
 /**
@@ -36,12 +36,12 @@ open class BibtexDuplicateIdInspection : TexifyInspectionBase() {
             .toSet()
 
         // All the ids that have been defined in the bibtex file. And next a list of all names.
-        val bibtexIds = BibtexEntryIndex.getIndexedEntriesInFileSet(file)
+        val bibtexIds = BibtexEntryIndex().getIndexedEntriesInFileSet(file)
         val strings = bibtexIds.map { it.identifier() }.toList()
 
         val added = HashSet<BibtexEntry>()
         // Check the bibtexIds in the current file
-        for (bibtexEntry in BibtexEntryIndex.getIndexedEntries(file)) {
+        for (bibtexEntry in BibtexEntryIndex().getIndexedEntries(file)) {
             val idName = bibtexEntry.identifier()
 
             // Check if defined as bibitem.

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexEscapeAmpersandInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexEscapeAmpersandInspection.kt
@@ -4,11 +4,13 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.psi.PsiElement
 import nl.hannahsten.texifyidea.inspections.TexifyRegexInspection
 import nl.hannahsten.texifyidea.psi.LatexCommands
-import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.firstParentOfType
+import nl.hannahsten.texifyidea.util.inDirectEnvironment
+import nl.hannahsten.texifyidea.util.isComment
 import nl.hannahsten.texifyidea.util.labels.getLabelDefinitionCommands
 import nl.hannahsten.texifyidea.util.labels.getLabelReferenceCommands
-import nl.hannahsten.texifyidea.util.magic.EnvironmentMagic
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
+import nl.hannahsten.texifyidea.util.magic.EnvironmentMagic
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
@@ -41,13 +43,8 @@ class LatexEscapeAmpersandInspection : TexifyRegexInspection(
 
         // Other exceptions
         val command = this.firstParentOfType(LatexCommands::class)?.name
-        if (command in CommandMagic.urls ||
+        return command in CommandMagic.urls ||
             command in project.getLabelReferenceCommands() ||
             command in project.getLabelDefinitionCommands()
-        ) {
-            return true
-        }
-
-        return false
     }
 }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexEscapeUnderscoreInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexEscapeUnderscoreInspection.kt
@@ -29,6 +29,7 @@ class LatexEscapeUnderscoreInspection : TexifyRegexInspection(
         return super.checkContext(matcher, element)
     }
 
+    @Suppress("RedundantIf")
     private fun PsiElement.isUnderscoreAllowed(): Boolean {
         if (this.inMathContext()) return true
         if (this.firstParentOfType(LatexNormalText::class) != null) return false

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspection.kt
@@ -6,6 +6,8 @@ import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
+import com.intellij.psi.SmartPsiElementPointer
+import com.intellij.refactoring.suggested.createSmartPointer
 import nl.hannahsten.texifyidea.inspections.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
@@ -13,7 +15,10 @@ import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.reference.InputFileReference
 import nl.hannahsten.texifyidea.ui.CreateFileDialog
 import nl.hannahsten.texifyidea.util.*
-import nl.hannahsten.texifyidea.util.files.*
+import nl.hannahsten.texifyidea.util.files.commandsInFile
+import nl.hannahsten.texifyidea.util.files.findRootFile
+import nl.hannahsten.texifyidea.util.files.getFileExtension
+import nl.hannahsten.texifyidea.util.files.writeToFileUndoable
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import java.util.*
 
@@ -68,7 +73,7 @@ open class LatexFileNotFoundInspection : TexifyInspectionBase() {
 
         // Create quick fixes for all extensions
         extensions.forEach {
-            fixes.add(CreateNewFileWithDialogQuickFix(fileName, it, reference))
+            fixes.add(CreateNewFileWithDialogQuickFix(fileName, it, reference.element.createSmartPointer()))
         }
 
         // Find expected extension
@@ -93,7 +98,7 @@ open class LatexFileNotFoundInspection : TexifyInspectionBase() {
      *
      * @param filePath Path relative to the root file parent.
      */
-    class CreateNewFileWithDialogQuickFix(private val filePath: String, private val extension: String, private val reference: InputFileReference) : LocalQuickFix {
+    class CreateNewFileWithDialogQuickFix(private val filePath: String, private val extension: String, private val elementPointer: SmartPsiElementPointer<LatexCommands>) : LocalQuickFix {
 
         override fun getFamilyName() = "Create file ${filePath.appendExtension(extension)}"
 
@@ -101,6 +106,7 @@ open class LatexFileNotFoundInspection : TexifyInspectionBase() {
 
         override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
             val cmd = descriptor.psiElement
+            val element = elementPointer.element ?: return
             val file = cmd.containingFile ?: return
             val root = file.findRootFile().containingDirectory?.virtualFile?.canonicalPath ?: return
 
@@ -118,7 +124,7 @@ open class LatexFileNotFoundInspection : TexifyInspectionBase() {
                     CommandMagic.illegalExtensions[command]?.forEach { fileNameRelativeToRoot = fileNameRelativeToRoot.replace(it, "") }
                 }
 
-                reference.handleElementRename(fileNameRelativeToRoot, false)
+                InputFileReference.handleElementRename(element, fileNameRelativeToRoot, false)
             }
         }
     }

--- a/src/nl/hannahsten/texifyidea/lang/SimpleBibtexEntryField.kt
+++ b/src/nl/hannahsten/texifyidea/lang/SimpleBibtexEntryField.kt
@@ -9,8 +9,7 @@ data class SimpleBibtexEntryField(override val fieldName: String, override val d
         if (this === other) return true
         if (other !is SimpleBibtexEntryField) return false
 
-        if (fieldName != other.fieldName) return false
-        return true
+        return fieldName == other.fieldName
     }
 
     override fun hashCode() = fieldName.hashCode()

--- a/src/nl/hannahsten/texifyidea/lang/magic/CustomMagicKey.kt
+++ b/src/nl/hannahsten/texifyidea/lang/magic/CustomMagicKey.kt
@@ -10,8 +10,7 @@ open class CustomMagicKey<Key>(override val key: Key) : MagicKey<Key> {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is CustomMagicKey<*>) return false
-        if (key != other.key) return false
-        return true
+        return key == other.key
     }
 
     override fun hashCode(): Int {

--- a/src/nl/hannahsten/texifyidea/lang/magic/MagicComment.kt
+++ b/src/nl/hannahsten/texifyidea/lang/magic/MagicComment.kt
@@ -169,8 +169,7 @@ open class MutableMagicComment<Key, Value> : MagicComment<Key, Value>() {
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (other !is MutableMagicComment<*, *>) return false
-        return true
+        return other is MutableMagicComment<*, *>
     }
 
     override fun hashCode(): Int {

--- a/src/nl/hannahsten/texifyidea/modules/LatexModuleType.kt
+++ b/src/nl/hannahsten/texifyidea/modules/LatexModuleType.kt
@@ -1,10 +1,11 @@
 package nl.hannahsten.texifyidea.modules
 
 import com.intellij.openapi.module.ModuleType
-import com.intellij.openapi.module.ModuleTypeManager
 import nl.hannahsten.texifyidea.TexifyIcons
 
 /**
+ * Note: ModuleTypes are deprecated, see [ModuleType].
+ *
  * @author Sten Wessel
  */
 class LatexModuleType : ModuleType<LatexModuleBuilder>(ID) {
@@ -13,8 +14,7 @@ class LatexModuleType : ModuleType<LatexModuleBuilder>(ID) {
 
         const val ID = "LATEX_MODULE_TYPE"
 
-        val INSTANCE: LatexModuleType
-            get() = ModuleTypeManager.getInstance().findByID(ID) as LatexModuleType
+        val INSTANCE = LatexModuleType()
     }
 
     override fun createModuleBuilder() = LatexModuleBuilder()

--- a/src/nl/hannahsten/texifyidea/psi/BibtexIdUtil.kt
+++ b/src/nl/hannahsten/texifyidea/psi/BibtexIdUtil.kt
@@ -30,7 +30,7 @@ fun delete(element: BibtexId) {
     val text = element.text ?: return
 
     val searchScope = GlobalSearchScope.fileScope(element.containingFile)
-    BibtexEntryIndex.getEntryByName(text, element.project, searchScope).forEach {
+    BibtexEntryIndex().getEntryByName(text, element.project, searchScope).forEach {
         it.remove()
     }
 }

--- a/src/nl/hannahsten/texifyidea/reference/BibtexIdReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/BibtexIdReference.kt
@@ -5,8 +5,8 @@ import com.intellij.util.containers.toArray
 import nl.hannahsten.texifyidea.index.BibtexEntryIndex
 import nl.hannahsten.texifyidea.psi.BibtexId
 import nl.hannahsten.texifyidea.psi.LatexParameterText
-import nl.hannahsten.texifyidea.util.labels.extractLabelName
 import nl.hannahsten.texifyidea.util.firstChildOfType
+import nl.hannahsten.texifyidea.util.labels.extractLabelName
 
 /**
  * Reference to a bibtex id.
@@ -24,7 +24,7 @@ class BibtexIdReference(element: LatexParameterText) : PsiReferenceBase<LatexPar
     }
 
     override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
-        return BibtexEntryIndex.getIndexedEntriesInFileSet(myElement.containingFile)
+        return BibtexEntryIndex().getIndexedEntriesInFileSet(myElement.containingFile)
             .filter { it.extractLabelName() == myElement.name }
             .mapNotNull {
                 // Resolve to the id, similarly as why we resolve to the label text for latex labels

--- a/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
@@ -40,6 +40,51 @@ class InputFileReference(
         rangeInElement = range
     }
 
+    companion object {
+
+        /**
+         * Handle element rename, but taking into account whether the given
+         * newElementName is just a filename which we have to replace,
+         * or a full relative path (in which case we replace the whole path).
+         */
+        fun handleElementRename(command: LatexCommands, newElementName: String, elementNameIsJustFilename: Boolean): PsiElement {
+
+            // A file has been renamed and we are given a new filename, to be replaced in the parameter text of the current command
+            // It seems to be problematic to find the old filename we want to replace
+            // Since the parameter content may be a path, but we are just given a filename, just replace the filename
+            // We guess the filename is after the last occurrence of /
+            val oldNode = command.node
+
+            val newName = if ((oldNode?.psi as? LatexCommands)?.name in CommandMagic.illegalExtensions.keys) {
+                newElementName.removeFileExtension()
+            }
+            else {
+                newElementName
+            }
+
+            val defaultNewText = "${command.name}{$newName}"
+            // Assumes that it is the last parameter, but at least leaves the options intact
+            val default = oldNode?.text?.replaceAfterLast('{', "$newName}", defaultNewText) ?: defaultNewText
+
+            // Recall that \ is a file separator on Windows
+            val newText = if (elementNameIsJustFilename) {
+                oldNode?.text?.trimStart('\\')?.replaceAfterLast('/', "$newName}", default.trimStart('\\'))
+                    ?.let { "\\" + it } ?: default
+            }
+            else {
+                default
+            }
+            val newNode = LatexPsiHelper(command.project).createFromText(newText).firstChild.node ?: return command
+            if (oldNode == null) {
+                command.parent?.node?.addChild(newNode)
+            }
+            else {
+                command.parent.node.replaceChild(oldNode, newNode)
+            }
+            return command
+        }
+    }
+
     val key by lazy {
         rangeInElement.substring(element.text)
     }
@@ -198,58 +243,16 @@ class InputFileReference(
         }
     }
 
-    /**
-     * Handle element rename, but taking into account whether the given
-     * newElementName is just a filename which we have to replace,
-     * or a full relative path (in which case we replace the whole path).
-     */
-    fun handleElementRename(newElementName: String, elementNameIsJustFilename: Boolean): PsiElement {
-
-        // A file has been renamed and we are given a new filename, to be replaced in the parameter text of the current command
-        // It seems to be problematic to find the old filename we want to replace
-        // Since the parameter content may be a path, but we are just given a filename, just replace the filename
-        // We guess the filename is after the last occurrence of /
-        val oldNode = myElement?.node
-
-        val newName = if ((oldNode?.psi as? LatexCommands)?.name in CommandMagic.illegalExtensions.keys) {
-            newElementName.removeFileExtension()
-        }
-        else {
-            newElementName
-        }
-
-        val defaultNewText = "${myElement?.name}{$newName}"
-        // Assumes that it is the last parameter, but at least leaves the options intact
-        val default = oldNode?.text?.replaceAfterLast('{', "$newName}", defaultNewText) ?: defaultNewText
-
-        // Recall that \ is a file separator on Windows
-        val newText = if (elementNameIsJustFilename) {
-            oldNode?.text?.trimStart('\\')?.replaceAfterLast('/', "$newName}", default.trimStart('\\'))
-                ?.let { "\\" + it } ?: default
-        }
-        else {
-            default
-        }
-        val newNode = LatexPsiHelper(element.project).createFromText(newText).firstChild.node ?: return myElement
-        if (oldNode == null) {
-            myElement?.parent?.node?.addChild(newNode)
-        }
-        else {
-            myElement.parent.node.replaceChild(oldNode, newNode)
-        }
-        return myElement
-    }
-
     override fun handleElementRename(newElementName: String): PsiElement {
-        return handleElementRename(newElementName, true)
+        return handleElementRename(element, newElementName, true)
     }
 
     // Required for moving referenced files
-    override fun bindToElement(element: PsiElement): PsiElement {
-        val newFile = element as? PsiFile ?: return this.element
+    override fun bindToElement(givenElement: PsiElement): PsiElement {
+        val newFile = givenElement as? PsiFile ?: return this.element
         // Assume LaTeX will accept paths relative to the root file
         val newFileName = newFile.virtualFile?.path?.toRelativePath(this.element.containingFile.findRootFile().virtualFile.parent.path) ?: return this.element
-        return handleElementRename(newFileName, false)
+        return handleElementRename(element, newFileName, false)
     }
 
     /**

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
@@ -53,7 +53,7 @@ import java.util.*
 /**
  * @author Hannah Schellekens, Sten Wessel
  */
-class LatexRunConfiguration constructor(
+class LatexRunConfiguration(
     project: Project,
     factory: ConfigurationFactory,
     name: String

--- a/src/nl/hannahsten/texifyidea/run/pdfviewer/PdfViewer.kt
+++ b/src/nl/hannahsten/texifyidea/run/pdfviewer/PdfViewer.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.project.Project
  * We also use this extension point to define the Intellij internal pdf viewer, to make sure that
  * TeXiFy only uses it when the (optional dependency) IntelliJ PDF Viewer plugin is installed.
  */
-@Suppress("PrivatePropertyName")
 private val EP_NAME = ExtensionPointName<ExternalPdfViewer>("nl.rubensten.texifyidea.pdfViewer")
 
 /**

--- a/src/nl/hannahsten/texifyidea/settings/sdk/LatexSdkUtil.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/LatexSdkUtil.kt
@@ -68,6 +68,7 @@ object LatexSdkUtil {
     private fun defaultIsDockerMiktex() =
         (!isMiktexAvailable && !TexliveSdk.isAvailable && DockerSdk.isAvailable)
 
+    @Suppress("RedundantIf")
     fun isAvailable(type: LatexDistributionType, project: Project): Boolean {
         if (type == LatexDistributionType.PROJECT_SDK && getLatexProjectSdk(project) != null) return true
         if (type == LatexDistributionType.MIKTEX && isMiktexAvailable) return true

--- a/src/nl/hannahsten/texifyidea/util/Container.kt
+++ b/src/nl/hannahsten/texifyidea/util/Container.kt
@@ -15,8 +15,7 @@ open class Container<T> @JvmOverloads constructor(
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is Container<*>) return false
-        if (item != other.item) return false
-        return true
+        return item == other.item
     }
 
     override fun hashCode() = item?.hashCode() ?: 0

--- a/src/nl/hannahsten/texifyidea/util/Numbers.kt
+++ b/src/nl/hannahsten/texifyidea/util/Numbers.kt
@@ -5,7 +5,6 @@ import java.util.*
 /**
  * @author Hannah Schellekens
  */
-@Suppress("PrivatePropertyName")
 private val ROMAN = TreeMap<Int, String>().apply {
     this[1000] = "M"
     this[500] = "D"

--- a/src/nl/hannahsten/texifyidea/util/Projects.kt
+++ b/src/nl/hannahsten/texifyidea/util/Projects.kt
@@ -102,6 +102,10 @@ fun Project.currentTextEditor(): TextEditor? {
 
 /**
  * Checks if there is a LaTeX module in this project.
+ *
+ * Note: according to the documentation of ModuleType:
+ *     If you need to make an action enabled in presence of a specific technology only, do this by looking for required files in the project
+ *     directories, not by checking type of the current module.
  */
 fun Project.hasLatexModule(): Boolean {
     if (isDisposed) return false

--- a/src/nl/hannahsten/texifyidea/util/files/FileSet.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/FileSet.kt
@@ -69,7 +69,7 @@ fun PsiFile.referencedFileSet(): Set<PsiFile> {
 /**
  * @see [BibtexEntryIndex.getIndexedEntriesInFileSet]
  */
-fun PsiFile.bibtexIdsInFileSet() = BibtexEntryIndex.getIndexedEntriesInFileSet(this)
+fun PsiFile.bibtexIdsInFileSet() = BibtexEntryIndex().getIndexedEntriesInFileSet(this)
 
 /**
  * @see [LatexCommandsIndex.getItemsInFileSet]

--- a/src/nl/hannahsten/texifyidea/util/labels/BibtexLabels.kt
+++ b/src/nl/hannahsten/texifyidea/util/labels/BibtexLabels.kt
@@ -26,7 +26,7 @@ fun PsiFile.findBibtexLabelsInFileSetAsSequence(): Sequence<String> = findBibtex
  * Finds all specified bibtex entries
  */
 fun PsiFile.findBibtexItems(): Collection<PsiElement> {
-    val bibtex = BibtexEntryIndex.getIndexedEntriesInFileSet(this)
+    val bibtex = BibtexEntryIndex().getIndexedEntriesInFileSet(this)
     val bibitem = findBibitemCommands().toList()
     return (bibtex + bibitem)
 }

--- a/src/nl/hannahsten/texifyidea/util/labels/ProjectLabels.kt
+++ b/src/nl/hannahsten/texifyidea/util/labels/ProjectLabels.kt
@@ -16,7 +16,7 @@ import nl.hannahsten.texifyidea.util.magic.CommandMagic
  */
 fun Project.findAllLabelsAndBibtexIds(): Collection<PsiElement> {
     val commands = LatexCommandsIndex.getItems(this).findLatexCommandsLabels(this)
-    val bibtexIds = BibtexEntryIndex.getIndexedEntries(this)
+    val bibtexIds = BibtexEntryIndex().getIndexedEntries(this)
     val environments = LatexParameterLabeledEnvironmentsIndex.getItems(this)
     val parameterLabeledCommands = LatexParameterLabeledCommandsIndex.getItems(this)
     val result = ArrayList<PsiElement>(commands)


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->

#### Summary of additions and changes

* Deregister the LaTeX Module Type, as module types are deprecated. The ModuleBuilder still exists, so you can still create a LaTeX module, except that at the end it's not going to be a LaTeX module but a generic one.
* Do not use PsiReference in field of quickfix

