### PR TITLE
Improve user feedback for preview when Inkscape is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@
 
 ### Fixed
 
+## [0.9.3-alpha.4] - 2024-01-12
+
+### Added
+
+* Improve autocompletion performance after starting IDE
+* Improve plugin loading performance
+
+### Fixed
+
+* Fix incorrectly inserted \items in enumeration environments, by @jojo2357
+* Fix false positives for equation gathering inspection, by @jojo2357
+* Don't attempt to use mthelp when it is not available, by @jojo2357
+* Fix #3361: false positive on duplicate identifier on @string entries in bib files
+* Replace code deprecated in 2023.3
+* Avoid creating output directories recursively and improve the cleanup process
+
 ## [0.9.3-alpha.3] - 2024-01-08
 
 ### Added
@@ -14,10 +30,10 @@
 
 ### Fixed
 
-* Avoid creating output directories recursively and improve the cleanup process
 * Don't attempt to use mthelp when it is not available, by @jojo2357
 * Fix #3361: false positive on duplicate identifier on @string entries in bib files
 * Replace code deprecated in 2023.3
+* Avoid creating output directories recursively and improve the cleanup process
 
 ## [0.9.2] - 2023-11-24
 
@@ -268,8 +284,9 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Fix some intention previews. ([#2796](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2796))
 * Other small bug fixes and improvements. ([#2776](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2776), [#2774](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2774), [#2765](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2765)-[#2773](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2773))
 
-[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3-alpha.3...HEAD
+[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3-alpha.4...HEAD
 [0.9.3-alpha.3]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.2...v0.9.3-alpha.3
+[0.9.3-alpha.4]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3-alpha.3...v0.9.3-alpha.4
 [0.9.2]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.33...v0.9.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.9.3-alpha.3
+pluginVersion = 0.9.3-alpha.4
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginVersion = 0.9.3-alpha.4
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*
 #    means that the first possible build is the next branch number after xyz, so e.g.
 #    a since build of 173.* is equal to 181
-pluginSinceBuild = 232
+pluginSinceBuild = 233
 
 # Token for releasing to Jetbrains using the Gradle intellij/publishPlugin task, for more information see the Gradle build file.
 intellijPublishToken=mytoken

--- a/src/nl/hannahsten/texifyidea/action/preview/InkscapePreviewer.kt
+++ b/src/nl/hannahsten/texifyidea/action/preview/InkscapePreviewer.kt
@@ -1,10 +1,11 @@
 package nl.hannahsten.texifyidea.action.preview
 
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.io.FileUtil
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import nl.hannahsten.texifyidea.settings.sdk.LatexSdkUtil
 import nl.hannahsten.texifyidea.util.SystemEnvironment
 import nl.hannahsten.texifyidea.util.runCommandWithExitCode
@@ -21,8 +22,8 @@ import javax.swing.SwingUtilities
 class InkscapePreviewer : Previewer {
 
     override fun preview(input: String, previewForm: PreviewForm, project: Project, preamble: String, waitTime: Long) {
-        runBlocking {
-            launch {
+        ProgressManager.getInstance().run(object : Task.Backgroundable(project, "Generating preview...") {
+            override fun run(indicator: ProgressIndicator) {
                 try {
                     // Snap apps are confined to the users home directory
                     if (SystemEnvironment.isInkscapeInstalledAsSnap) {
@@ -46,7 +47,7 @@ class InkscapePreviewer : Previewer {
                     previewForm.setLatexErrorMessage("${exception.message}")
                 }
             }
-        }
+        })
     }
 
     /**


### PR DESCRIPTION
Previously, when inkscape was not installed (but used because of a custom preamble) the error shown would be 'can't read input file'. With this fix it will display the error that inkscape is missing.