### PR TITLE
Fix #3361: false positive on duplicate identifier on @string entries in bib files

### DIFF
--- a/src/nl/hannahsten/texifyidea/util/parser/BibtexPsiUtil.kt
+++ b/src/nl/hannahsten/texifyidea/util/parser/BibtexPsiUtil.kt
@@ -23,7 +23,12 @@ fun BibtexEntry.getYear(): String {
 
 fun BibtexEntry.getIdentifier(): String {
     val stub = this.stub
-    return stub?.identifier ?: (firstChildOfType(BibtexId::class)?.text ?: return "")
+    return stub?.identifier ?: if (this.type.text.lowercase() == "@string") {
+        this.entryContent?.tagList?.firstOrNull()?.key?.text ?: ""
+    }
+    else {
+        firstChildOfType(BibtexId::class)?.text ?: ""
+    }
 }
 
 fun BibtexEntry.getAbstract(): String {

--- a/src/nl/hannahsten/texifyidea/util/parser/BibtexPsiUtil.kt
+++ b/src/nl/hannahsten/texifyidea/util/parser/BibtexPsiUtil.kt
@@ -23,12 +23,11 @@ fun BibtexEntry.getYear(): String {
 
 fun BibtexEntry.getIdentifier(): String {
     val stub = this.stub
-    return stub?.identifier ?: if (this.type.text.lowercase() == "@string") {
-        this.entryContent?.tagList?.firstOrNull()?.key?.text ?: ""
-    }
-    else {
-        firstChildOfType(BibtexId::class)?.text ?: ""
-    }
+    return stub?.identifier
+        ?: firstChildOfType(BibtexId::class)?.text
+        ?: this.entryContent?.tagList?.firstOrNull()?.key?.text
+        ?: this.preamble?.text
+        ?: ""
 }
 
 fun BibtexEntry.getAbstract(): String {

--- a/test/nl/hannahsten/texifyidea/inspections/bibtex/BibtexDuplicateIdInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/bibtex/BibtexDuplicateIdInspectionTest.kt
@@ -1,0 +1,31 @@
+package nl.hannahsten.texifyidea.inspections.bibtex
+
+import nl.hannahsten.texifyidea.file.BibtexFileType
+import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
+
+class BibtexDuplicateIdInspectionTest : TexifyInspectionTestBase(BibtexDuplicateIdInspection()) {
+
+    fun `test @strings are not always duplicate ids`() {
+        myFixture.configureByText(
+            BibtexFileType,
+            """
+            @string{ a = test }
+
+            @string{ b = c }
+            """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test duplicate @strings`() {
+        myFixture.configureByText(
+            BibtexFileType,
+            """
+            <error descr="Duplicate identifier 'a'">@string{ a = test </error>}
+
+            <error descr="Duplicate identifier 'a'">@string{ a = c </error>}
+            """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+}

--- a/test/nl/hannahsten/texifyidea/psi/BibtexEntryImplUtilTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/BibtexEntryImplUtilTest.kt
@@ -7,9 +7,9 @@ import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import junit.framework.TestCase
 import nl.hannahsten.texifyidea.file.BibtexFileType
 import nl.hannahsten.texifyidea.util.parser.firstChildOfType
+import nl.hannahsten.texifyidea.util.parser.getIdentifier
 import nl.hannahsten.texifyidea.util.parser.getTagContent
 import org.intellij.lang.annotations.Language
-import org.junit.Test
 
 class BibtexEntryImplUtilTest : BasePlatformTestCase() {
 
@@ -37,15 +37,29 @@ class BibtexEntryImplUtilTest : BasePlatformTestCase() {
         myFixture.configureByText(BibtexFileType, entryText)
     }
 
-    @Test
     fun testEntryGetReferences() {
         listOf(WebReference(entryElement, url)).map { it.url }.forEach {
             UsefulTestCase.assertContainsElements(entryElement.references.map { reference -> (reference as WebReference).url }, it)
         }
     }
 
-    @Test
     fun testGetTagContent() {
         TestCase.assertEquals("TeXiFy IDEA", entryElement.getTagContent("title"))
+    }
+
+    fun `test get id of 'empty' element`() {
+        myFixture.configureByText(
+            BibtexFileType,
+            """
+                @misc{identifier,
+                }
+            """.trimIndent()
+        )
+        TestCase.assertEquals("identifier", entryElement.getIdentifier())
+    }
+
+    fun `test get id of @string element`() {
+        myFixture.configureByText(BibtexFileType, "@string{a = b}")
+        TestCase.assertEquals("a", entryElement.getIdentifier())
     }
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fixes #3361 and #3360

#### Summary of additions and changes

* Fixed the incorrect warning of duplicate `@string` ids in  bib files. (#3361).
* Fixed that empty items showed up weird in the structure view. (#3360).
* Fixed that empty items all had the same id.

#### How to test this pull request

See added tests.

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary