### PR TITLE
Don't recursively create output directories and remember files to clean up

### DIFF
--- a/resources/inspectionDescriptions/LatexUndefinedCommand.html
+++ b/resources/inspectionDescriptions/LatexUndefinedCommand.html
@@ -1,5 +1,6 @@
 <html>
     <body>
         The command was not found in LaTeX or any included package.
+        This inspection is still experimental and a work in progress, so may have (many) false positives.
     </body>
 </html>

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexCommandLineState.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexCommandLineState.kt
@@ -68,6 +68,7 @@ open class LatexCommandLineState(environment: ExecutionEnvironment, private val 
         else {
             setOf()
         }
+        runConfig.filesToCleanUpIfEmpty.addAll(createdOutputDirectories)
 
         val handler = createHandler(mainFile, compiler)
         val isMakeindexNeeded = runMakeindexIfNeeded(handler, mainFile, runConfig.filesToCleanUp)
@@ -77,7 +78,7 @@ open class LatexCommandLineState(environment: ExecutionEnvironment, private val 
         if (!isLastCompile(isMakeindexNeeded, handler)) return handler
         scheduleBibtexRunIfNeeded(handler)
         schedulePdfViewerIfNeeded(handler)
-        scheduleFileCleanup(runConfig.filesToCleanUp, createdOutputDirectories, handler)
+        scheduleFileCleanup(runConfig.filesToCleanUp, runConfig.filesToCleanUpIfEmpty, handler)
 
         return handler
     }

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexOutputPath.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexOutputPath.kt
@@ -154,6 +154,8 @@ class LatexOutputPath(private val variant: String, var contentRoot: VirtualFile?
 
         // Create output paths (see issue #70 on GitHub)
         files.asSequence()
+            // Ignore all output directories to avoid exponential recursion
+            .filter { !it.path.contains(outPath) }
             .mapNotNull {
                 FileUtil.pathRelativeTo(includeRoot?.path ?: return@mapNotNull null, it.path)
             }

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
@@ -176,6 +176,7 @@ class LatexRunConfiguration(
     // In order to propagate information about which files need to be cleaned up at the end between one run of the run config
     // (for example makeindex) and the last run, we save this information temporarily here while the run configuration is running.
     val filesToCleanUp = mutableListOf<File>()
+    val filesToCleanUpIfEmpty = mutableSetOf<File>()
 
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> {
         return LatexSettingsEditor(project)


### PR DESCRIPTION

<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3322

#### Summary of additions and changes

* Never create output directories recursively when creating output paths for #70
* Clean up these created output directories if empty, also when running a run configuration multiple times (e.g. with bibtex inbetween)