### PR TITLE
3273 Fix structure view nesting

### DIFF
--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexStructureViewElement.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexStructureViewElement.kt
@@ -195,7 +195,7 @@ class LatexStructureViewElement(private val element: PsiElement) : StructureView
             }
             // Avoid that an element is not added at all by adding it one level up anyway.
             // If index is null, that means that the tree currently only has elements with a higher order.
-            else {
+            else if (index == null || indexInsert == index) {
                 registerSameLevel(sections, child, currentCmd, treeElements, numbering)
                 break
             }

--- a/test/nl/hannahsten/texifyidea/structure/latex/LatexStructureViewElementTest.kt
+++ b/test/nl/hannahsten/texifyidea/structure/latex/LatexStructureViewElementTest.kt
@@ -1,0 +1,60 @@
+package nl.hannahsten.texifyidea.structure.latex
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import nl.hannahsten.texifyidea.file.LatexFileType
+
+class LatexStructureViewElementTest : BasePlatformTestCase() {
+    fun `test that item is added to correct level when it is more than one level higher than the previous element`() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \section{s}
+
+            \subsection{ss1}
+
+            \subsubsection{sss}
+
+            \paragraph{p}
+
+            \subsection{ss2}
+            """.trimIndent()
+        )
+
+        myFixture.testStructureView { component ->
+            val documentChildren = (component.treeModel as LatexStructureViewModel).root.children
+            // \section{s1} is the only child element of the document class element.
+            assertEquals(1, documentChildren.size)
+            // \subsection{ss1}
+            //   ...
+            // \subsection{ss2}
+            assertEquals(
+                listOf("\\subsection{ss1}", "\\subsection{ss2}"),
+                documentChildren[0].children.map { (it as LatexStructureViewCommandElement).value.text }
+            )
+        }
+    }
+
+    fun `test that item is added to tree when all items before where of lower level`() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \subsubsection{sss}
+
+            \paragraph{p}
+
+            \subsection{ss}
+            """.trimIndent()
+        )
+
+        myFixture.testStructureView { component ->
+            val documentChildren = (component.treeModel as LatexStructureViewModel).root.children
+            // \subsubsection{sss}
+            //    \paragraph{p}
+            // \subsection{ss}
+            assertEquals(
+                listOf("\\subsubsection{sss}", "\\subsection{ss}"),
+                documentChildren.map { (it as LatexStructureViewCommandElement).value.text }
+            )
+        }
+    }
+}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3273 

#### Summary of additions and changes

* Fixes that structure view  elements would be inserted too deep in the tree in some occasions.
* Added a test case for this as well as for #2681 (it seems likely that the change there actually broke this).

#### How to test this pull request

```latex
\section{s}

\subsection{ss}

\subsubsection{sss}

\paragraph{p}

\paragraph{p}

\paragraph{p}

\subsection{ss}
```

open the structure view.

![image](https://github.com/Hannah-Sten/TeXiFy-IDEA/assets/15685876/b002b297-ee3e-4eaa-b762-9e7fa1bf7882)


- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary