### PR TITLE
Include bib files in package location cache

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnresolvedReferenceInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnresolvedReferenceInspection.kt
@@ -7,12 +7,14 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.inspections.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
+import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.util.files.commandsInFile
 import nl.hannahsten.texifyidea.util.labels.findLatexAndBibtexLabelStringsInFileSet
-import nl.hannahsten.texifyidea.util.parser.firstParentOfType
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
+import nl.hannahsten.texifyidea.util.magic.cmd
+import nl.hannahsten.texifyidea.util.parser.firstParentOfType
 import java.lang.Integer.max
 import java.util.*
 
@@ -56,7 +58,7 @@ open class LatexUnresolvedReferenceInspection : TexifyInspectionBase() {
                 if (part == "*") continue
 
                 // The cleveref package allows empty items to customize enumerations
-                if (part.isEmpty() && (command.commandToken.text == "\\cref" || command.commandToken.text == "\\Cref")) continue
+                if (part.isEmpty() && (command.name == LatexGenericRegularCommand.CREF.cmd || command.name == LatexGenericRegularCommand.CREF_CAPITAL.cmd)) continue
 
                 // If there is no label with this required label parameter value
                 if (!labels.contains(part.trim())) {

--- a/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
@@ -27,7 +27,7 @@ object LatexPackageLocationCache {
         // We cannot just fill the cache on the fly, because then we will also run kpsewhich when the user is still typing a package name, so we will run it once for every letter typed and this is already too expensive.
         // We cannot rely on ls-R databases because they are not always populated, and running mktexlsr may run into permission issues.
         val executableName = LatexSdkUtil.getExecutableName("kpsewhich", project)
-        val searchPaths = runCommand(executableName, "-show-path=tex")
+        val searchPaths = (runCommand(executableName, "-show-path=tex") ?: ".") + File.pathSeparator + (runCommand(executableName, "-show-path=bib") ?: ".")
         cache = runCommand(executableName, "-expand-path", searchPaths ?: ".:")?.split(File.pathSeparator)
             ?.flatMap { LocalFileSystem.getInstance().findFileByPath(it)?.children?.toList() ?: emptyList() }
             ?.filter { !it.isDirectory }

--- a/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
@@ -28,7 +28,7 @@ object LatexPackageLocationCache {
         // We cannot rely on ls-R databases because they are not always populated, and running mktexlsr may run into permission issues.
         val executableName = LatexSdkUtil.getExecutableName("kpsewhich", project)
         val searchPaths = (runCommand(executableName, "-show-path=tex") ?: ".") + File.pathSeparator + (runCommand(executableName, "-show-path=bib") ?: ".")
-        cache = runCommand(executableName, "-expand-path", searchPaths ?: ".:")?.split(File.pathSeparator)
+        cache = runCommand(executableName, "-expand-path", searchPaths)?.split(File.pathSeparator)
             ?.flatMap { LocalFileSystem.getInstance().findFileByPath(it)?.children?.toList() ?: emptyList() }
             ?.filter { !it.isDirectory }
             ?.toSet()


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3294

#### Summary of additions and changes

* Include bib files in package location cache, as it is used for input file references for \bibliography commands

