### PR TITLE
Fix bug with completion of file path arguments when text already present

### DIFF
--- a/.github/actions/insert-youtrack-link/action.yml
+++ b/.github/actions/insert-youtrack-link/action.yml
@@ -11,5 +11,5 @@ inputs:
     description: 'Secret repository token'
     required: true
 runs:
-  using: node16
+  using: node20
   main: index.js

--- a/src/nl/hannahsten/texifyidea/completion/pathcompletion/LatexPathProviderBase.kt
+++ b/src/nl/hannahsten/texifyidea/completion/pathcompletion/LatexPathProviderBase.kt
@@ -21,7 +21,7 @@ import nl.hannahsten.texifyidea.psi.LatexRequiredParam
 import nl.hannahsten.texifyidea.util.expandCommandsOnce
 import nl.hannahsten.texifyidea.util.files.findRootFile
 import nl.hannahsten.texifyidea.util.files.isLatexFile
-import nl.hannahsten.texifyidea.util.replaceFrom
+import nl.hannahsten.texifyidea.util.replaceAfterFrom
 import java.io.File
 import java.util.regex.Pattern
 
@@ -57,7 +57,6 @@ abstract class LatexPathProviderBase : CompletionProvider<CompletionParameters>(
         // Process the expanded text again
         finalCompleteText = processAutocompleteText(finalCompleteText)
         resultSet = result.withPrefixMatcher(finalCompleteText)
-//        resultSet = result
         selectScanRoots(parameters.originalFile).forEach {
             addByDirectory(it, finalCompleteText)
         }
@@ -249,7 +248,7 @@ abstract class LatexPathProviderBase : CompletionProvider<CompletionParameters>(
         result = result.split(",").last()
 
         // Remove everything that comes after and including IntellijIdeaRulezzz, as that is the dummy for the caret.
-        result = result.replaceFrom("IntellijIdeaRulezzz", "")
+        result = result.replaceAfterFrom("IntellijIdeaRulezzz", "")
 
         // Prevent double ./
         if (result.startsWith("./")) {

--- a/src/nl/hannahsten/texifyidea/completion/pathcompletion/LatexPathProviderBase.kt
+++ b/src/nl/hannahsten/texifyidea/completion/pathcompletion/LatexPathProviderBase.kt
@@ -177,7 +177,8 @@ abstract class LatexPathProviderBase : CompletionProvider<CompletionParameters>(
         val icon = TexifyIcons.getIconFromExtension(foundFile.extension, default = FILE)
         resultSet?.addElement(
             LookupElementBuilder.create(baseDir + foundFile.name)
-                .withPresentableText(foundFile.presentableName)
+                .withPresentableText(foundFile.nameWithoutExtension)
+                .withTailText(".${foundFile.extension}", true)
                 .withInsertHandler(
                     CompositeHandler(
                         LatexReferenceInsertHandler(),

--- a/src/nl/hannahsten/texifyidea/completion/pathcompletion/LatexPathProviderBase.kt
+++ b/src/nl/hannahsten/texifyidea/completion/pathcompletion/LatexPathProviderBase.kt
@@ -21,6 +21,7 @@ import nl.hannahsten.texifyidea.psi.LatexRequiredParam
 import nl.hannahsten.texifyidea.util.expandCommandsOnce
 import nl.hannahsten.texifyidea.util.files.findRootFile
 import nl.hannahsten.texifyidea.util.files.isLatexFile
+import nl.hannahsten.texifyidea.util.replaceFrom
 import java.io.File
 import java.util.regex.Pattern
 
@@ -56,6 +57,7 @@ abstract class LatexPathProviderBase : CompletionProvider<CompletionParameters>(
         // Process the expanded text again
         finalCompleteText = processAutocompleteText(finalCompleteText)
         resultSet = result.withPrefixMatcher(finalCompleteText)
+//        resultSet = result
         selectScanRoots(parameters.originalFile).forEach {
             addByDirectory(it, finalCompleteText)
         }
@@ -233,7 +235,7 @@ abstract class LatexPathProviderBase : CompletionProvider<CompletionParameters>(
      *
      * This does the following:
      * - Removes any start '{' and ending '}'
-     * - Remove 'IntelliJIdeaRulezz'
+     * - Remove 'IntelliJIdeaRulezzz'
      * - Removes any arguments before the last one (separated by ',')
      * - Remove starting './'
      * - Prevent '//' (removes the first '/')
@@ -244,8 +246,10 @@ abstract class LatexPathProviderBase : CompletionProvider<CompletionParameters>(
         // When the last parameter is autocompleted, parameters before that may also be present in
         // autocompleteText so we split on commas and take the last one. If it is not the last
         // parameter, no commas will be present so the split will do nothing.
-        result = result.replace("IntellijIdeaRulezzz", "")
-            .split(",").last()
+        result = result.split(",").last()
+
+        // Remove everything that comes after and including IntellijIdeaRulezzz, as that is the dummy for the caret.
+        result = result.replaceFrom("IntellijIdeaRulezzz", "")
 
         // Prevent double ./
         if (result.startsWith("./")) {

--- a/src/nl/hannahsten/texifyidea/util/Strings.kt
+++ b/src/nl/hannahsten/texifyidea/util/Strings.kt
@@ -155,6 +155,11 @@ fun String.removeAll(vararg strings: String): String {
 fun String.remove(string: String): String = this.replace(string, "")
 
 /**
+ * Replace everything after [string] - including [string] - from [this].
+ */
+fun String.replaceFrom(string: String, replacement: String) = this.replaceAfter(string, replacement).remove(string)
+
+/**
  * Formats the string as a valid filename, removing not-allowed characters, in TeX-style with - as separator.
  */
 fun String.formatAsFileName(): String = this.formatAsFilePath().removeAll("/", "\\")

--- a/src/nl/hannahsten/texifyidea/util/Strings.kt
+++ b/src/nl/hannahsten/texifyidea/util/Strings.kt
@@ -157,7 +157,7 @@ fun String.remove(string: String): String = this.replace(string, "")
 /**
  * Replace everything after [string] - including [string] - from [this].
  */
-fun String.replaceFrom(string: String, replacement: String) = this.replaceAfter(string, replacement).remove(string)
+fun String.replaceAfterFrom(string: String, replacement: String) = this.replaceAfter(string, replacement).remove(string)
 
 /**
  * Formats the string as a valid filename, removing not-allowed characters, in TeX-style with - as separator.

--- a/test/nl/hannahsten/texifyidea/completion/LatexPathCompletionRelativeToRootFile.kt
+++ b/test/nl/hannahsten/texifyidea/completion/LatexPathCompletionRelativeToRootFile.kt
@@ -1,6 +1,7 @@
 package nl.hannahsten.texifyidea.completion
 
 import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.lookup.Lookup
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import nl.hannahsten.texifyidea.file.LatexFileType
 
@@ -35,6 +36,24 @@ class LatexPathCompletionRelativeToRootFile : BasePlatformTestCase() {
         val result = myFixture.complete(CompletionType.BASIC)
 
         assert(result.any { it.lookupString == "inputted.tex" })
+    }
+
+    fun `test completion for partly entered filename`() {
+        myFixture.configureByText(LatexFileType, """\input{i<caret>.tex}""")
+
+        myFixture.complete(CompletionType.BASIC)
+        myFixture.finishLookup(Lookup.NORMAL_SELECT_CHAR)
+
+        myFixture.checkResult ("""\input{inputted.tex}""")
+    }
+
+    fun `test tab completion for partly entered filename`() {
+        myFixture.configureByText(LatexFileType, """\input{i<caret>.tex}""")
+
+        myFixture.complete(CompletionType.BASIC)
+        myFixture.finishLookup(Lookup.REPLACE_SELECT_CHAR)
+
+        myFixture.checkResult ("""\input{inputted}""")
     }
 
     fun `test completion in included file from subdirectory for files in main dir`() {

--- a/test/nl/hannahsten/texifyidea/completion/LatexPathCompletionRelativeToRootFile.kt
+++ b/test/nl/hannahsten/texifyidea/completion/LatexPathCompletionRelativeToRootFile.kt
@@ -44,7 +44,7 @@ class LatexPathCompletionRelativeToRootFile : BasePlatformTestCase() {
         myFixture.complete(CompletionType.BASIC)
         myFixture.finishLookup(Lookup.NORMAL_SELECT_CHAR)
 
-        myFixture.checkResult ("""\input{inputted.tex}""")
+        myFixture.checkResult("""\input{inputted.tex}""")
     }
 
     fun `test tab completion for partly entered filename`() {
@@ -53,7 +53,7 @@ class LatexPathCompletionRelativeToRootFile : BasePlatformTestCase() {
         myFixture.complete(CompletionType.BASIC)
         myFixture.finishLookup(Lookup.REPLACE_SELECT_CHAR)
 
-        myFixture.checkResult ("""\input{inputted}""")
+        myFixture.checkResult("""\input{inputted}""")
     }
 
     fun `test completion in included file from subdirectory for files in main dir`() {


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix [TEX-153](https://texify-idea.myjetbrains.com/youtrack/issue/TEX-153)

#### Summary of additions and changes

* Improved insertion of file name when using the autocompletion.
* Moved the file extension from the main text to the tail text, so it's clear that this is not inserted when selecting the lookup element.
* Upgraded node version in issue linker Action. 


#### How to test this pull request

Create two extra files, `one.tex` and `two.tex`, then add a `main.tex` file with the following contents:

```latex
\documentclass{article}

\begin{document}
    \input{tw.tex}
\end{document}
```

place the caret like `tw<caret>.tex` and trigger the autocompletion. Complete with <kbd>tab</kbd> or <kbd>enter</kbd>. 


- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary