### PR TITLE
Add Zotero Group to the remote libraries tool window

### DIFF
--- a/Writerside/topics/Tool-Windows.md
+++ b/Writerside/topics/Tool-Windows.md
@@ -17,11 +17,13 @@ With the Library tool window (located on the right toolbar) it is possible to co
 
 * [Mendeley](https://www.mendeley.com/search/)
 * [Zotero](https://www.zotero.org/)
+* [Zotero Groups](https://www.zotero.org/groups/)
 * Local BibTeX file, for example a JabRef library
 
 After connecting to a library the contents of this library will be shown in the tool window.
 The items from a remote library are available to the autocompletion of `\cite`-like commands the same way bibliography items that are included in a bibliography file are.
 When using completion on an item that is not in the local bibliography file it will be added by TeXiFy.
+Note that there is a maximum limit of bibtex entries that will be downloaded by TeXiFy to avoid performance issues.
 
 **Completion of a bibliography item from a remote library. LaTeX file on top, BibTeX file on bottom, Libraries tool window on the right.**
 

--- a/resources/META-INF/extensions/tool-windows.xml
+++ b/resources/META-INF/extensions/tool-windows.xml
@@ -20,6 +20,8 @@
             <add-to-group group-id="texify.remotelibraries" anchor="first"/>
             <action class="nl.hannahsten.texifyidea.action.library.zotero.AddZoteroAction" id="texify.zotero.add"
                     text="Zotero"/>
+            <action class="nl.hannahsten.texifyidea.action.library.zotero.AddZoteroGroupAction" id="texify.zoterogroup.add"
+                    text="Zotero Group"/>
             <action class="nl.hannahsten.texifyidea.action.library.mendeley.AddMendeleyAction" id="texify.mendeley.add"
                     text="Mendeley"/>
             <action class="nl.hannahsten.texifyidea.action.library.AddBibtexFileAction" id="texify.bibtexfile.add"

--- a/src/nl/hannahsten/texifyidea/action/library/zotero/AddZoteroGroupAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/library/zotero/AddZoteroGroupAction.kt
@@ -1,0 +1,59 @@
+package nl.hannahsten.texifyidea.action.library.zotero
+
+import arrow.core.Either
+import arrow.core.getOrElse
+import arrow.core.raise.either
+import com.intellij.credentialStore.Credentials
+import com.intellij.ide.passwordSafe.PasswordSafe
+import com.intellij.openapi.project.Project
+import com.intellij.ui.dsl.builder.bindText
+import com.intellij.ui.dsl.builder.panel
+import nl.hannahsten.texifyidea.RemoteLibraryRequestFailure
+import nl.hannahsten.texifyidea.action.library.AddLibraryAction
+import nl.hannahsten.texifyidea.psi.BibtexEntry
+import nl.hannahsten.texifyidea.remotelibraries.RemoteBibLibraryFactory
+import nl.hannahsten.texifyidea.remotelibraries.RemoteLibraryManager
+import nl.hannahsten.texifyidea.remotelibraries.zotero.ZoteroGroupLibrary
+import nl.hannahsten.texifyidea.ui.remotelibraries.AddLibDialogWrapper
+import nl.hannahsten.texifyidea.util.CredentialAttributes
+import javax.swing.JComponent
+
+class AddZoteroGroupAction : AddLibraryAction<ZoteroGroupLibrary, AddZoteroGroupAction.AddZoteroGroupDialogWrapper>() {
+
+    override fun getDialog(project: Project): AddZoteroGroupDialogWrapper {
+        return AddZoteroGroupDialogWrapper(project)
+    }
+
+    override suspend fun createLibrary(dialogWrapper: AddZoteroGroupDialogWrapper, project: Project): Either<RemoteLibraryRequestFailure, Pair<ZoteroGroupLibrary, List<BibtexEntry>>?> = either {
+        val library = RemoteBibLibraryFactory.create<ZoteroGroupLibrary>(ZoteroGroupLibrary.NAME) ?: return@either null
+        val credentials = Credentials(dialogWrapper.groupId, dialogWrapper.userApiKey)
+        PasswordSafe.instance.set(CredentialAttributes.ZoteroGroup.groupAttributes, credentials)
+        val bibItems = library.getCollection().getOrElse { raise(it) }
+        RemoteLibraryManager.getInstance().updateLibrary(library, bibItems)
+        library to bibItems
+    }
+
+    class AddZoteroGroupDialogWrapper(val project: Project) : AddLibDialogWrapper(ZoteroGroupLibrary.NAME) {
+
+        var groupId: String = ""
+
+        var userApiKey: String = ""
+
+        init {
+            init()
+        }
+
+        override fun createCenterPanel(): JComponent {
+            return panel {
+                row("Group ID:") {
+                    textField().bindText({ groupId }, { groupId = it }).focused()
+                    contextHelp("You can find the group ID in the URL of the group")
+                }
+                row("User API key:") {
+                    textField().bindText({ userApiKey }, { userApiKey = it })
+                    contextHelp("Create a new API key in Zotero Settings > Feeds/API > Create new private key")
+                }
+            }
+        }
+    }
+}

--- a/src/nl/hannahsten/texifyidea/remotelibraries/RemoteBibLibraryFactory.kt
+++ b/src/nl/hannahsten/texifyidea/remotelibraries/RemoteBibLibraryFactory.kt
@@ -1,6 +1,7 @@
 package nl.hannahsten.texifyidea.remotelibraries
 
 import nl.hannahsten.texifyidea.remotelibraries.mendeley.MendeleyLibrary
+import nl.hannahsten.texifyidea.remotelibraries.zotero.ZoteroGroupLibrary
 import nl.hannahsten.texifyidea.remotelibraries.zotero.ZoteroLibrary
 import java.nio.charset.StandardCharsets.UTF_8
 import java.security.MessageDigest
@@ -20,6 +21,7 @@ object RemoteBibLibraryFactory {
         val libraryState = RemoteLibraryManager.getInstance().getLibraries()[identifier ?: return null] ?: return null
         return when (libraryState.libraryType.simpleName) {
             ZoteroLibrary::class.simpleName -> ZoteroLibrary(identifier, libraryState.displayName)
+            ZoteroGroupLibrary::class.simpleName -> ZoteroGroupLibrary(identifier, libraryState.displayName)
             MendeleyLibrary::class.simpleName -> MendeleyLibrary(identifier, libraryState.displayName)
             BibtexFileLibrary::class.simpleName -> BibtexFileLibrary(identifier, libraryState.displayName)
             else -> null
@@ -34,6 +36,7 @@ object RemoteBibLibraryFactory {
 
         return when (T::class.simpleName) {
             ZoteroLibrary::class.simpleName -> ZoteroLibrary(identifier, displayName) as T
+            ZoteroGroupLibrary::class.simpleName -> ZoteroGroupLibrary(identifier, displayName) as T
             MendeleyLibrary::class.simpleName -> MendeleyLibrary(identifier, displayName) as T
             BibtexFileLibrary::class.simpleName -> BibtexFileLibrary(identifier, displayName) as T
             else -> null

--- a/src/nl/hannahsten/texifyidea/remotelibraries/zotero/ZoteroGroupLibrary.kt
+++ b/src/nl/hannahsten/texifyidea/remotelibraries/zotero/ZoteroGroupLibrary.kt
@@ -1,0 +1,67 @@
+package nl.hannahsten.texifyidea.remotelibraries.zotero
+
+import arrow.core.Either
+import arrow.core.raise.either
+import arrow.core.raise.ensure
+import com.intellij.ide.passwordSafe.PasswordSafe
+import io.ktor.client.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+import nl.hannahsten.texifyidea.RemoteLibraryRequestFailure
+import nl.hannahsten.texifyidea.remotelibraries.RemoteBibLibrary
+import nl.hannahsten.texifyidea.util.CredentialAttributes
+import nl.hannahsten.texifyidea.util.paginateViaLinkHeader
+
+/**
+ * Similar to [ZoteroLibrary] but then for Zotero Groups, using a group id instead of user id.
+ */
+class ZoteroGroupLibrary(override val identifier: String = NAME, override val displayName: String = NAME) :
+    RemoteBibLibrary(identifier, displayName) {
+
+    private val client by lazy {
+        HttpClient(CIO) {
+            install(HttpRequestRetry) {
+                retryOnServerErrors(maxRetries = 3)
+                exponentialDelay()
+            }
+        }
+    }
+
+    override suspend fun getBibtexString(): Either<RemoteLibraryRequestFailure, String> = either {
+        val credentials = PasswordSafe.instance.get(CredentialAttributes.ZoteroGroup.groupAttributes)
+        // userName will be the group id
+        val (response, content) = client.get("$BASE_URL/groups/${credentials?.userName}/items") {
+            headers {
+                append("Zotero-API-version", VERSION.toString())
+                append("Zotero-API-key", credentials?.password.toString())
+            }
+            parameter("format", "bibtex")
+            parameter("limit", PAGINATION_LIMIT)
+        }.paginateViaLinkHeader {
+            client.get(it) {
+                headers {
+                    append("Zotero-API-version", VERSION.toString())
+                    append("Zotero-API-key", credentials?.password.toString())
+                }
+            }
+        }
+
+        ensure(response.status.value in 200 until 300) {
+            RemoteLibraryRequestFailure(displayName, "${response.status.value}: ${response.status.description}")
+        }
+        content
+    }
+
+    override fun destroyCredentials() {
+        PasswordSafe.instance.set(CredentialAttributes.ZoteroGroup.groupAttributes, null)
+    }
+
+    companion object {
+
+        const val VERSION = 3
+        const val BASE_URL = "https://api.zotero.org"
+        const val PAGINATION_LIMIT = 50
+        const val NAME = "Zotero Group"
+    }
+}

--- a/src/nl/hannahsten/texifyidea/util/CredentialAttributes.kt
+++ b/src/nl/hannahsten/texifyidea/util/CredentialAttributes.kt
@@ -16,6 +16,11 @@ object CredentialAttributes {
         val userAttributes = createCredentialsAttributes(ZoteroLibrary.NAME)
     }
 
+    object ZoteroGroup {
+
+        val groupAttributes = createCredentialsAttributes(ZoteroLibrary.NAME)
+    }
+
     object Mendeley {
 
         val tokenAttributes = createCredentialsAttributes("${MendeleyLibrary.NAME}-token")


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3356

#### Summary of additions and changes

* Add Zotero Group library, same as Zotero but with group instead of user id
* Not sure how to show the group id in the treeview, it will just say 'zotero group' now
* It would be possible to use the api to retrieve available groups

#### How to test this pull request

Group id to test with: 2608283

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary