### PR TITLE
Use TEXINPUTS properly (direct and via .latexmkrc)

### DIFF
--- a/src/nl/hannahsten/texifyidea/util/LatexmkRcFileFinder.kt
+++ b/src/nl/hannahsten/texifyidea/util/LatexmkRcFileFinder.kt
@@ -107,7 +107,7 @@ object LatexmkRcFileFinder {
      * Get TEXINPUTS from latexmkrc.
      */
     private fun getTexinputs(file: VirtualFile): String? {
-        return """ensure_path\('TEXINPUTS',\s*'(?<path>[^']+)'\)""".toRegex().find(file.inputStream.reader().readText())?.groups?.get("path")?.value
+        return """ensure_path\(\s*'TEXINPUTS',\s*'(?<path>[^']+)'\s*\)""".toRegex().find(file.inputStream.reader().readText())?.groups?.get("path")?.value
     }
 
     private var usesLatexmkrc: Boolean? = null


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/3038#issuecomment-1627733061 probably
Fix #3038 by using kpsewhich to read TEXINPUTS directly (instead of just from run config)
