### PR TITLE
Disable "Forward Search" action in non-LaTeX files

### DIFF
--- a/src/nl/hannahsten/texifyidea/action/ForwardSearchAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/ForwardSearchAction.kt
@@ -2,10 +2,12 @@ package nl.hannahsten.texifyidea.action
 
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import nl.hannahsten.texifyidea.TexifyIcons
+import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.run.linuxpdfviewer.InternalPdfViewer
 import nl.hannahsten.texifyidea.run.pdfviewer.ExternalPdfViewer
 import nl.hannahsten.texifyidea.run.pdfviewer.PdfViewer
@@ -17,11 +19,7 @@ open class ForwardSearchAction(var viewer: PdfViewer? = null) : EditorAction(
 ) {
 
     override fun actionPerformed(file: VirtualFile, project: Project, textEditor: TextEditor) {
-        if (viewer == null) return
-
-        if (!viewer!!.isAvailable()) {
-            return
-        }
+        if (viewer?.isAvailable() != true || file.fileType !is LatexFileType) return
 
         val document = textEditor.editor.document
         val line = document.getLineNumber(textEditor.editor.caretModel.offset) + 1
@@ -35,6 +33,7 @@ open class ForwardSearchAction(var viewer: PdfViewer? = null) : EditorAction(
 
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabledAndVisible = e.project?.selectedRunConfig()?.pdfViewer == viewer
+            && e.getData(CommonDataKeys.VIRTUAL_FILE)?.fileType is LatexFileType
     }
 
     override fun getActionUpdateThread() = ActionUpdateThread.BGT


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3066

#### Summary of additions and changes
- Added check in `ForwardSearchAction#actionPerformed` to ensure `fileType` is `LatexFileType`
- Added condition in `ForwardSearchAction#update` to disable and hide action unless `fileType` is `LatexFileType`

#### How to test this pull request
- Create an arbitrary LaTeX file and an arbitrary non-LaTeX file
- Compile the LaTeX file, having the built-in PDF viewer enabled
- Verify that the `Forward Search` action can be triggered from the LaTeX file (either with a bound shortcut or directly through `Search Everywhere/Actions`), and it works properly
- Verify that the `Forward Search` action cannot be triggered (in any of the two ways) from the non-LaTeX file

<details><summary>Any files will do</summary>

> `test.tex`
```latex
\documentclass{article}
\begin{document}
    test
    \newpage
    test
\end{document}
```

> `test.kt`
```kotlin
val test = "test"
```
</details>

#### Wiki
There are no changes in expected behavior that would require to update the wiki.