### PR TITLE
Fix some small exceptions in textidote implementation

### DIFF
--- a/src/nl/hannahsten/texifyidea/highlighting/TextidoteAnnotator.kt
+++ b/src/nl/hannahsten/texifyidea/highlighting/TextidoteAnnotator.kt
@@ -106,13 +106,19 @@ class TextidoteAnnotator : DumbAware, ExternalAnnotator<TextidoteAnnotatorInitia
                 continue
             }
 
-            // In Textidote, everything is 1-based, and here everyting is 0-based
+            // In Textidote, everything is 1-based, and here everything is 0-based
             val lineStartOffset1 = document.getLineStartOffset(warning.startLine - 1)
             val lineStartOffset2 = document.getLineStartOffset(warning.endLine - 1)
 
-            holder.newAnnotation(HighlightSeverity.WARNING, warning.message + " (Textidote)")
-                .range(TextRange(lineStartOffset1 + warning.startColumn - 1, lineStartOffset2 + warning.endColumn - 1))
-                .create()
+            val startOffset = lineStartOffset1 + warning.startColumn - 1
+            val endOffset = lineStartOffset2 + warning.endColumn - 1
+
+            // Check if computed range falls in the document range.
+            if (startOffset < document.textLength && endOffset < document.textLength) {
+                holder.newAnnotation(HighlightSeverity.WARNING, warning.message + " (Textidote)")
+                    .range(TextRange(startOffset, endOffset))
+                    .create()
+            }
         }
 
         super.apply(file, annotationResult, holder)

--- a/src/nl/hannahsten/texifyidea/highlighting/TextidoteAnnotator.kt
+++ b/src/nl/hannahsten/texifyidea/highlighting/TextidoteAnnotator.kt
@@ -39,7 +39,9 @@ data class TextidoteAnnotationResult(
 
 class TextidoteAnnotator : DumbAware, ExternalAnnotator<TextidoteAnnotatorInitialInfo, TextidoteAnnotationResult>() {
 
-    override fun collectInformation(file: PsiFile, editor: Editor, hasErrors: Boolean): TextidoteAnnotatorInitialInfo {
+    override fun collectInformation(file: PsiFile, editor: Editor, hasErrors: Boolean): TextidoteAnnotatorInitialInfo? {
+        if (file.containingDirectory == null) return null
+
         return TextidoteAnnotatorInitialInfo(
             file.virtualFile.name,
             File(file.containingDirectory.virtualFile.path),


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3086, fix #3089 

#### Summary of additions and changes

* Check if range of annotation is within document range (#3086)
* Add null-check for containing directory (#3089)