### PR TITLE
Inspection performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 ### Fixed
 
+## [0.7.32-alpha.1] - 2023-07-06
+
+### Added
+* Add option to add custom environments/commands in label convention settings, by @jojo2357
+* Autocomplete \{...\}, by @jojo2357
+* Improve inspections performance
+
+### Fixed
+* Fix false positive non-breaking space warning when starting a sentence with a reference, by @jojo2357
+
 ## [0.7.31] - 2023-07-01
 Welcome to TeXiFy IDEA 0.7.31! This release improves the grammar checks and syntax highlighter, as well as the parsing of optional parameters.
 
@@ -155,7 +165,8 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Fix some intention previews. ([#2796](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2796))
 * Other small bug fixes and improvements. ([#2776](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2776), [#2774](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2774), [#2765](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2765)-[#2773](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2773))
 
-[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.31...HEAD
+[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.32-alpha.1...HEAD
+[0.7.32-alpha.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.31...v0.7.32-alpha.1
 [0.7.31]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.30...v0.7.31
 [0.7.30]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.29...v0.7.30
 [0.7.29]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.28...v0.7.29

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,12 +99,12 @@ dependencies {
 
     // Http requests
     implementation("io.ktor:ktor-client-core:2.3.2")
-    implementation("io.ktor:ktor-client-cio:2.3.1")
+    implementation("io.ktor:ktor-client-cio:2.3.2")
     implementation("io.ktor:ktor-client-auth:2.3.2")
-    implementation("io.ktor:ktor-client-content-negotiation:2.3.1")
-    implementation("io.ktor:ktor-server-core:2.3.1")
-    implementation("io.ktor:ktor-server-jetty:2.3.1")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.1")
+    implementation("io.ktor:ktor-client-content-negotiation:2.3.2")
+    implementation("io.ktor:ktor-server-core:2.3.2")
+    implementation("io.ktor:ktor-server-jetty:2.3.2")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.2")
 
     // Comparing versions
     implementation("org.apache.maven:maven-artifact:4.0.0-alpha-5")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.7.31
+pluginVersion = 0.7.32-alpha.1
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/index/LatexIndexUtil.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexIndexUtil.kt
@@ -2,9 +2,11 @@ package nl.hannahsten.texifyidea.index
 
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IndexSink
+import nl.hannahsten.texifyidea.highlighting.LatexAnnotator
 
 fun <T : PsiElement> indexSinkOccurrence(indexSink: IndexSink, index: IndexUtilBase<T>, token: String) {
     // Clear cache to be sure that any update will be reflected (we don't know whether something will be added to the index or whether it's already in there)
     index.cache.clear()
     indexSink.occurrence(index.key(), token)
+    LatexAnnotator.allUserDefinedCommands = emptyList()
 }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspection.kt
@@ -20,6 +20,7 @@ import nl.hannahsten.texifyidea.util.files.findRootFile
 import nl.hannahsten.texifyidea.util.files.getFileExtension
 import nl.hannahsten.texifyidea.util.files.writeToFileUndoable
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
+import nl.hannahsten.texifyidea.util.parser.getFileArgumentsReferences
 import nl.hannahsten.texifyidea.util.parser.parentsOfType
 import java.util.*
 
@@ -49,7 +50,7 @@ open class LatexFileNotFoundInspection : TexifyInspectionBase() {
                 continue
             }
 
-            val referencesList = command.references.filterIsInstance<InputFileReference>()
+            val referencesList = command.getFileArgumentsReferences()
             for (reference in referencesList) {
                 if (reference.resolve() == null) {
                     createQuickFixes(reference, descriptors, manager, isOntheFly)

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/packages/LatexMissingImportInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/packages/LatexMissingImportInspection.kt
@@ -19,9 +19,11 @@ import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexEnvironment
 import nl.hannahsten.texifyidea.settings.TexifySettings
-import nl.hannahsten.texifyidea.util.*
+import nl.hannahsten.texifyidea.util.PackageUtils
 import nl.hannahsten.texifyidea.util.files.commandsInFile
 import nl.hannahsten.texifyidea.util.files.definitionsAndRedefinitionsInFileSet
+import nl.hannahsten.texifyidea.util.findCommandDefinitions
+import nl.hannahsten.texifyidea.util.includedPackages
 import nl.hannahsten.texifyidea.util.magic.PackageMagic
 import nl.hannahsten.texifyidea.util.parser.*
 import java.util.*
@@ -105,6 +107,9 @@ open class LatexMissingImportInspection : TexifyInspectionBase() {
         descriptors: MutableList<ProblemDescriptor>, manager: InspectionManager,
         isOntheFly: Boolean
     ) {
+        // This loops over all commands, so we don't want to do this again for every command in the file for performance
+        val commandDefinitionsInProject = file.project.findCommandDefinitions().map { it.definedCommandName() }
+
         val commands = file.commandsInFile()
         commandLoop@ for (command in commands) {
             // If we are actually defining the command, then it doesn't need any dependency
@@ -113,7 +118,7 @@ open class LatexMissingImportInspection : TexifyInspectionBase() {
             }
 
             // If defined within the project, also fine
-            if (command.project.findCommandDefinitions().map { it.definedCommandName() }.contains(command.name)) {
+            if (commandDefinitionsInProject.contains(command.name)) {
                 continue
             }
 

--- a/src/nl/hannahsten/texifyidea/psi/impl/LatexCommandsImplMixin.kt
+++ b/src/nl/hannahsten/texifyidea/psi/impl/LatexCommandsImplMixin.kt
@@ -9,7 +9,10 @@ import com.intellij.psi.PsiReference
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.tree.IElementType
 import nl.hannahsten.texifyidea.index.stub.LatexCommandsStub
-import nl.hannahsten.texifyidea.psi.*
+import nl.hannahsten.texifyidea.psi.LatexCommandWithParams
+import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.psi.LatexPsiHelper
+import nl.hannahsten.texifyidea.psi.LatexVisitor
 import nl.hannahsten.texifyidea.reference.CommandDefinitionReference
 import nl.hannahsten.texifyidea.util.labels.getLabelReferenceCommands
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
@@ -74,6 +77,9 @@ abstract class LatexCommandsImplMixin : StubBasedPsiElementBase<LatexCommandsStu
     /**
      * References which do not need a find usages to work on lower level psi elements (normal text) can be implemented on the command, otherwise they are in {@link LatexPsiImplUtil#getReference(LatexParameterText)}.
      * For more info and an example, see {@link nl.hannahsten.texifyidea.reference.LatexLabelParameterReference}.
+     *
+     * Do not use this if you just want references of a particular type, to avoid resolving references (which can be expensive) that are not needed.
+     * For example, use LatexCommands.getFileArgumentsReferences() for InputFileReferences.
      */
     override fun getReferences(): Array<PsiReference> {
         val requiredParameters = getRequiredParameters(this)

--- a/src/nl/hannahsten/texifyidea/util/parser/LatexCommandsImplMixinUtil.kt
+++ b/src/nl/hannahsten/texifyidea/util/parser/LatexCommandsImplMixinUtil.kt
@@ -23,7 +23,7 @@ import kotlin.collections.set
 /**
  * Check if the command includes other files, and if so return [InputFileReference] instances for them.
  *
- * Do not use this method directly, use command.references.filterIsInstance<InputFileReference>() instead.
+ * Use this instead of command.references.filterIsInstance<InputFileReference>(), to avoid resolving references of types that will not be needed.
  */
 fun LatexCommands.getFileArgumentsReferences(): List<InputFileReference> {
     val inputFileReferences = mutableListOf<InputFileReference>()


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->


#### Summary of additions and changes

* Fix some performance bugs introduced in recent versions. The root issue remains, however. Currently inspecting a 7000 line file takes about 20 seconds.

https://plugins.jetbrains.com/plugin/download?rel=true&updateId=357446