### PR TITLE
Avoid line breaking in the middle of commands, math and words

### DIFF
--- a/src/nl/hannahsten/texifyidea/editor/LatexLineWrapper.kt
+++ b/src/nl/hannahsten/texifyidea/editor/LatexLineWrapper.kt
@@ -125,7 +125,7 @@ object LatexLineWrapper {
      * @return negative value if no wrapping should be performed for the target line;
      * preferred wrap position otherwise
      */
-    private fun calculatePreferredWrapPosition(
+    fun calculatePreferredWrapPosition(
         editor: Editor,
         text: CharSequence,
         tabSize: Int,

--- a/src/nl/hannahsten/texifyidea/editor/LatexLineWrapper.kt
+++ b/src/nl/hannahsten/texifyidea/editor/LatexLineWrapper.kt
@@ -125,7 +125,7 @@ object LatexLineWrapper {
      * @return negative value if no wrapping should be performed for the target line;
      * preferred wrap position otherwise
      */
-    fun calculatePreferredWrapPosition(
+    private fun calculatePreferredWrapPosition(
         editor: Editor,
         text: CharSequence,
         tabSize: Int,

--- a/src/nl/hannahsten/texifyidea/util/parser/Psi.kt
+++ b/src/nl/hannahsten/texifyidea/util/parser/Psi.kt
@@ -98,6 +98,18 @@ fun <T : PsiElement> PsiElement.firstParentOfType(clazz: KClass<T>): T? {
     return null
 }
 
+// Kotlin version of the above
+inline fun <reified T : PsiElement> PsiElement.firstParentOfType(): T? {
+    var current: PsiElement? = this
+    while (current != null) {
+        if (current is T) {
+            return current
+        }
+        current = current.parent
+    }
+    return null
+}
+
 /**
  * Finds the last child of a certain type.
  */

--- a/test/nl/hannahsten/texifyidea/editor/LatexParagraphFillHandlerTest.kt
+++ b/test/nl/hannahsten/texifyidea/editor/LatexParagraphFillHandlerTest.kt
@@ -70,15 +70,16 @@ class LatexParagraphFillHandlerTest : BasePlatformTestCase() {
             """.trimIndent(),
             """
             Lorem ipsum dolor sit amet, consectetur
-            adipiscing elit, sed do eiusmod tempor 
-            incididunt ut labore et dolore magna aliqua. Ut 
-            enim ad minim veniam, quis nostrud exercitation 
-            ullamco laboris nisi ut aliquip ex ea commodo 
-            consequat. Duis aute irure dolor in 
-            reprehenderit in voluptate velit esse cillum 
-            dolore eu fugiat nulla pariatur. Excepteur sint 
-            occaecat cupidatat non proident, sunt in culpa 
-            qui officia deserunt mollit anim id est laborum.
+            adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua.
+            Ut enim ad minim veniam, quis nostrud
+            exercitation ullamco laboris nisi ut aliquip
+            ex ea commodo consequat. Duis aute irure dolor
+            in reprehenderit in voluptate velit esse
+            cillum dolore eu fugiat nulla pariatur.
+            Excepteur sint occaecat cupidatat non
+            proident, sunt in culpa qui officia deserunt
+            mollit anim id est laborum.
             """.trimIndent()
         )
     }
@@ -98,16 +99,17 @@ class LatexParagraphFillHandlerTest : BasePlatformTestCase() {
             qui officia deserunt mollit anim id est laborum.
             """.trimIndent(),
             """
-            Lorem ipsum dolor sit amet, consectetur 
-            adipiscing elit, sed do eiusmod tempor NEW 
-            WORDS HERE incididunt ut labore et dolore magna
-            aliqua. Ut enim ad minim veniam, quis nostrud 
-            exercitation ullamco laboris nisi ut aliquip ex
-            ea commodo consequat. Duis aute irure dolor in 
-            reprehenderit in voluptate velit esse cillum 
-            dolore eu fugiat nulla pariatur. Excepteur sint
-            occaecat cupidatat non proident, sunt in culpa 
-            qui officia deserunt mollit anim id est laborum.
+            Lorem ipsum dolor sit amet, consectetur
+            adipiscing elit, sed do eiusmod tempor NEW
+            WORDS HERE incididunt ut labore et dolore
+            magna aliqua. Ut enim ad minim veniam, quis
+            nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat. Duis aute
+            irure dolor in reprehenderit in voluptate
+            velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaecat cupidatat
+            non proident, sunt in culpa qui officia
+            deserunt mollit anim id est laborum.
             """.trimIndent()
         )
     }

--- a/test/nl/hannahsten/texifyidea/formatting/LatexLineWrapStrategyTest.kt
+++ b/test/nl/hannahsten/texifyidea/formatting/LatexLineWrapStrategyTest.kt
@@ -39,8 +39,7 @@ class LatexLineWrapStrategyTest : BasePlatformTestCase() {
         myFixture.configureByText(LatexFileType, text)
         myFixture.performEditorAction("ReformatCode")
         val expected = """
-            \section{This includes 
-            permissions.}
+            \section{This includes permissions.}
             \href{https://the-very-very-long.url}{This includes}
             permissions.
         """.trimIndent()
@@ -59,6 +58,41 @@ class LatexLineWrapStrategyTest : BasePlatformTestCase() {
         myFixture.type("URL")
         val expected = """
             \href{https://the-very-very-long.url}{unreasonable long URL}
+        """.trimIndent()
+        myFixture.checkResult(expected)
+    }
+
+    fun testTextWrap() {
+        setUpTest()
+        val text = """
+        \documentclass{article}
+        \begin{document}
+            Über die grüne Wiese hüpft
+            er das gemeinsame Frühstück
+        
+            Beisammensein, onders ${'$'}^{,}${'$'} bei
+        
+            jedoch \footfullcite{author} abhielt
+        
+        \end{document}
+        """.trimIndent()
+        myFixture.configureByText(LatexFileType, text)
+        myFixture.performEditorAction("ReformatCode")
+        val expected = """
+        \documentclass{article}
+        \begin{document}
+            Über die grüne Wiese hüpft
+            er das gemeinsame 
+            Frühstück
+        
+            Beisammensein, onders 
+            ${'$'}^{,}${'$'} bei
+        
+            jedoch 
+            \footfullcite{author} 
+            abhielt
+        
+        \end{document}
         """.trimIndent()
         myFixture.checkResult(expected)
     }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #2923

#### Summary of additions and changes

Changes to the formatter:
* Don't break on German characters in the middle of words (why is this even a default?)
* Don't line break in math, commands. Not so sure about this.

#### How to test this pull request

See new test