### PR TITLE
Fix equation gathering

### DIFF
--- a/src/nl/hannahsten/texifyidea/util/parser/LatexPsiUtil.kt
+++ b/src/nl/hannahsten/texifyidea/util/parser/LatexPsiUtil.kt
@@ -77,7 +77,7 @@ fun LatexEndCommand.beginCommand(): LatexBeginCommand? = previousSiblingOfType(L
 /**
  * Checks if the latex content objects is a display math environment.
  */
-fun LatexNoMathContent.isDisplayMath() = children.firstOrNull() is LatexMathEnvironment
+fun LatexNoMathContent.isDisplayMath() = children.firstOrNull() is LatexMathEnvironment && children.first().firstChild is LatexDisplayMath
 
 /*
  * Technically it's impossible to determine for all cases whether a users wants to compile with biber or biblatex.

--- a/src/nl/hannahsten/texifyidea/util/parser/LatexPsiUtil.kt
+++ b/src/nl/hannahsten/texifyidea/util/parser/LatexPsiUtil.kt
@@ -77,7 +77,7 @@ fun LatexEndCommand.beginCommand(): LatexBeginCommand? = previousSiblingOfType(L
 /**
  * Checks if the latex content objects is a display math environment.
  */
-fun LatexNoMathContent.isDisplayMath() = firstChildOfType(LatexDisplayMath::class) != null && firstChildOfType(LatexEnvironment::class) == null
+fun LatexNoMathContent.isDisplayMath() = children.firstOrNull() is LatexMathEnvironment
 
 /*
  * Technically it's impossible to determine for all cases whether a users wants to compile with biber or biblatex.

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexGatherEquationsInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexGatherEquationsInspectionTest.kt
@@ -20,6 +20,33 @@ class LatexGatherEquationsInspectionTest : TexifyInspectionTestBase(LatexGatherE
         myFixture.checkHighlighting()
     }
 
+    fun `test two consecutive inline math environments`() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            ${"$"}a=b$
+            ${"$"}b=a$
+            """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test display math seperated by inline math environments`() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \[
+                a=b
+            \]
+            ${"$"}c=d$
+            \[
+                e=f
+            \]
+            """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
     fun `test two consecutive (non-display) math environments`() {
         myFixture.configureByText(
             LatexFileType,

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexGatherEquationsInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexGatherEquationsInspectionTest.kt
@@ -35,6 +35,19 @@ class LatexGatherEquationsInspectionTest : TexifyInspectionTestBase(LatexGatherE
         myFixture.checkHighlighting()
     }
 
+    fun `test two consecutive (non-display) math environments in item`() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \begin{enumerate}
+                \item{\[a=b\]}
+                \item{\[b=a\]}
+            \end{enumerate}
+            """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
     fun `test quick fix`() {
         testQuickFix(
             """


### PR DESCRIPTION
Fix #3321 

Previously, the `\item{\[a=b\]}` was returning true from `isDisplayMath` due to it not caring about the depth that the `DisplayMath` child was. This fix passed all tests locally by requiring the math child to be at a depth of exactly 1. 

What should this do?
```latex
\begin{enumerate}
    \item{ \[a=b\] \[b=a\] }
\end{enumerate}
```

right now it does not error and there is no test for it.