### PR TITLE
Reset pdf viewer to default when the saved pdf viewer is not available.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add partial support for detecting non-global installations of SumatraPDF.
 
 ### Fixed
+* Fix issue with running an unsupported run configuration taken from another OS.
 
 ## [0.7.29] - 2023-04-14
 Welcome to TeXiFy IDEA 0.7.29! This release fixes the equation preview, and fully supports IntelliJ 2023.1.

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
@@ -257,7 +257,8 @@ class LatexRunConfiguration(
         val viewerName = parent.getChildText(PDF_VIEWER)
         try {
             this.pdfViewer = ExternalPdfViewers.getExternalPdfViewers().firstOrNull { it.name == viewerName }
-                ?: InternalPdfViewer.valueOf(viewerName ?: "")
+                ?: InternalPdfViewer.values().firstOrNull { it.isAvailable() && it.name == viewerName }
+                ?: InternalPdfViewer.NONE
         }
         catch (e: IllegalArgumentException) {
             // Try to recover from old settings (when the pdf viewer was set in the TeXiFy settings instead of the run config).

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
@@ -257,7 +257,7 @@ class LatexRunConfiguration(
         val viewerName = parent.getChildText(PDF_VIEWER)
         try {
             this.pdfViewer = ExternalPdfViewers.getExternalPdfViewers().firstOrNull { it.name == viewerName }
-                ?: InternalPdfViewer.values().firstOrNull { it.isAvailable() && it.name == viewerName }
+                ?: InternalPdfViewer.values().firstOrNull { it.name == viewerName && it.isAvailable() }
                 ?: InternalPdfViewer.NONE
         }
         catch (e: IllegalArgumentException) {


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2975 

#### Summary of additions and changes

* Check for availability of the selected/stored pdf viewer when reading the run configuration. For example, when running a (linux) run configuration that used Evince on Windows we would happily try to run Evince even though it obviously isn't available on Windows.