### PR TITLE
Improve extraction of MiKTeX package source files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@
 
 ### Fixed
 
+## [0.9.3-alpha.5] - 2024-01-14
+
+### Added
+
+* Improve MiKTeX package source files extraction
+* Add optidev environments as math environments, by @leandrolerena
+* Improve autocompletion performance after starting IDE
+* Improve plugin loading performance
+
+### Fixed
+
+* Improve user feedback for equation preview when Inkscape is not installed
+* Fix incorrectly inserted \items in enumeration environments, by @jojo2357
+* Fix false positives for equation gathering inspection, by @jojo2357
+* Don't attempt to use mthelp when it is not available, by @jojo2357
+* Fix #3361: false positive on duplicate identifier on @string entries in bib files
+* Replace code deprecated in 2023.3
+* Avoid creating output directories recursively and improve the cleanup process
+
 ## [0.9.3-alpha.4] - 2024-01-12
 
 ### Added
@@ -284,9 +303,10 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Fix some intention previews. ([#2796](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2796))
 * Other small bug fixes and improvements. ([#2776](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2776), [#2774](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2774), [#2765](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2765)-[#2773](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2773))
 
-[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3-alpha.4...HEAD
-[0.9.3-alpha.3]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.2...v0.9.3-alpha.3
+[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3-alpha.5...HEAD
 [0.9.3-alpha.4]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3-alpha.3...v0.9.3-alpha.4
+[0.9.3-alpha.3]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.2...v0.9.3-alpha.3
+[0.9.3-alpha.5]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3-alpha.4...v0.9.3-alpha.5
 [0.9.2]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.7.33...v0.9.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.9.3-alpha.4
+pluginVersion = 0.9.3-alpha.5
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/index/file/LatexIndexableSetContributor.kt
+++ b/src/nl/hannahsten/texifyidea/index/file/LatexIndexableSetContributor.kt
@@ -1,5 +1,8 @@
 package nl.hannahsten.texifyidea.index.file
 
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task.Backgroundable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.indexing.IndexableSetContributor
@@ -19,8 +22,6 @@ import java.nio.file.Path
  */
 class LatexIndexableSetContributor : IndexableSetContributor() {
 
-    private var extractedFiles = false
-
     override fun getAdditionalProjectRootsToIndex(project: Project): MutableSet<VirtualFile> {
         // Avoid indexing in tests
         if (project.isTestProject()) {
@@ -31,19 +32,24 @@ class LatexIndexableSetContributor : IndexableSetContributor() {
 
         // Add source files
         val roots = LatexSdkUtil.getSdkSourceRoots(project) { sdk, homePath -> sdk.getDefaultSourcesPath(homePath) }.toMutableSet()
-        // Check if we possibly need to extract files first
+        // Check if we possibly need to extract files first, but don't try more than once
         if (!extractedFiles) {
             extractedFiles = true
             for (root in roots) {
                 if (root.path.contains("MiKTeX", ignoreCase = true)) {
-                    try {
-                        if (!extractMiktexFiles(root)) continue
-                    }
-                    catch (e: ArchiverException) {
-                        // Ignore permission errors, nothing we can do about that
-                        Log.debug("Exception when trying to extract MiKTeX source files: ${e.message}")
-                        continue
-                    }
+                    // Run in the background with progress, we cannot wait for completion because that would block this thread,
+                    // so in the worst case the files will only be indexed the next time indexing is triggered
+                    ProgressManager.getInstance().run(object : Backgroundable(project, "Extracting MiKTeX package source files", true) {
+                        override fun run(indicator: ProgressIndicator) {
+                            try {
+                                extractMiktexFiles(root, indicator)
+                            }
+                            catch (e: ArchiverException) {
+                                // Ignore permission errors, nothing we can do about that
+                                Log.debug("Exception when trying to extract MiKTeX source files: ${e.stackTraceToString()}")
+                            }
+                        }
+                    })
                 }
             }
         }
@@ -64,10 +70,11 @@ class LatexIndexableSetContributor : IndexableSetContributor() {
      *
      * @return If succeeded.
      */
-    private fun extractMiktexFiles(root: VirtualFile): Boolean {
+    private fun extractMiktexFiles(root: VirtualFile, indicator: ProgressIndicator): Boolean {
         val txArchiver = TarXZUnArchiver()
         val zips = File(root.path).list { _, name -> name.endsWith("tar.xz") } ?: return false
         for ((index, zipName) in zips.withIndex()) {
+            indicator.fraction = index.toDouble() / zips.size
             txArchiver.sourceFile = File(root.path, zipName)
             // Note that by keeping the target path the same for everything, some packages will install in source/latex and some in source/latex/latex depending on how they were zipped
             val destination = File(root.path, "latex")
@@ -102,3 +109,5 @@ class LatexIndexableSetContributor : IndexableSetContributor() {
 
     override fun getAdditionalRootsToIndex() = mutableSetOf<VirtualFile>()
 }
+
+private var extractedFiles = false


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3316

#### Summary of additions and changes

* Only try to extract package sources once, even if it fails
* Run extraction in background to avoid blocking UI. This may cause files not to be indexed the first time, but not sure
