### PR TITLE
Refactor command execution in documentation provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@
 
 ### Fixed
 
+## [0.7.31-alpha.2] - 2023-06-19
+
+### Added
+* Add text parameters of commands to grammar checked text
+* Improved parsing of optional parameters
+* Internal improvements (#3092, #3102)
+
+### Fixed
+* Improve code of the documentation provider
+* Fix double highlighting of inline and display math, by @jojo2357
+* Fix false positive grammar error when a sentence ends with a closing brace
+* Fix false positive grammar error when a newline follows a command between sentences
+
 ## [0.7.31-alpha.1] - 2023-06-18
 
 ### Added
@@ -150,8 +163,9 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Fix some intention previews. ([#2796](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2796))
 * Other small bug fixes and improvements. ([#2776](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2776), [#2774](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2774), [#2765](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2765)-[#2773](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2773))
 
-[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.31-alpha.1...HEAD
+[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.31-alpha.2...HEAD
 [0.7.31-alpha.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.30...v0.7.31-alpha.1
+[0.7.31-alpha.2]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.31-alpha.1...v0.7.31-alpha.2
 [0.7.30]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.29...v0.7.30
 [0.7.29]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.28...v0.7.29
 [0.7.28]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.27...v0.7.28

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
     kotlin("plugin.serialization") version ("1.8.20")
 
     // Used for Arrow Optics
-    id("com.google.devtools.ksp") version "1.8.20-1.0.11"
+    id("com.google.devtools.ksp") version "1.8.22-1.0.11"
 
     // Plugin which can check for Gradle dependencies, use the help/dependencyUpdates task.
     id("com.github.ben-manes.versions") version "0.47.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.7.31-alpha.1
+pluginVersion = 0.7.31-alpha.2
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/TeXception.kt
+++ b/src/nl/hannahsten/texifyidea/TeXception.kt
@@ -20,3 +20,8 @@ open class TeXception : RuntimeException {
  * Represents a signal that a request to one of the remote libraries failed.
  */
 data class RemoteLibraryRequestFailure(val libraryName: String, val response: HttpResponse)
+
+/**
+ * A system command/program that failed to run successfully.
+ */
+data class CommandFailure(val output: String, val exitCode: Int)

--- a/src/nl/hannahsten/texifyidea/documentation/LatexDocumentationProvider.kt
+++ b/src/nl/hannahsten/texifyidea/documentation/LatexDocumentationProvider.kt
@@ -117,7 +117,7 @@ class LatexDocumentationProvider : DocumentationProvider {
         )
         val urlsText = urlsMaybe.fold(
             { it.output },
-            { urls -> urls?.joinToString(separator="<br>") { "<a href=\"file:///$it\">$it</a>" } }
+            { urls -> urls?.joinToString(separator = "<br>") { "<a href=\"file:///$it\">$it</a>" } }
         )
 
         // Add a line break if necessary


### PR DESCRIPTION
This PR doesn't fix anything (yet), but at least the command now should time out after three seconds instead of blocking the UI indefinitely.

Regarding debugging any issues, it may also help to go to Help > Diagnostic Tools > Debug Log Settings and add `#nl.hannahsten.texifyidea.util.Log`, so that you can see in idea.log exactly which commands TeXiFy runs in the background.

Note that the documentation provider is already triggered when hovering over a psi element (though for me, it doesn't block the UI while running).

Tested with MiKTeX, not sure if it still works for TeX Live.

https://plugins.jetbrains.com/plugin/download?rel=true&updateId=350496