### PR TITLE
Math toggle intention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,21 +6,32 @@
 
 ### Fixed
 
+## [0.9.2-alpha.2] - 2023-10-04
+
+### Fixed
+
+* Fix a sync issue with remote libraries
+
 ## [0.9.2-alpha.1] - 2023-08-16
 
 ### Fixed
+
 * Fix a sync issue with remote libraries
 
 ## [0.9.1] - 2023-08-15
+
 This release fixes a bug related to the new file icons from the previous release.
 
 ### Added
+
 * Improve performance on plugin installation
 
 ### Fixed
+
 * Fix a bug where the plugin would override file icons of non-LaTeX files
 
 ## [0.9.0] - 2023-08-14
+
 Welcome to TeXiFy IDEA 0.9.0! In this release, we celebrate the completely new icon set by @HannahSchellekens which blends in much better with the new IntelliJ UI.
 Enjoy the new icons for LaTeX file types, menu entries, tool windows and more!
 
@@ -28,19 +39,23 @@ We thank everyone who submitted issues and provided feedback to make TeXiFy IDEA
 Your input is valuable and well appreciated.
 
 ### Added
+
 * New icons
 * Improve performance of file reference resolving
 
 ### Fixed
+
 * Fix a parse issue with TEXINPUTS
 * Fix a possible infinite loop when resolving imports
 * Fix an initialization issue in the remote library tool window
 * Fix an incorrect package import when completing commands from a project class file that is also in a project root
 
 ## [0.7.33] - 2023-07-27
+
 This release fixes an exception introduced by IntelliJ 2023.2.
 
 ### Fixed
+
 * Fix a PluginException that occurred in 2023.2
 * Fix parsing of TEXINPUTS
 * Change phi and varphi folding characters
@@ -48,33 +63,39 @@ This release fixes an exception introduced by IntelliJ 2023.2.
 ## [0.7.32] - 2023-07-13
 
 ### Added
+
 * Add option to add custom environments/commands in label convention settings, by @jojo2357
 * Autocomplete \{...\}, by @jojo2357
 * Improve inspections performance
 * Include globally defined TEXINPUTS when looking for files
 
 ### Fixed
+
 * Fix PluginException #3140
 * Fix false positive non-breaking space warning when starting a sentence with a reference, by @jojo2357
 
 ## [0.7.31] - 2023-07-01
+
 Welcome to TeXiFy IDEA 0.7.31! This release improves the grammar checks and syntax highlighter, as well as the parsing of optional parameters.
 
 We thank everyone who submitted issues and provided feedback to make TeXiFy IDEA better.
 Your input is valuable and well appreciated.
 
 ### Added
+
 * Add text parameters of commands to grammar checked text
 * Improved parsing of optional parameters
 * Internal improvements (#3092, #3102)
 
 ### Fixed
+
 * Improve code of the documentation provider
 * Fix double highlighting of inline and display math, by @jojo2357
 * Fix false positive grammar error when a sentence ends with a closing brace
 * Fix false positive grammar error when a newline follows a command between sentences
 
 ## [0.7.30] - 2023-06-01
+
 Welcome to TeXiFy IDEA 0.7.30! This release removes the LaTeX Module Type deprecated by IntelliJ, fixes some bugs and more.
 
 We thank everyone who submitted issues and provided feedback to make TeXiFy IDEA better.
@@ -82,12 +103,14 @@ Your input is valuable and well appreciated.
 In particular, many thanks to @svensieber for reporting a critical bug in a pre-release version!
 
 ### Added
+
 * Add inspection to check for suspicious formatting in section-like commands
 * Add latexindent command line options to settings
 * Add inspection preview for the unicode inspection.
 * Add partial support for detecting non-global installations of SumatraPDF.
 
 ### Fixed
+
 * Fix Textidote exceptions #3086 and #3089
 * Fix NPE #3083
 * Fix an issue where the LaTeX Project Task Runner would override those of other languages
@@ -100,19 +123,24 @@ In particular, many thanks to @svensieber for reporting a critical bug in a pre-
 * Fix issue with running an unsupported run configuration taken from another OS.
 
 ### Removed
+
 * Removed the LaTeX module type, as this is deprecated by IntelliJ
 
 ## [0.7.29] - 2023-04-14
+
 Welcome to TeXiFy IDEA 0.7.29! This release fixes the equation preview, and fully supports IntelliJ 2023.1.
 
 ### Added
+
 * Update minimum required IntelliJ version to 2023.1
 
 ### Fixed
+
 * Fix equation preview TranscoderException
 * Fix IncorrectOperationException
 
 ## [0.7.28] - 2023-04-01
+
 Welcome to TeXiFy IDEA 0.7.28! This release fixes some exceptions, adds comment folding and improves run configuration performance even more.
 
 We thank everyone who submitted issues and provided feedback to make TeXiFy IDEA better.
@@ -121,6 +149,7 @@ Your input is valuable and well appreciated.
 Thanks to @jojo2357 for contributing to this release!
 
 ### Added
+
 * Support @Comment comments in bibtex
 * Fold blocks of comments, by @jojo2357
 * Highlight comment environment as a comment, by @jojo2357
@@ -130,6 +159,7 @@ Thanks to @jojo2357 for contributing to this release!
 * Add \newminted code blocks as verbatim environments
 
 ### Fixed
+
 * Fixed usage of IntelliJ api deprecated in 2023.1
 * Fixed exception "Cannot distinguish StubFileElementTypes".
 * Fix exception #2971
@@ -139,6 +169,7 @@ Thanks to @jojo2357 for contributing to this release!
 * Fix bug when resolving \subimport
 
 ## [0.7.27] - 2023-03-09
+
 Welcome to TeXiFy IDEA 0.7.27! This release fixes a bug related to dashes, and adds an option to disable the (slow) indexing of your LaTeX installation.
 
 We thank everyone who submitted issues and provided feedback to make TeXiFy IDEA better.
@@ -147,15 +178,18 @@ Your input is valuable and well appreciated.
 Thanks to @FWDekker for contributing to this release!
 
 ### Added
+
 * Add information about newtxmath by @FWDekker
 * Add an option to disable indexing of LaTeX installation.
 
 ### Fixed
+
 * Fix an issue with dashes in referencing elements.
 * Fix a bug in "Convert to LaTeX alternative" quickfix
 * Fix exceptions #2928 and #2937
 
 ## [0.7.26] - 2023-02-01
+
 Welcome to TeXiFy IDEA 0.7.26! This release has some notable performance improvements and fixes many exceptions.
 
 We thank everyone who submitted issues and provided feedback to make TeXiFy IDEA better.
@@ -164,6 +198,7 @@ Your input is valuable and well appreciated.
 Thanks to @jojo2357 and @Yodude2002 for contributing to this release!
 
 ### Added
+
 * Improve performance when starting a run configuration.
 * Don't wrap urls when formatting.
 * Add (custom) highlighting for the equals separator in key-value pairs
@@ -171,6 +206,7 @@ Thanks to @jojo2357 and @Yodude2002 for contributing to this release!
 * Add tabularray package, by @Yodude2002.
 
 ### Fixed
+
 * Fix exceptions #2895, #2896 and #2856.
 * Fix unreliable \item insertion in itemize.
 * Reformat suggested file name before showing it to the user, instead of afterwards.
@@ -182,6 +218,7 @@ Thanks to @jojo2357 and @Yodude2002 for contributing to this release!
 * Fix custom file name being overridden in inspection quickfix.
 
 ## [0.7.25] - 2022-12-01
+
 Welcome to TeXiFy IDEA 0.7.25! This release has many additions by @jojo2357, enjoy!
 
 We thank everyone who submitted issues and provided feedback to make TeXiFy IDEA better.
@@ -190,6 +227,7 @@ Your input is valuable and well appreciated.
 Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 
 ### Added
+
 * Support undoing 'move se(le)ction to file' actions, by @jojo2357. ([#2739](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2739))
 * Add 'inline included file' action, by @jojo2357. ([#2741](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2741))
 * Enable synchronizing remote libraries without opening the tool window. ([#2749](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2749))
@@ -199,6 +237,7 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Complete rework of the support for a custom path to SumatraPDF, by @MisterDeenis. ([#2781](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2781))
 
 ### Fixed
+
 * Fix incorrect section contents moved to file, by @jojo2357. ([#2739](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2739))
 * Fix syntax highlighting for custom color scheme, by @jojo2357. ([#2761](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2761))
 * Fix unreliable forward search. ([#2777](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2777))
@@ -206,8 +245,9 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Fix some intention previews. ([#2796](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2796))
 * Other small bug fixes and improvements. ([#2776](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2776), [#2774](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2774), [#2765](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2765)-[#2773](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2773))
 
-[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.2-alpha.1...HEAD
+[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.2-alpha.2...HEAD
 [0.9.2-alpha.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.1...v0.9.2-alpha.1
+[0.9.2-alpha.2]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.2-alpha.1...v0.9.2-alpha.2
 [0.9.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.33...v0.9.0
 [0.7.33]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.32...v0.7.33

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
     id("se.patrikerdes.use-latest-versions") version "0.2.18"
 
     // Used to debug in a different IDE
-    id("de.undercouch.download") version "5.4.0"
+    id("de.undercouch.download") version "5.5.0"
 
     // Test coverage
     id("org.jetbrains.kotlinx.kover") version "0.7.3"
@@ -29,7 +29,7 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "11.3.2"
 
     // Vulnerability scanning
-    id("org.owasp.dependencycheck") version "8.3.1"
+    id("org.owasp.dependencycheck") version "8.4.0"
 
     id("org.jetbrains.changelog") version "2.2.0"
 
@@ -82,7 +82,7 @@ dependencies {
 
     // D-Bus Java bindings
     implementation("com.github.hypfvieh:dbus-java:3.3.2")
-    implementation("org.slf4j:slf4j-simple:2.0.7")
+    implementation("org.slf4j:slf4j-simple:2.0.9")
 
     // Unzipping tar.xz/tar.bz2 files on Windows containing dtx files
     implementation("org.codehaus.plexus:plexus-component-api:1.0-alpha-33")
@@ -98,11 +98,11 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.2")
 
     // Http requests
-    implementation("io.ktor:ktor-client-core:2.3.3")
-    implementation("io.ktor:ktor-client-cio:2.3.3")
+    implementation("io.ktor:ktor-client-core:2.3.4")
+    implementation("io.ktor:ktor-client-cio:2.3.4")
     implementation("io.ktor:ktor-client-auth:2.3.4")
     implementation("io.ktor:ktor-client-content-negotiation:2.3.4")
-    implementation("io.ktor:ktor-server-core:2.3.3")
+    implementation("io.ktor:ktor-server-core:2.3.4")
     implementation("io.ktor:ktor-server-jetty:2.3.4")
     implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.4")
 
@@ -117,8 +117,8 @@ dependencies {
         exclude("xml-apis", "xml-apis-ext")
     }
 
-    implementation("io.arrow-kt:arrow-core:1.2.0")
-    implementation("io.arrow-kt:arrow-fx-coroutines:1.2.0")
+    implementation("io.arrow-kt:arrow-core:1.2.1")
+    implementation("io.arrow-kt:arrow-fx-coroutines:1.2.1")
     implementation("io.arrow-kt:arrow-resilience:1.2.1")
 
     // Test dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.9.2-alpha.1
+pluginVersion = 0.9.2-alpha.2
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/editor/MathEnvironmentEditor.kt
+++ b/src/nl/hannahsten/texifyidea/editor/MathEnvironmentEditor.kt
@@ -23,27 +23,29 @@ class MathEnvironmentEditor(
     fun apply() {
         val document = editor.document
         val indent = document.lineIndentationByOffset(environment.textOffset)
+        val currentStartLineNumber = document.getLineNumber(environment.textOffset)
+        val currentEndLineNumber = document.getLineNumber(environment.endOffset())
 
         // The number of characters to replace before the begin block of the old environment starts.
-        val whitespace = if (newEnvironmentName == "inline") indent.length + 1
-        else if (oldEnvironmentName == "inline") 1
+        val whitespace = if (newEnvironmentName == "inline" && environment.textOffset > 0) indent.length + 1
+        else if (oldEnvironmentName == "inline" && environment.textOffset > 0) 1
         else 0
 
         // Extra white space to be added to the beginning of the new environment, when converting from/to inline.
-        val extraWhiteSpace = if (newEnvironmentName == "inline") {
+        val extraWhiteSpace = if (newEnvironmentName == "inline" && environment.textOffset > 0) {
             // Add indentation if indentation of old environment is bigger than the previous line.
-            val indentOfPreviousLine = document.lineIndentation(document.getLineNumber(environment.textOffset) - 1)
+            val indentOfPreviousLine = if (currentStartLineNumber > 0) document.lineIndentation(currentStartLineNumber - 1) else ""
             // Get the previous line, so we can check if it ends with a sentence separator. In that case the inline should not move to the previous line.
-            val previousLine = document.getText(TextRange(document.getLineStartOffset(document.getLineNumber(environment.textOffset) - 1), environment.textOffset))
+            val previousLine = if (currentStartLineNumber > 0) document.getText(TextRange(document.getLineStartOffset(currentStartLineNumber - 1), environment.textOffset)) else ""
             when {
                 indentOfPreviousLine.length < indent.length -> "\n$indent"
                 PatternMagic.sentenceSeparatorAtLineEnd.matcher(previousLine).find() -> "\n$indent"
                 else -> " "
             }
         }
-        else if (oldEnvironmentName == "inline") {
+        else if (oldEnvironmentName == "inline" && environment.textOffset > 0) {
             // Add a newline if there is no text on the line before the inline environment.
-            val prefixOnLine = document.getText(TextRange(document.getLineStartOffset(document.getLineNumber(environment.textOffset)), environment.textOffset))
+            val prefixOnLine = document.getText(TextRange(document.getLineStartOffset(currentStartLineNumber), environment.textOffset))
             if (prefixOnLine.matches(Regex("^\\s*"))) " " else "\n$indent"
         }
         else ""
@@ -52,21 +54,19 @@ class MathEnvironmentEditor(
         val extra = if (newEnvironmentName == "inline") {
             // Only add the indentation if the next line is indented by at least the same amount as the end command
             // of the old environment.
-            val nextLineIndent = document.lineIndentation(
-                document.getLineNumber(environment.endOffset()) + 1
-            )
+            val nextLineIndent = if (currentEndLineNumber < document.lineCount - 1) document.lineIndentation(currentEndLineNumber + 1) else ""
             if (nextLineIndent.length < indent.length) 0 else indent.length
         }
-        else if (oldEnvironmentName == "inline") 1
+        else if (oldEnvironmentName == "inline" && environment.endOffset() < document.textLength - 1) 1
         else 0
 
         // Extra new line to be added at the end of the new environment if the old environment was inline.
-        val extraNewLine = if (oldEnvironmentName == "inline") {
+        val extraNewLine = if (oldEnvironmentName == "inline" && environment.endOffset() < document.textLength - 1) {
             // If the rest of the line is empty, add a new line without indentation.
             val restOfLine = document.getText(
                 TextRange(
                     environment.endOffset(),
-                    document.getLineEndOffset(document.getLineNumber(environment.endOffset()))
+                    document.getLineEndOffset(currentEndLineNumber)
                 )
             )
             if (restOfLine.matches(Regex("^\\s*"))) "\n" else "\n$indent"

--- a/test/nl/hannahsten/texifyidea/intentions/LatexInlineDisplayToggleIntentionTest.kt
+++ b/test/nl/hannahsten/texifyidea/intentions/LatexInlineDisplayToggleIntentionTest.kt
@@ -46,4 +46,38 @@ class LatexInlineDisplayToggleIntentionTest : BasePlatformTestCase() {
             """.trimIndent()
         )
     }
+
+    fun testDisplayToInlineToggleFirstLine() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \[
+                \pi = 3<caret>
+            \]
+            """.trimIndent()
+        )
+        myFixture.findSingleIntention("Toggle inline/display math mode").invoke(myFixture.project, myFixture.editor, myFixture.file)
+        myFixture.checkResult(
+            """
+            $\pi = 3$
+            """.trimIndent()
+        )
+    }
+
+    fun testInlineToDisplayToggleFirstLine() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            $\pi = 3<caret>$
+            """.trimIndent()
+        )
+        myFixture.findSingleIntention("Toggle inline/display math mode").invoke(myFixture.project, myFixture.editor, myFixture.file)
+        myFixture.checkResult(
+            """
+            \[
+                \pi = 3
+            \]
+            """.trimIndent()
+        )
+    }
 }

--- a/test/nl/hannahsten/texifyidea/intentions/LatexInlineDisplayToggleIntentionTest.kt
+++ b/test/nl/hannahsten/texifyidea/intentions/LatexInlineDisplayToggleIntentionTest.kt
@@ -1,0 +1,49 @@
+package nl.hannahsten.texifyidea.intentions
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import nl.hannahsten.texifyidea.file.LatexFileType
+
+class LatexInlineDisplayToggleIntentionTest : BasePlatformTestCase() {
+
+    fun testInlineToDisplayToggle() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \begin{document}
+                $\pi = 3<caret>$
+            \end{document}
+            """.trimIndent()
+        )
+        myFixture.findSingleIntention("Toggle inline/display math mode").invoke(myFixture.project, myFixture.editor, myFixture.file)
+        myFixture.checkResult(
+            """
+            \begin{document}
+                \[
+                    \pi = 3
+                \]
+            \end{document}
+            """.trimIndent()
+        )
+    }
+
+    fun testDisplayToInline() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \begin{document}
+                \[
+                    \pi = 3<caret>
+                \]
+            \end{document}
+            """.trimIndent()
+        )
+        myFixture.findSingleIntention("Toggle inline/display math mode").invoke(myFixture.project, myFixture.editor, myFixture.file)
+        myFixture.checkResult(
+            """
+            \begin{document}
+                $\pi = 3$
+            \end{document}
+            """.trimIndent()
+        )
+    }
+}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3249 

#### Summary of additions and changes

* Reuse the `MathEnvironmentEditor` in the inline/display math toggle intention, so its behaviour is consistent with the other math environment toggle inspection.
* Fix behaviour for the edge cases where a math environment is at the start of end of a document.

#### How to test this pull request
See test cases.

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary