### PR TITLE
Do not use jlatexmath for tikz preview

### DIFF
--- a/src/nl/hannahsten/texifyidea/action/preview/PreviewAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/preview/PreviewAction.kt
@@ -39,6 +39,7 @@ abstract class PreviewAction(name: String, val icon: Icon?) : EditorAction(name)
         project: Project,
         element: PsiElement,
         key: Key<PreviewFormUpdater>,
+        canUseJlatexmath: Boolean = true,
         config: PreviewFormUpdater.() -> Unit
     ) {
         val toolWindowId = name
@@ -67,7 +68,7 @@ abstract class PreviewAction(name: String, val icon: Icon?) : EditorAction(name)
             if (!content.isPinned) {
                 val form = content.getUserData(key) ?: continue
                 form.config()
-                form.compilePreview(element.text, project)
+                form.compilePreview(element.text, project, canUseJlatexmath)
                 content.displayName = displayName
                 replaced = true
                 break
@@ -89,7 +90,7 @@ abstract class PreviewAction(name: String, val icon: Icon?) : EditorAction(name)
             updater.config()
 
             newContent.putUserData(key, updater)
-            updater.compilePreview(element.text, project)
+            updater.compilePreview(element.text, project, canUseJlatexmath)
         }
         // Show but not focus the window
         toolWindow.activate(null, false)

--- a/src/nl/hannahsten/texifyidea/action/preview/PreviewFormUpdater.kt
+++ b/src/nl/hannahsten/texifyidea/action/preview/PreviewFormUpdater.kt
@@ -50,14 +50,14 @@ class PreviewFormUpdater(private val previewForm: PreviewForm) {
      * This function also starts the creation and compilation of the temporary preview document, and will then
      * either display the preview, or if something failed, the error produced.
      */
-    fun compilePreview(previewCode: String, project: Project) {
+    fun compilePreview(previewCode: String, project: Project, canUseJlatexmath: Boolean) {
         previewForm.setEquation(previewCode)
 
         // Combine default and user defined preamble. Cannot be used if we decide to run latexmath.
         val preamble = preamble + userPreamble
 
         // jlatexmath cannot handle a custom preamble
-        val previewer = if (userPreamble.isBlank()) {
+        val previewer = if (userPreamble.isBlank() && canUseJlatexmath) {
             JlatexmathPreviewer()
         }
         else {

--- a/src/nl/hannahsten/texifyidea/action/preview/ShowTikzPreview.kt
+++ b/src/nl/hannahsten/texifyidea/action/preview/ShowTikzPreview.kt
@@ -34,7 +34,8 @@ class ShowTikzPreview : PreviewAction("Tikz Picture Preview", TexifyIcons.TIKZ_P
         // Make sure we're currently in a tikz environment.
         val tikzEnvironment = findTikzEnvironment(element) ?: return
 
-        displayPreview(project, tikzEnvironment, FORM_KEY) {
+        // jlatexmath cannot display tikz
+        displayPreview(project, tikzEnvironment, FORM_KEY, canUseJlatexmath = false) {
             resetPreamble()
             val psiFile = getPsiFile(file, project) ?: return@displayPreview
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3314

#### Summary of additions and changes

* tikz pictures will never work with jlatexmath so no point in trying

#### How to test this pull request

```latex
    \begin{tikzpicture}
        \node{3};
    \end{tikzpicture}
```
