### PR TITLE
Improve inline resilience

### DIFF
--- a/src/nl/hannahsten/texifyidea/refactoring/inlinecommand/LatexInlineCommandDescriptor.kt
+++ b/src/nl/hannahsten/texifyidea/refactoring/inlinecommand/LatexInlineCommandDescriptor.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.refactoring.inlinecommand
 
-import com.intellij.java.refactoring.JavaRefactoringBundle
 import com.intellij.psi.PsiElement
+import com.intellij.refactoring.RefactoringBundle
 import com.intellij.usageView.UsageViewBundle
 import com.intellij.usageView.UsageViewDescriptor
 import nl.hannahsten.texifyidea.file.LatexFile
@@ -27,7 +27,7 @@ class LatexInlineCommandDescriptor(private val myElement: PsiElement) : UsageVie
     }
 
     override fun getCodeReferencesText(usagesCount: Int, filesCount: Int): String {
-        return JavaRefactoringBundle.message(
+        return RefactoringBundle.message(
             "invocations.to.be.inlined",
             UsageViewBundle.getReferencesString(usagesCount, filesCount)
         )

--- a/src/nl/hannahsten/texifyidea/refactoring/inlinecommand/LatexInlineCommandDialog.kt
+++ b/src/nl/hannahsten/texifyidea/refactoring/inlinecommand/LatexInlineCommandDialog.kt
@@ -54,7 +54,6 @@ class LatexInlineCommandDialog(
                 GlobalSearchScope.projectScope(myProject)
             )
         )
-        updateSettingsPreferences()
     }
 
     override fun getNumberOfOccurrences(): Int {

--- a/src/nl/hannahsten/texifyidea/refactoring/inlinecommand/LatexInlineDialog.kt
+++ b/src/nl/hannahsten/texifyidea/refactoring/inlinecommand/LatexInlineDialog.kt
@@ -4,7 +4,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNameIdentifierOwner
 import com.intellij.psi.search.searches.ReferencesSearch
-import com.intellij.refactoring.JavaRefactoringSettings
 import com.intellij.refactoring.RefactoringBundle
 import com.intellij.refactoring.inline.InlineOptionsDialog
 
@@ -30,13 +29,7 @@ abstract class LatexInlineDialog(project: Project?, genericDefinition: PsiElemen
         return RefactoringBundle.message("inline.method.border.title")
     }
 
-    override fun isInlineThis(): Boolean {
-        return JavaRefactoringSettings.getInstance().INLINE_METHOD_THIS
-    }
-
-    override fun isKeepTheDeclarationByDefault(): Boolean {
-        return JavaRefactoringSettings.getInstance().INLINE_METHOD_KEEP
-    }
+    override fun isInlineThis(): Boolean = false
 
     override fun hasHelpAction(): Boolean {
         return false
@@ -44,15 +37,5 @@ abstract class LatexInlineDialog(project: Project?, genericDefinition: PsiElemen
 
     override fun allowInlineAll(): Boolean {
         return true
-    }
-
-    protected fun updateSettingsPreferences() {
-        val settings = JavaRefactoringSettings.getInstance()
-        if (myRbInlineThisOnly.isEnabled && myRbInlineAll.isEnabled) {
-            settings.INLINE_METHOD_THIS = isInlineThisOnly
-        }
-        if (myKeepTheDeclaration != null && myKeepTheDeclaration!!.isEnabled) {
-            settings.INLINE_METHOD_KEEP = isKeepTheDeclaration
-        }
     }
 }

--- a/src/nl/hannahsten/texifyidea/refactoring/inlinefile/LatexInlineFileDescriptor.kt
+++ b/src/nl/hannahsten/texifyidea/refactoring/inlinefile/LatexInlineFileDescriptor.kt
@@ -1,7 +1,7 @@
 package nl.hannahsten.texifyidea.refactoring.inlinefile
 
-import com.intellij.java.refactoring.JavaRefactoringBundle
 import com.intellij.psi.PsiElement
+import com.intellij.refactoring.RefactoringBundle
 import com.intellij.usageView.UsageViewBundle
 import com.intellij.usageView.UsageViewDescriptor
 import nl.hannahsten.texifyidea.file.LatexFile
@@ -27,7 +27,7 @@ class LatexInlineFileDescriptor(private val myElement: PsiElement) : UsageViewDe
     }
 
     override fun getCodeReferencesText(usagesCount: Int, filesCount: Int): String {
-        return JavaRefactoringBundle.message(
+        return RefactoringBundle.message(
             "invocations.to.be.inlined",
             UsageViewBundle.getReferencesString(usagesCount, filesCount)
         )

--- a/src/nl/hannahsten/texifyidea/refactoring/inlinefile/LatexInlineFileDialog.kt
+++ b/src/nl/hannahsten/texifyidea/refactoring/inlinefile/LatexInlineFileDialog.kt
@@ -55,7 +55,6 @@ class LatexInlineFileDialog(
                 GlobalSearchScope.projectScope(myProject)
             )
         )
-        updateSettingsPreferences()
     }
 
     override fun getNumberOfOccurrences(): Int {


### PR DESCRIPTION
Should work better outside of IJ

Fix #3244

Inlining a command will no longer piggyback off of Java's inline settings, and so will need to be specified every time, but it will work in any ide regardless of the status of the `java` plugin