### PR TITLE
Destroy credentials in case of invalid token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@
 
 ### Fixed
 
+## [0.9.5-alpha.2] - 2024-02-10
+
+### Added
+
+* Improve file filters for the LaTeX package index
+* Improve \DescribeMacro handling for the package doocumentation index
+* Automatically translate HTML from the clipboard to LaTeX, by @jojo2357
+* Add option to disable indentation of environments, by @slideclimb
+
+### Fixed
+
+* Fix exception #3274 in the equation preview
+* Never use jlatexmath for the TikZ preview
+* Destroy invalid tokens for the remote libraries tool windows
+* Fix missing folding for commands in math environments, by @jojo2357
+* Fix an issue when inlining files with whitespace, by @jojo2357
+
 ## [0.9.5-alpha.1] - 2024-02-06
 
 ### Added
@@ -308,8 +325,9 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Fix some intention previews. ([#2796](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2796))
 * Other small bug fixes and improvements. ([#2776](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2776), [#2774](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2774), [#2765](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2765)-[#2773](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2773))
 
-[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5-alpha.1...HEAD
+[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5-alpha.2...HEAD
 [0.9.5-alpha.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.4...v0.9.5-alpha.1
+[0.9.5-alpha.2]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5-alpha.1...v0.9.5-alpha.2
 [0.9.4]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3...v0.9.2
 [0.9.2]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.1...v0.9.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.9.5-alpha.1
+pluginVersion = 0.9.5-alpha.2
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/remotelibraries/mendeley/MendeleyLibrary.kt
+++ b/src/nl/hannahsten/texifyidea/remotelibraries/mendeley/MendeleyLibrary.kt
@@ -8,8 +8,10 @@ import io.ktor.client.plugins.auth.*
 import io.ktor.client.plugins.auth.providers.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
+import io.ktor.http.parsing.*
 import nl.hannahsten.texifyidea.remotelibraries.RemoteBibLibrary
 import nl.hannahsten.texifyidea.util.CredentialAttributes.Mendeley
+import nl.hannahsten.texifyidea.util.Log
 import nl.hannahsten.texifyidea.util.paginateViaLinkHeader
 
 /**
@@ -47,14 +49,29 @@ class MendeleyLibrary(override val identifier: String = NAME, override val displ
 
     override suspend fun getBibtexString(): Pair<HttpResponse, String> {
         MendeleyAuthenticator.getAccessToken()
-        return client.get(urlString = "https://api.mendeley.com/documents") {
+        return try {
+            getBibtexStringWithoutRetry()
+        }
+        catch (e: ParseException) {
+            // If the token is invalid, the http auth header will be "Invalid token" and ktor can't parse it, so we delete credentials and retry
+            // https://github.com/orgs/Hannah-Sten/projects/1/views/2?pane=issue&itemId=48414574
+            // https://youtrack.jetbrains.com/issue/KTOR-4759/Auth-BearerAuthProvider-caches-result-of-loadToken-until-process-death
+            Log.debug(e.message)
+            destroyCredentials()
+            client.plugin(Auth).providers
+                .filterIsInstance<BearerAuthProvider>()
+                .first().clearToken()
+            getBibtexStringWithoutRetry()
+        }
+    }
+
+    private suspend fun getBibtexStringWithoutRetry() = client.get(urlString = "https://api.mendeley.com/documents") {
+        header("Accept", "application/x-bibtex")
+        parameter("view", "bib")
+        parameter("limit", 50)
+    }.paginateViaLinkHeader {
+        client.get(it) {
             header("Accept", "application/x-bibtex")
-            parameter("view", "bib")
-            parameter("limit", 50)
-        }.paginateViaLinkHeader {
-            client.get(it) {
-                header("Accept", "application/x-bibtex")
-            }
         }
     }
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3315

#### Summary of additions and changes

* The parse exception happens because "error(invalid_token)" is not a valid http auth header. I don't know of any better way to detect this
* I think it can happen in cases similar to this: https://stackoverflow.com/questions/72064782/correct-way-to-retrigger-loadtokens-in-ktor-client
