### PR TITLE
Insert \}

### DIFF
--- a/src/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandler.kt
+++ b/src/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandler.kt
@@ -85,6 +85,9 @@ class LatexTypedHandler : TypedHandlerDelegate() {
             else if (c == '(') {
                 return insertRobustInlineMathClose(editor)
             }
+            else if (c == '{') {
+                return insertClosingEscapeBracket(editor)
+            }
         }
         return Result.CONTINUE
     }
@@ -135,6 +138,14 @@ class LatexTypedHandler : TypedHandlerDelegate() {
             return Result.STOP
         }
         return Result.CONTINUE
+    }
+
+    /**
+     * Upon typing `\{`, inserts the closing delimiter `\}`.
+     */
+    private fun insertClosingEscapeBracket(editor: Editor): Result {
+        editor.document.insertString(editor.caretModel.offset, "\\}")
+        return Result.STOP
     }
 
     /**

--- a/src/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandler.kt
+++ b/src/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandler.kt
@@ -18,8 +18,8 @@ import nl.hannahsten.texifyidea.psi.LatexInlineMath
 import nl.hannahsten.texifyidea.psi.LatexTypes
 import nl.hannahsten.texifyidea.settings.TexifySettings.Companion.getInstance
 import nl.hannahsten.texifyidea.util.files.isLatexFile
-import nl.hannahsten.texifyidea.util.parser.inVerbatim
 import nl.hannahsten.texifyidea.util.orFalse
+import nl.hannahsten.texifyidea.util.parser.inVerbatim
 
 /**
  * @author Sten Wessel
@@ -86,7 +86,7 @@ class LatexTypedHandler : TypedHandlerDelegate() {
                 return insertRobustInlineMathClose(editor)
             }
             else if (c == '{') {
-                return insertClosingEscapeBracket(editor)
+                return insertClosingEscapeBrace(editor)
             }
         }
         return Result.CONTINUE
@@ -143,7 +143,7 @@ class LatexTypedHandler : TypedHandlerDelegate() {
     /**
      * Upon typing `\{`, inserts the closing delimiter `\}`. Unlike the others, this isnt a token so we just have to check manually
      */
-    private fun insertClosingEscapeBracket(editor: Editor): Result {
+    private fun insertClosingEscapeBrace(editor: Editor): Result {
         val offset = editor.caretModel.offset
         if (offset > editor.document.textLength) return Result.CONTINUE
         if (offset - 2 < 0) return Result.CONTINUE

--- a/src/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandler.kt
+++ b/src/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandler.kt
@@ -141,11 +141,17 @@ class LatexTypedHandler : TypedHandlerDelegate() {
     }
 
     /**
-     * Upon typing `\{`, inserts the closing delimiter `\}`.
+     * Upon typing `\{`, inserts the closing delimiter `\}`. Unlike the others, this isnt a token so we just have to check manually
      */
     private fun insertClosingEscapeBracket(editor: Editor): Result {
-        editor.document.insertString(editor.caretModel.offset, "\\}")
-        return Result.STOP
+        val offset = editor.caretModel.offset
+        if (offset > editor.document.textLength) return Result.CONTINUE
+        if (offset - 2 < 0) return Result.CONTINUE
+        if (editor.document.getText(TextRange.from(offset - 2, 2)) == "\\{") {
+            editor.document.insertString(editor.caretModel.offset, "\\}")
+            return Result.STOP
+        }
+        return Result.CONTINUE
     }
 
     /**

--- a/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandlerTest.kt
+++ b/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandlerTest.kt
@@ -59,4 +59,10 @@ class LatexTypedHandlerTest : BasePlatformTestCase() {
             """.trimIndent()
         )
     }
+
+    fun testBracesCompletion() {
+        myFixture.configureByText(LatexFileType, """\mycommand<caret>""")
+        myFixture.type("{")
+        myFixture.checkResult("""\mycommand{<caret>}""")
+    }
 }

--- a/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandlerTest.kt
+++ b/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandlerTest.kt
@@ -65,4 +65,22 @@ class LatexTypedHandlerTest : BasePlatformTestCase() {
         myFixture.type("{")
         myFixture.checkResult("""\mycommand{<caret>}""")
     }
+
+    fun testStartOfLineBracesCompletion() {
+        myFixture.configureByText(LatexFileType, """<caret>""")
+        myFixture.type("{")
+        myFixture.checkResult("""{<caret>}""")
+    }
+
+    fun testStartOfLineEscapedBracesCompletion() {
+        myFixture.configureByText(LatexFileType, """<caret>""")
+        myFixture.type("\\{")
+        myFixture.checkResult("""\{<caret>\}""")
+    }
+
+    fun testEscapedBracesCompletion() {
+        myFixture.configureByText(LatexFileType, """Hello World <caret>""")
+        myFixture.type("\\{")
+        myFixture.checkResult("""Hello World \{<caret>\}""")
+    }
 }


### PR DESCRIPTION
Fix #3100

Does exactly as the issue opener requested. when `\{` is typed, `\}` is automatically inserted.

I fear it is too simple