### PR TITLE
Just dont inline whitespaces

### DIFF
--- a/src/nl/hannahsten/texifyidea/refactoring/inlinefile/LatexInlineFileProcessor.kt
+++ b/src/nl/hannahsten/texifyidea/refactoring/inlinefile/LatexInlineFileProcessor.kt
@@ -72,12 +72,14 @@ class LatexInlineFileProcessor(
      * @param psiElement The element to remove and replace with the contents of the file
      */
     private fun replaceUsage(psiElement: PsiElement) {
+        val nonEmptyChildren = inlineFile.children.filter { it.text.trim().length > 0 }
+
         val root = psiElement.replace(
-            inlineFile.children[0]
+            nonEmptyChildren[0]
         )
 
-        for (i in 1 until inlineFile.children.size) {
-            psiElement.containingFile.addAfter(inlineFile.children[i], root)
+        for (i in 1 until nonEmptyChildren.size) {
+            psiElement.containingFile.addAfter(nonEmptyChildren[i], root)
         }
     }
 

--- a/src/nl/hannahsten/texifyidea/refactoring/inlinefile/LatexInlineFileProcessor.kt
+++ b/src/nl/hannahsten/texifyidea/refactoring/inlinefile/LatexInlineFileProcessor.kt
@@ -72,7 +72,7 @@ class LatexInlineFileProcessor(
      * @param psiElement The element to remove and replace with the contents of the file
      */
     private fun replaceUsage(psiElement: PsiElement) {
-        val nonEmptyChildren = inlineFile.children.filter { it.text.trim().length > 0 }
+        val nonEmptyChildren = inlineFile.children.filter { it.text.trim().isNotEmpty() }
 
         val root = psiElement.replace(
             nonEmptyChildren[0]


### PR DESCRIPTION
Fix #3434 

#### Summary of additions and changes
Simply does not attempt to insert random whitespaces

#### How to test this pull request
Ensure to keep whitespace

main.tex:
```latex
\documentclass[12pt]{article}

\begin{document}
    \section{PDF Questions}
    \input{evil}
\end{document}
```

evil.tex:
```latex
    \subsection{subsection}
```