### PR TITLE
Fix infinite loop in resolving imports

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.7.33
+pluginVersion = 0.7.34-alpha.1
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/util/files/ImportPackage.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/ImportPackage.kt
@@ -12,6 +12,7 @@ import nl.hannahsten.texifyidea.reference.InputFileReference
 import nl.hannahsten.texifyidea.util.appendExtension
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.parser.requiredParameter
+import kotlin.math.min
 
 /**
  * This method will try to find a file when the 'import' package is used, which means that including files have to be searched for import paths.
@@ -84,7 +85,7 @@ fun checkForAbsolutePath(command: LatexCommands): VirtualFile? {
 }
 
 fun findRelativeSearchPathsForImportCommands(command: LatexCommands, givenRelativeSearchPaths: List<String> = listOf("")): List<VirtualFile> {
-    var relativeSearchPaths = givenRelativeSearchPaths.toMutableList()
+    var relativeSearchPaths = givenRelativeSearchPaths.toMutableSet()
     val allIncludeCommands = LatexIncludesIndex.getItems(command.project)
     // Commands which may include the current file (this is an overestimation, better would be to check for RequiredFileArguments)
     var includingCommands = allIncludeCommands.filter {
@@ -94,12 +95,15 @@ fun findRelativeSearchPathsForImportCommands(command: LatexCommands, givenRelati
         // Only consider commands that can include LaTeX files
         LatexCommand.lookup(includeCommand.name)?.firstOrNull()?.getArgumentsOf(RequiredFileArgument::class.java)?.any { it.supportedExtensions.contains("tex") } == true
     }
+    // To avoid infinite loops, keep track of where we have been
+    val visitedIncludeCommands = includingCommands.toMutableSet()
+    val handledFiles = mutableListOf<PsiFile>()
 
     // Assume the containingFile might be a root file - if there are no includingCommands we will not search further anyway
     val defaultParentDir = command.containingFile.containingDirectory?.virtualFile?.findFileByRelativePath(command.requiredParameter(0) ?: "")
 
-    // Avoid endless loop (in case of a file inclusion loop)
-    val maxDepth = allIncludeCommands.size
+    // Avoid endless loop (in case of a file inclusion loop), limited to some reasonable maximum nesting level
+    val maxDepth = min(allIncludeCommands.size, 20)
     var counter = 0
 
     // Final paths
@@ -110,9 +114,10 @@ fun findRelativeSearchPathsForImportCommands(command: LatexCommands, givenRelati
     }
 
     // I think it's a kind of reversed BFS
+    // Loop over all commands which possibly include the current element
     while (includingCommands.isNotEmpty() && counter < maxDepth) {
-        val newSearchPaths = mutableListOf<String>()
-        val handledFiles = mutableListOf<PsiFile>()
+        counter++
+        val newSearchPaths = mutableSetOf<String>()
         val newIncludingcommands = mutableListOf<LatexCommands>()
 
         for (includingCommand in includingCommands) {
@@ -133,6 +138,7 @@ fun findRelativeSearchPathsForImportCommands(command: LatexCommands, givenRelati
             // Find files/commands to search next
             val file = includingCommand.containingFile
             if (file !in handledFiles) {
+                handledFiles.add(file)
                 val commandsIncludingThisFile = allIncludeCommands.filter { includeCommand -> includeCommand.getRequiredParameters().any { it.contains(file.name) } }
                 if (commandsIncludingThisFile.isEmpty()) {
                     // Cool, we supposedly have a root file, now try to find the directory containing the file being included by command
@@ -142,13 +148,13 @@ fun findRelativeSearchPathsForImportCommands(command: LatexCommands, givenRelati
                     }
                 }
                 newIncludingcommands.addAll(commandsIncludingThisFile)
-                handledFiles.add(file)
             }
         }
 
-        includingCommands = newIncludingcommands
+        val unvisitedNewIncludingCommands = newIncludingcommands.filter { !visitedIncludeCommands.contains(it) }
+        includingCommands = unvisitedNewIncludingCommands
+        visitedIncludeCommands.addAll(unvisitedNewIncludingCommands)
         relativeSearchPaths = newSearchPaths
-        counter++
     }
 
     return absoluteSearchDirs


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3156

#### Summary of additions and changes

* When there is a file inclusion loop (or an apparent one) the loop could repeatedly add the same commands as prefix

#### How to test this pull request

Didn't reproduce