### PR TITLE
Grazie fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ idea-flex.skeleton
 jflex-*.jar
 scripts/venv
 results/
+**/node_modules

--- a/src/nl/hannahsten/texifyidea/inspections/grazie/LatexTextExtractor.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/grazie/LatexTextExtractor.kt
@@ -57,7 +57,7 @@ class LatexTextExtractor : TextExtractor() {
                 var start = text.textRange.startOffset - root.startOffset
                 // If LatexNormalText starts after a newline following a command, the newline is not part of the LatexNormalText so we include it manually to make sure that it is seen as a space between sentences
                 // NOTE: it is not allowed to start the text we send to Grazie with a newline! If we do, then Grazie will just not do anything. So we exclude the newline for the first normal text in the file.
-                if (setOf(' ', '\n').contains(rootText.getOrNull(start - 1)) && root.childrenOfType(LatexNormalText::class).first() != text
+                if (setOf(' ', '\n').contains(rootText.getOrNull(start - 1)) && root.childrenOfType(LatexNormalText::class).firstOrNull() != text
                 ) {
                     //  We have to skip over indents to find the newline though (indents will be ignored later)
                     start -= rootText.substring(0, start).takeLastWhile { it.isWhitespace() }.length

--- a/src/nl/hannahsten/texifyidea/inspections/grazie/LatexTextExtractor.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/grazie/LatexTextExtractor.kt
@@ -48,14 +48,9 @@ class LatexTextExtractor : TextExtractor() {
             // Note that textRangeInParent will not be correct because that's the text range in the direct parent, not in the root
             .flatMap {
                 // I have no idea what happens here. I don't think Grazie uses the same indices and text as root.text, because it doesn't behave consistently when I move around indices, so it may appear we are ignoring too much or too little while in practice the inspections may work.
-                var start = it.textRange.startOffset - root.startOffset
-                if (start > 0 && rootText[start - 1] != '\n' && rootText[start - 1] != ' ') {
-                    // Support sentence ends with inline math
-                    start -= 1
-                }
                 listOf(
-                    start,
-                    // -1 Because endOffset is exclusive but we are working with inclusive end here
+                    it.textRange.startOffset - root.startOffset,
+                    // -1 Because endOffset is exclusive, but we are working with inclusive end here
                     it.textRange.endOffset - 1 - root.startOffset
                 )
             }

--- a/src/nl/hannahsten/texifyidea/inspections/grazie/LatexTextExtractor.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/grazie/LatexTextExtractor.kt
@@ -5,6 +5,8 @@ import com.intellij.grazie.text.TextContent
 import com.intellij.grazie.text.TextExtractor
 import com.intellij.psi.PsiElement
 import com.intellij.refactoring.suggested.startOffset
+import nl.hannahsten.texifyidea.lang.commands.Argument
+import nl.hannahsten.texifyidea.lang.commands.LatexCommand
 import nl.hannahsten.texifyidea.psi.*
 import nl.hannahsten.texifyidea.util.*
 
@@ -41,17 +43,21 @@ class LatexTextExtractor : TextExtractor() {
         val rootText = root.text
 
         // Only keep normaltext, assuming other things (like inline math) need to be ignored.
-        val ranges = root.childrenOfType(LatexNormalText::class)
+        val ranges = (root.childrenOfType(LatexNormalText::class) + root.childrenOfType<LatexParameterText>())
             .asSequence()
             .filter { it.isNotInMathEnvironment() && it.isNotInSquareBrackets() }
             // Ranges that we need to keep
             // Note that textRangeInParent will not be correct because that's the text range in the direct parent, not in the root
             .flatMap { text ->
+                // Skip arguments of non-text commands
+                if (text is LatexParameterText && LatexCommand.lookup(text.firstParentOfType(LatexCommands::class)?.name)?.firstOrNull()?.arguments?.any { it.type == Argument.Type.TEXT } != true) {
+                    return@flatMap emptyList()
+                }
+
                 var start = text.textRange.startOffset - root.startOffset
                 // If LatexNormalText starts after a newline following a command, the newline is not part of the LatexNormalText so we include it manually to make sure that it is seen as a space between sentences
                 // NOTE: it is not allowed to start the text we send to Grazie with a newline! If we do, then Grazie will just not do anything. So we exclude the newline for the first normal text in the file.
-                if (setOf(' ', '\n').contains(rootText.getOrNull(start - 1)) && root.childrenOfType(LatexNormalText::class)
-                        .first() != text
+                if (setOf(' ', '\n').contains(rootText.getOrNull(start - 1)) && root.childrenOfType(LatexNormalText::class).first() != text
                 ) {
                     //  We have to skip over indents to find the newline though (indents will be ignored later)
                     start -= rootText.substring(0, start).takeLastWhile { it.isWhitespace() }.length
@@ -75,7 +81,7 @@ class LatexTextExtractor : TextExtractor() {
             // + 1 because we want to exclude all letters _after_ the last letter that we want to keep (the ranges defined above are inclusive)
             // -1 because IntRange has inclusive end, but we want to exclude all letters _excluding_ the letter where the normal text started
             .chunked(2) { IntRange(it[0] + 1, it[1] - 1) }
-            .filter { it.first < it.last && it.first >= 0 && it.last < rootText.length }
+            .filter { it.first <= it.last && it.first >= 0 && it.last < rootText.length }
             .toMutableSet()
 
         // There is still a bit of a problem, because when stitching together the NormalTexts, whitespace is lost

--- a/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
@@ -36,12 +36,11 @@ class GrazieInspectionTest : BasePlatformTestCase() {
         myFixture.checkHighlighting(true, false, false, true)
     }
 
-    // No idea why it doesn't work
-//    fun testMultilineCheckGrammar() {
-//        val testName = getTestName(false)
-//        myFixture.configureByFile("$testName.tex")
-//        myFixture.checkHighlighting(true, false, false, true)
-//    }
+    fun testMultilineCheckGrammar() {
+        val testName = getTestName(false)
+        myFixture.configureByFile("$testName.tex")
+        myFixture.checkHighlighting(true, false, false, true)
+    }
 
     fun testInlineMath() {
         myFixture.configureByText(
@@ -64,6 +63,16 @@ class GrazieInspectionTest : BasePlatformTestCase() {
     fun testMatchingParens() {
         myFixture.configureByText(
             LatexFileType, """a (in this case) . aa"""
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun testUnpairedSymbol() {
+        myFixture.configureByText(
+            LatexFileType, """
+                This is an unpaired symbol example
+                with \textit{example text}. % Error at ending bracket
+            """.trimIndent()
         )
         myFixture.checkHighlighting()
     }

--- a/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
@@ -108,4 +108,16 @@ class GrazieInspectionTest : BasePlatformTestCase() {
         )
         myFixture.checkHighlighting()
     }
+
+    fun testGermanCommandSpacing() {
+        GrazieRemote.download(Lang.GERMANY_GERMAN)
+        GrazieConfig.update { it.copy(enabledLanguages = it.enabledLanguages + Lang.GERMANY_GERMAN) }
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            Eine \textbf{Folge oder Zahlenfolge} in ${'$'}M${'$'} ist eine Abbildung
+            """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
 }

--- a/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
@@ -69,7 +69,8 @@ class GrazieInspectionTest : BasePlatformTestCase() {
 
     fun testUnpairedSymbol() {
         myFixture.configureByText(
-            LatexFileType, """
+            LatexFileType,
+            """
                 This is an unpaired symbol example
                 with \textit{example text}. % Error at ending bracket
             """.trimIndent()

--- a/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
@@ -120,4 +120,21 @@ class GrazieInspectionTest : BasePlatformTestCase() {
         )
         myFixture.checkHighlighting()
     }
+
+    fun testTabular() {
+        GrazieRemote.download(Lang.GERMANY_GERMAN)
+        GrazieConfig.update { it.copy(enabledLanguages = it.enabledLanguages + Lang.GERMANY_GERMAN) }
+        myFixture.configureByText(
+            LatexFileType,
+            """
+                \begin{tabular}{llll}
+                    ${'$'}a${'$'}:                 & ${'$'}\mathbb{N}${'$'} & \rightarrow & ${'$'}M${'$'}     \\
+                    \multicolumn{1}{l}{} & ${'$'}n${'$'}          & \mapsto     & ${'$'}a(n)${'$'}.
+                \end{tabular}
+            
+                Ich bin über die Entwicklung sehr froh.
+            """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
 }

--- a/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
@@ -95,4 +95,17 @@ class GrazieInspectionTest : BasePlatformTestCase() {
         )
         myFixture.checkHighlighting()
     }
+
+    fun testGermanList() {
+        GrazieRemote.download(Lang.GERMANY_GERMAN)
+        GrazieConfig.update { it.copy(enabledLanguages = it.enabledLanguages + Lang.GERMANY_GERMAN) }
+        myFixture.configureByText(
+            LatexFileType,
+            """
+                \item Bietet es eine unterstützende Lösung?
+                \item Können diese Dinge durchgeführt werden?
+            """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
 }

--- a/test/resources/inspections/grazie/MultilineCheckGrammar.tex
+++ b/test/resources/inspections/grazie/MultilineCheckGrammar.tex
@@ -1,4 +1,4 @@
 \begin{document}
-    <warning descr="EN_A_VS_AN">A</warning> apple a day keeps the doctor away.
+    <warning descr="Use An instead of 'A' if the following word starts with a vowel sound, e.g. 'an article', 'an hour'.">A</warning> apple a day keeps the doctor away.
     Some other sentence.
 \end{document}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->

Fix #2931 issue with sentence ending with } 
Fix #2972 whitespace/newlines after a command between sentences
Fix #3021 or at least could not reproduce
Fix an issue with Grazie not being able to handle text starting with a newline
Add text parameters of commands to grammar checked text
Improve my knowledge of German
