### PR TITLE
Don't overwrite non-LaTeX icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,18 @@
 ## [Unreleased]
 
 ### Added
+
+### Fixed
+
+## [0.9.1] - 2023-08-15
+
+This release fixes a bug related to the new file icons from the previous release.
+
+### Added
 * Improve performance on plugin installation
 
 ### Fixed
+* Fix a bug where the plugin would override file icons of non-LaTeX files
 
 ## [0.9.0] - 2023-08-14
 Welcome to TeXiFy IDEA 0.9.0! In this release, we celebrate the completely new icon set by @HannahSchellekens which blends in much better with the new IntelliJ UI.
@@ -193,7 +202,8 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Fix some intention previews. ([#2796](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2796))
 * Other small bug fixes and improvements. ([#2776](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2776), [#2774](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2774), [#2765](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2765)-[#2773](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2773))
 
-[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.1-alpha.1...HEAD
+[0.9.1-alpha.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.0...v0.9.1-alpha.1
 [0.9.0]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.33...v0.9.0
 [0.7.33]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.32...v0.7.33
 [0.7.32]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.31...v0.7.32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### Fixed
 
 ## [0.9.1] - 2023-08-15
-
 This release fixes a bug related to the new file icons from the previous release.
 
 ### Added
@@ -202,8 +201,8 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Fix some intention previews. ([#2796](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2796))
 * Other small bug fixes and improvements. ([#2776](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2776), [#2774](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2774), [#2765](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2765)-[#2773](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2773))
 
-[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.1-alpha.1...HEAD
-[0.9.1-alpha.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.0...v0.9.1-alpha.1
+[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.33...v0.9.0
 [0.7.33]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.32...v0.7.33
 [0.7.32]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.31...v0.7.32

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -136,7 +136,7 @@ dependencies {
     // Enable use of the JUnitPlatform Runner within the IDE
     testImplementation("org.junit.platform:junit-platform-runner:1.10.0")
 
-    testImplementation("io.mockk:mockk:1.13.5")
+    testImplementation("io.mockk:mockk:1.13.7")
 
     // Add custom ruleset from github.com/slideclimb/ktlint-ruleset
     ktlintRuleset(files("lib/ktlint-ruleset-0.2.jar"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.9.0
+pluginVersion = 0.9.1
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/TexifyIcons.kt
+++ b/src/nl/hannahsten/texifyidea/TexifyIcons.kt
@@ -228,7 +228,7 @@ object TexifyIcons {
      * @throws IllegalArgumentException
      * When `extension` is null.
      */
-    fun getIconFromExtension(extension: String?, default: Icon?=null): Icon? {
+    fun getIconFromExtension(extension: String?, default: Icon? = null): Icon? {
         return if (extension == null) {
             default
         }

--- a/src/nl/hannahsten/texifyidea/TexifyIcons.kt
+++ b/src/nl/hannahsten/texifyidea/TexifyIcons.kt
@@ -221,15 +221,16 @@ object TexifyIcons {
      *
      * This method ignores case.
      *
-     * @param extension
-     *              The extension of the file to get the icon of without a dot.
+     * @param extension The extension of the file to get the icon of without a dot.
+     * @param default Use this if you want to get an icon also if the extension is not known to TeXiFy
+     *
      * @return The Icon that corresponds to the given extension.
      * @throws IllegalArgumentException
      * When `extension` is null.
      */
-    fun getIconFromExtension(extension: String?): Icon {
+    fun getIconFromExtension(extension: String?, default: Icon?=null): Icon? {
         return if (extension == null) {
-            FILE
+            default
         }
         else when (extension.lowercase(Locale.getDefault())) {
             "tex" -> LATEX_FILE
@@ -243,7 +244,7 @@ object TexifyIcons {
             "pdf" -> PDF_FILE
             "synctex.gz" -> SYNCTEX_FILE
             "dvi" -> DVI_FILE
-            else -> FILE
+            else -> default
         }
     }
 

--- a/src/nl/hannahsten/texifyidea/completion/pathcompletion/LatexPathProviderBase.kt
+++ b/src/nl/hannahsten/texifyidea/completion/pathcompletion/LatexPathProviderBase.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.util.parentOfTypes
 import com.intellij.util.PlatformIcons
 import com.intellij.util.ProcessingContext
 import nl.hannahsten.texifyidea.TexifyIcons
+import nl.hannahsten.texifyidea.TexifyIcons.FILE
 import nl.hannahsten.texifyidea.completion.handlers.CompositeHandler
 import nl.hannahsten.texifyidea.completion.handlers.FileNameInsertionHandler
 import nl.hannahsten.texifyidea.completion.handlers.LatexReferenceInsertHandler
@@ -172,7 +173,7 @@ abstract class LatexPathProviderBase : CompletionProvider<CompletionParameters>(
             if (validExtensions!!.contains(foundFile.extension).not()) return
         }
 
-        val icon = TexifyIcons.getIconFromExtension(foundFile.extension)
+        val icon = TexifyIcons.getIconFromExtension(foundFile.extension, default=FILE)
         resultSet?.addElement(
             LookupElementBuilder.create(baseDir + foundFile.name)
                 .withPresentableText(foundFile.presentableName)

--- a/src/nl/hannahsten/texifyidea/completion/pathcompletion/LatexPathProviderBase.kt
+++ b/src/nl/hannahsten/texifyidea/completion/pathcompletion/LatexPathProviderBase.kt
@@ -173,7 +173,7 @@ abstract class LatexPathProviderBase : CompletionProvider<CompletionParameters>(
             if (validExtensions!!.contains(foundFile.extension).not()) return
         }
 
-        val icon = TexifyIcons.getIconFromExtension(foundFile.extension, default=FILE)
+        val icon = TexifyIcons.getIconFromExtension(foundFile.extension, default = FILE)
         resultSet?.addElement(
             LookupElementBuilder.create(baseDir + foundFile.name)
                 .withPresentableText(foundFile.presentableName)

--- a/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
+++ b/src/nl/hannahsten/texifyidea/gutter/LatexNavigationGutter.kt
@@ -6,6 +6,7 @@ import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
 import com.intellij.ide.util.gotoByName.GotoFileCellRenderer
 import com.intellij.psi.PsiElement
 import nl.hannahsten.texifyidea.TexifyIcons
+import nl.hannahsten.texifyidea.TexifyIcons.FILE
 import nl.hannahsten.texifyidea.lang.commands.LatexCommand
 import nl.hannahsten.texifyidea.lang.commands.RequiredFileArgument
 import nl.hannahsten.texifyidea.psi.LatexCommands
@@ -57,7 +58,7 @@ class LatexNavigationGutter : RelatedItemLineMarkerProvider() {
             if (it.name.endsWith("synctex.gz")) "synctex.gz" else it.extension
         }
         // Gutter requires a smaller icon per IJ SDK docs.
-        val icon = TexifyIcons.getIconFromExtension(extension)
+        val icon = TexifyIcons.getIconFromExtension(extension, default = FILE) ?: return
 
         try {
             val builder = NavigationGutterIconBuilder

--- a/src/nl/hannahsten/texifyidea/ui/TeXiFyProjectViewNodeDecorator.kt
+++ b/src/nl/hannahsten/texifyidea/ui/TeXiFyProjectViewNodeDecorator.kt
@@ -30,7 +30,8 @@ class TeXiFyProjectViewNodeDecorator : ProjectViewNodeDecorator {
         // Allow Material design plugins to take over the icons
         // For file types registered in plugin.xml this happens automatically
         if (PluginManager.getLoadedPlugins().none { it.name.contains("Material") }) {
-            val icon = TexifyIcons.getIconFromExtension(extension.lowercase(Locale.getDefault()))
+            // Make sure to now override non-LaTeX extensions with the default icon
+            val icon = TexifyIcons.getIconFromExtension(extension.lowercase(Locale.getDefault()), default = null) ?: return
             presentationData.setIcon(icon)
         }
     }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3229

#### Summary of additions and changes

* Don't use the default icon if the extension is not known
