### PR TITLE
Check for mthelp before calling it

### DIFF
--- a/src/nl/hannahsten/texifyidea/documentation/LatexDocumentationProvider.kt
+++ b/src/nl/hannahsten/texifyidea/documentation/LatexDocumentationProvider.kt
@@ -184,10 +184,11 @@ class LatexDocumentationProvider : DocumentationProvider {
                 // texdoc on MiKTeX is just a shortcut for mthelp which doesn't need the -M option
                 listOf("texdoc", "-l", name)
             }
-            else {
+            else if (SystemEnvironment.isAvailable("mthelp")) {
                 // In some cases, texdoc may not be available but mthelp is
                 listOf("mthelp", "-l", name)
-            }
+            } else
+                raise(CommandFailure("Could not find mthelp or texdoc", 0))
         }
         val (output, exitCode) = runCommandWithExitCode(*command.toTypedArray(), returnExceptionMessage = true)
         if (exitCode != 0 || output?.isNotBlank() != true) {


### PR DESCRIPTION
Fix #3335 

I am unable to test the changes, but I presume that since we were calling `mthelp` without checking for its presence, that that hung things up a lot. Feel free to change the error handling