### PR TITLE
Fix #3336: disable alignment of & in \url commands in table

### DIFF
--- a/src/nl/hannahsten/texifyidea/formatting/spacingrules/TableAlignRule.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/spacingrules/TableAlignRule.kt
@@ -11,6 +11,7 @@ import nl.hannahsten.texifyidea.psi.getEnvironmentName
 import nl.hannahsten.texifyidea.util.getIndent
 import nl.hannahsten.texifyidea.util.magic.EnvironmentMagic
 import nl.hannahsten.texifyidea.util.parser.firstParentOfType
+import nl.hannahsten.texifyidea.util.parser.inUrl
 import kotlin.math.min
 
 /** At this length, we put table cells on their own line. */
@@ -20,9 +21,10 @@ const val LINE_LENGTH = 80
  * Align spaces to the right of &
  */
 fun rightTableSpaceAlign(latexCommonSettings: CommonCodeStyleSettings, parent: ASTBlock, left: ASTBlock): Spacing? {
-    // Only add spaces after &, unless escaped
+    // Only add spaces after &, unless escaped or inside url.
     if (left.node?.text?.endsWith("&") == false) return null
     if (left.node?.text?.endsWith("\\&") == true) return null
+    if (left.node?.psi?.inUrl() == true) return null
 
     if (parent.node?.psi?.firstParentOfType(LatexEnvironmentContent::class)
         ?.firstParentOfType(LatexEnvironment::class)?.getEnvironmentName() !in EnvironmentMagic.getAllTableEnvironments(
@@ -43,6 +45,8 @@ fun rightTableSpaceAlign(latexCommonSettings: CommonCodeStyleSettings, parent: A
  * Align spaces to the left of & or \\
  */
 fun leftTableSpaceAlign(latexCommonSettings: CommonCodeStyleSettings, parent: ASTBlock, right: ASTBlock): Spacing? {
+    if (right.node?.psi?.inUrl() == true) return null
+
     // Check if parent is in environment content of a table environment
     val contentElement = parent.node?.psi?.firstParentOfType(LatexEnvironmentContent::class)
     val project = parent.node?.psi?.project ?: ProjectManager.getInstance().defaultProject

--- a/src/nl/hannahsten/texifyidea/formatting/spacingrules/TableAlignRule.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/spacingrules/TableAlignRule.kt
@@ -7,11 +7,11 @@ import com.intellij.psi.codeStyle.CommonCodeStyleSettings
 import nl.hannahsten.texifyidea.formatting.createSpacing
 import nl.hannahsten.texifyidea.psi.LatexEnvironment
 import nl.hannahsten.texifyidea.psi.LatexEnvironmentContent
+import nl.hannahsten.texifyidea.psi.LatexTypes
 import nl.hannahsten.texifyidea.psi.getEnvironmentName
 import nl.hannahsten.texifyidea.util.getIndent
 import nl.hannahsten.texifyidea.util.magic.EnvironmentMagic
 import nl.hannahsten.texifyidea.util.parser.firstParentOfType
-import nl.hannahsten.texifyidea.util.parser.inUrl
 import kotlin.math.min
 
 /** At this length, we put table cells on their own line. */
@@ -24,7 +24,7 @@ fun rightTableSpaceAlign(latexCommonSettings: CommonCodeStyleSettings, parent: A
     // Only add spaces after &, unless escaped or inside url.
     if (left.node?.text?.endsWith("&") == false) return null
     if (left.node?.text?.endsWith("\\&") == true) return null
-    if (left.node?.psi?.inUrl() == true) return null
+    if (left.node?.elementType == LatexTypes.RAW_TEXT_TOKEN || parent.node?.elementType == LatexTypes.RAW_TEXT) return null
 
     if (parent.node?.psi?.firstParentOfType(LatexEnvironmentContent::class)
         ?.firstParentOfType(LatexEnvironment::class)?.getEnvironmentName() !in EnvironmentMagic.getAllTableEnvironments(
@@ -45,7 +45,7 @@ fun rightTableSpaceAlign(latexCommonSettings: CommonCodeStyleSettings, parent: A
  * Align spaces to the left of & or \\
  */
 fun leftTableSpaceAlign(latexCommonSettings: CommonCodeStyleSettings, parent: ASTBlock, right: ASTBlock): Spacing? {
-    if (right.node?.psi?.inUrl() == true) return null
+    if (right.node?.elementType == LatexTypes.RAW_TEXT_TOKEN || parent.node?.elementType == LatexTypes.RAW_TEXT) return null
 
     // Check if parent is in environment content of a table environment
     val contentElement = parent.node?.psi?.firstParentOfType(LatexEnvironmentContent::class)

--- a/src/nl/hannahsten/texifyidea/util/parser/Psi.kt
+++ b/src/nl/hannahsten/texifyidea/util/parser/Psi.kt
@@ -17,7 +17,6 @@ import nl.hannahsten.texifyidea.lang.DefaultEnvironment
 import nl.hannahsten.texifyidea.lang.Environment
 import nl.hannahsten.texifyidea.lang.magic.TextBasedMagicCommentParser
 import nl.hannahsten.texifyidea.psi.*
-import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.magic.EnvironmentMagic
 import kotlin.reflect.KClass
 
@@ -178,15 +177,6 @@ fun PsiElement?.findOuterMathEnvironment(): PsiElement? {
 fun PsiElement.inComment() = inDirectEnvironmentContext(Environment.Context.COMMENT) || when (this) {
     is PsiComment -> true
     else -> this is LeafPsiElement && elementType == LatexTypes.COMMAND_TOKEN
-}
-
-/**
- * Check if the element is in a url command.
- */
-fun PsiElement?.inUrl(): Boolean {
-    return this?.hasParentMatching(100) {
-        (it as? LatexCommands)?.name in CommandMagic.urls
-    } ?: false
 }
 
 /**

--- a/src/nl/hannahsten/texifyidea/util/parser/Psi.kt
+++ b/src/nl/hannahsten/texifyidea/util/parser/Psi.kt
@@ -17,6 +17,7 @@ import nl.hannahsten.texifyidea.lang.DefaultEnvironment
 import nl.hannahsten.texifyidea.lang.Environment
 import nl.hannahsten.texifyidea.lang.magic.TextBasedMagicCommentParser
 import nl.hannahsten.texifyidea.psi.*
+import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.magic.EnvironmentMagic
 import kotlin.reflect.KClass
 
@@ -177,6 +178,15 @@ fun PsiElement?.findOuterMathEnvironment(): PsiElement? {
 fun PsiElement.inComment() = inDirectEnvironmentContext(Environment.Context.COMMENT) || when (this) {
     is PsiComment -> true
     else -> this is LeafPsiElement && elementType == LatexTypes.COMMAND_TOKEN
+}
+
+/**
+ * Check if the element is in a url command.
+ */
+fun PsiElement?.inUrl(): Boolean {
+    return this?.hasParentMatching(100) {
+        (it as? LatexCommands)?.name in CommandMagic.urls
+    } ?: false
 }
 
 /**

--- a/test/nl/hannahsten/texifyidea/formatting/TableAlignTest.kt
+++ b/test/nl/hannahsten/texifyidea/formatting/TableAlignTest.kt
@@ -375,6 +375,28 @@ class TableAlignTest : BasePlatformTestCase() {
         """.trimIndent()
     }
 
+    fun testAmpersandsInUrl() {
+        """
+            \documentclass{article}
+            \usepackage{hyperref}
+            \begin{document}
+                \begin{tabular}{ll}
+                    a & \url{https://youtu.be/dQw4w9WgXcQ?si=SHq6ADlwRNZ1hwOB&t=18} & c \\
+                    be & \url{https://youtu.be/dQw4w9WgXcQ?si=SHq6ADlwRNZ1hwOB&t=18} & d
+                \end{tabular}
+            \end{document}
+        """.trimIndent() `should be reformatted to` """
+            \documentclass{article}
+            \usepackage{hyperref}
+            \begin{document}
+                \begin{tabular}{ll}
+                    a  & \url{https://youtu.be/dQw4w9WgXcQ?si=SHq6ADlwRNZ1hwOB&t=18} & c \\
+                    be & \url{https://youtu.be/dQw4w9WgXcQ?si=SHq6ADlwRNZ1hwOB&t=18} & d
+                \end{tabular}
+            \end{document}
+        """.trimIndent()
+    }
+
     fun testVeryWideTable() {
         val start = """
 \documentclass[11pt]{article}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3336 

#### Summary of additions and changes

* Fix alignment of `&` inside tables when used inside a `\url` command.

#### How to test this pull request

See tests

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary