### PR TITLE
Define optidev environments

### DIFF
--- a/src/nl/hannahsten/texifyidea/lang/DefaultEnvironment.kt
+++ b/src/nl/hannahsten/texifyidea/lang/DefaultEnvironment.kt
@@ -126,6 +126,18 @@ enum class DefaultEnvironment(
     VSMALLMATRIX_STAR(environmentName = "vsmallmatrix*", context = Context.MATH, dependency = MATHTOOLS),
     VSMALLMATRIX_CAPITAL(environmentName = "Vsmallmatrix", context = Context.MATH, dependency = MATHTOOLS),
     VSMALLMATRIX_CAPITAL_STAR(environmentName = "Vsmallmatrix*", context = Context.MATH, dependency = MATHTOOLS),
+    OPTIDEF_MAXI(environmentName = "maxi", context = Context.MATH),
+    OPTIDEF_MAXI_NO_REFERENCES(environmentName = "maxi*", context = Context.MATH),
+    OPTIDEF_MAXI_MULTI_REFERENCES(environmentName = "maxi!", context = Context.MATH),
+    OPTIDEF_ARGMAXI(environmentName = "argmaxi", context = Context.MATH),
+    OPTIDEF_ARGMAXI_NO_REFERENCES(environmentName = "argmaxi*", context = Context.MATH),
+    OPTIDEF_ARGMAXI_MULTI_REFERENCES(environmentName = "argmaxi!", context = Context.MATH),
+    OPTIDEF_MINI(environmentName = "mini", context = Context.MATH),
+    OPTIDEF_MINI_NO_REFERENCES(environmentName = "mini*", context = Context.MATH),
+    OPTIDEF_MINI_MULTI_REFERENCES(environmentName = "mini!", context = Context.MATH),
+    OPTIDEF_ARGMINI(environmentName = "argmini", context = Context.MATH),
+    OPTIDEF_ARGMINI_NO_REFERENCES(environmentName = "argmini*", context = Context.MATH),
+    OPTIDEF_ARGMINI_MULTI_REFERENCES(environmentName = "argmini!", context = Context.MATH),
 
     // other
     ALGORITHM("algorithm"),


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3388

#### Summary of additions and changes

* This configures math mode for the 12 optidef environments 

#### How to test this pull request

Optidef environments are now using math mode in the editor. 

```latex
\documentclass{article}
\usepackage{optidef}
\begin{document}

    \begin{maxi!}|l|[3]
        {x}{x}{}{}{}
    \addConstraint{x}{\leq 0}{}\label{test}
    \end{maxi!}


\end{document}
```

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary