### PR TITLE
Fix an issue with the canRun check in the LaTeX Project Task Runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@
 
 ### Fixed
 
+## [0.7.30-alpha.4] - 2023-05-19
+
+### Added
+* Add inspection preview for the unicode inspection.
+* Add partial support for detecting non-global installations of SumatraPDF.
+
+### Fixed
+* Fix an issue where the LaTeX Project Task Runner would override those of other languages
+* Internal improvements (#3070, #3072, #3074)
+* Fix InvalidVirtualFileAccessException #2991
+* Disable some editor actions in non-LaTeX files
+* Disable forward search action in non-LaTeX files, by @endorh
+* Fix IndexOutOfBoundsException #3036
+* Fix FileBasedIndex getting a default project (#3049)
+* Fix issue with running an unsupported run configuration taken from another OS.
+
+### Removed
+* Removed the LaTeX module type, as this is deprecated by IntelliJ
+
 ## [0.7.30-alpha.3] - 2023-05-17
 
 ### Added
@@ -151,10 +170,11 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Fix some intention previews. ([#2796](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2796))
 * Other small bug fixes and improvements. ([#2776](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2776), [#2774](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2774), [#2765](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2765)-[#2773](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2773))
 
-[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.30-alpha.3...HEAD
-[0.7.30-alpha.2]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.30-alpha.1...v0.7.30-alpha.2
-[0.7.30-alpha.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.29...v0.7.30-alpha.1
+[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.30-alpha.4...HEAD
 [0.7.30-alpha.3]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.30-alpha.2...v0.7.30-alpha.3
+[0.7.30-alpha.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.29...v0.7.30-alpha.1
+[0.7.30-alpha.2]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.30-alpha.1...v0.7.30-alpha.2
+[0.7.30-alpha.4]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.30-alpha.3...v0.7.30-alpha.4
 [0.7.29]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.28...v0.7.29
 [0.7.28]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.27...v0.7.28
 [0.7.27]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.26...v0.7.27

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.7.30-alpha.3
+pluginVersion = 0.7.30-alpha.4
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/run/LatexProjectTaskRunner.kt
+++ b/src/nl/hannahsten/texifyidea/run/LatexProjectTaskRunner.kt
@@ -10,6 +10,7 @@ import com.intellij.task.ProjectTask
 import com.intellij.task.ProjectTaskContext
 import com.intellij.task.ProjectTaskRunner
 import nl.hannahsten.texifyidea.util.getLatexRunConfigurations
+import nl.hannahsten.texifyidea.util.isLatexProject
 import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
 
@@ -21,7 +22,7 @@ import org.jetbrains.concurrency.Promise
 class LatexProjectTaskRunner : ProjectTaskRunner() {
 
     override fun canRun(projectTask: ProjectTask): Boolean {
-        return projectTask is ModuleBuildTask
+        return projectTask is ModuleBuildTask && projectTask.module.project.isLatexProject()
     }
 
     override fun run(project: Project, context: ProjectTaskContext, vararg tasks: ProjectTask?): Promise<Result> {


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3079

#### Summary of additions and changes

* The previous PR accidentally removed the check instead of replacing it by the proper check
