### PR TITLE
Support running code before compiling the main file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@
 
 ### Fixed
 
+## [0.9.5-alpha.6] - 2024-03-01
+
+### Added
+
+* Add option to the run configuration settings to run LaTeX commands before compiling the main file
+* Autocompletion for compiler arguments in run configuration settings
+* Support a local Zotero instance in the remote libraries tool window via the BBT plugin
+* Support Zotero groups in the remote libraries tool window
+* Support local BibTeX files in the remote libraries tool window
+* Improve file filters for the LaTeX package index
+* Improve \DescribeMacro handling for the package doocumentation index
+* Automatically translate HTML from the clipboard to LaTeX, by @jojo2357
+* Add option to disable indentation of environments, by @slideclimb
+
+### Fixed
+
+* Fix exception #2976
+* Fix exception #3469
+* Avoid line breaks when reformatting in the middle of commands, math and words
+* Fix exception #3274 in the equation preview
+* Never use jlatexmath for the TikZ preview
+* Destroy invalid tokens for the remote libraries tool windows
+* Fix missing folding for commands in math environments, by @jojo2357
+* Fix an issue when inlining files with whitespace, by @jojo2357
+
 ## [0.9.5-alpha.4] - 2024-02-28
 
 ### Added
@@ -368,11 +393,12 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Fix some intention previews. ([#2796](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2796))
 * Other small bug fixes and improvements. ([#2776](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2776), [#2774](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2774), [#2765](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2765)-[#2773](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2773))
 
-[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5-alpha.4...HEAD
-[0.9.5-alpha.4]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5-alpha.3...v0.9.5-alpha.4
-[0.9.5-alpha.3]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5-alpha.2...v0.9.5-alpha.3
-[0.9.5-alpha.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.4...v0.9.5-alpha.1
+[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5-alpha.6...HEAD
 [0.9.5-alpha.2]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5-alpha.1...v0.9.5-alpha.2
+[0.9.5-alpha.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.4...v0.9.5-alpha.1
+[0.9.5-alpha.3]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5-alpha.2...v0.9.5-alpha.3
+[0.9.5-alpha.4]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5-alpha.3...v0.9.5-alpha.4
+[0.9.5-alpha.6]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5-alpha.4...v0.9.5-alpha.6
 [0.9.4]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3...v0.9.2
 [0.9.2]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.1...v0.9.2

--- a/Writerside/topics/Run-configuration-settings.md
+++ b/Writerside/topics/Run-configuration-settings.md
@@ -123,6 +123,34 @@ You can use for example the `TEXINPUTS` environment variable to include LaTeX fi
 For example `TEXINPUTS=/path/to/directory//:`, where `//` means that LaTeX (and TeXiFy) will search in any subdirectory of `/path/to/directory` for the file to be included, and `:` means to include the standard content of `TEXINPUTS`. For Windows, it is similar: `TEXINPUTS=C:...\path\to\directory\\;` (note the semicolon).
 For more information about paths resolving, see [https://www.tug.org/texinfohtml/kpathsea.html#Path-searching](https://www.tug.org/texinfohtml/kpathsea.html#Path-searching)
 
+## LaTeX code to run before compiling the main file
+_Since b0.9.5_
+
+You can enter LaTeX code to be executed before the main file.
+For example, suppose you want to have two versions of a document, then you could create two run configurations and use this field to set a boolean flag to a different value.
+
+For example, if your LaTeX file contains
+
+<!-- ```latex -->
+```
+\documentclass{article}
+\usepackage{etoolbox}
+
+% Only sets the value of \waarde if it is undefined
+\providecommand{\waarde}{true}
+
+% Create a boolean and set it to the value of \waarde
+\newbool{binair}
+\setbool{binair}{\waarde}
+
+\begin{document}
+    \ifbool{binair}{waar}{onwaar}
+\end{document}
+```
+
+then you can put `\newcommand{\waarde}{false}` in this field in your run configuration to set the value of the boolean to `false`.
+This works for at least pdflatex, lualatex, xelatex and latexmk.
+
 ## Custom SumatraPDF path
 
 See [(Windows) Choose a custom path to SumatraPDF](PDF-viewers.md#portable-sumatrapdf).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
     id("se.patrikerdes.use-latest-versions") version "0.2.18"
 
     // Used to debug in a different IDE
-    id("de.undercouch.download") version "5.5.0"
+    id("de.undercouch.download") version "5.6.0"
 
     // Test coverage
     id("org.jetbrains.kotlinx.kover") version "0.7.6"
@@ -124,9 +124,9 @@ dependencies {
     implementation("org.apache.xmlgraphics:batik-all:1.17")
     implementation("batik:batik-svg-dom:1.6-1")
 
-    implementation("io.arrow-kt:arrow-core:1.2.2")
-    implementation("io.arrow-kt:arrow-fx-coroutines:1.2.2")
-    implementation("io.arrow-kt:arrow-resilience:1.2.2")
+    implementation("io.arrow-kt:arrow-core:1.2.3")
+    implementation("io.arrow-kt:arrow-fx-coroutines:1.2.3")
+    implementation("io.arrow-kt:arrow-resilience:1.2.3")
 
     // Test dependencies
     // No version specified, it equals the kotlin version

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.9.5-alpha.4
+pluginVersion = 0.9.5-alpha.6
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/editor/postfix/LatexPostfixExpressionSelector.kt
+++ b/src/nl/hannahsten/texifyidea/editor/postfix/LatexPostfixExpressionSelector.kt
@@ -9,6 +9,9 @@ import nl.hannahsten.texifyidea.psi.*
 import nl.hannahsten.texifyidea.util.parser.firstParentOfType
 import nl.hannahsten.texifyidea.util.parser.inMathContext
 
+/**
+ * This class is also used by https://github.com/xylo/intellij-postfix-templates/blob/idea-232/src/de/endrullis/idea/postfixtemplates/languages/latex/LatexPostfixTemplateProvider.java
+ */
 class LatexPostfixExpressionSelector(private val mathOnly: Boolean = false, private val textOnly: Boolean = false) : PostfixTemplateExpressionSelector {
 
     override fun hasExpression(context: PsiElement, copyDocument: Document, newOffset: Int): Boolean {

--- a/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
+++ b/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
@@ -348,7 +348,14 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
                 .forEach { command.add(it) }
         }
 
-        command.add(mainFile.name)
+        // Run some code before running the document, which pdflatex supports by being able to run commands in the given string and then using \input to run the actual document
+        if (runConfig.beforeRunCommand?.isNotBlank() == true) {
+            command.add(runConfig.beforeRunCommand + " \\input{${mainFile.name}}")
+        }
+        else {
+            command.add(mainFile.name)
+        }
+
 
         return command
     }

--- a/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
+++ b/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
@@ -348,14 +348,21 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
                 .forEach { command.add(it) }
         }
 
-        // Run some code before running the document, which pdflatex supports by being able to run commands in the given string and then using \input to run the actual document
+        // Run some code before running the document
         if (runConfig.beforeRunCommand?.isNotBlank() == true) {
-            command.add(runConfig.beforeRunCommand + " \\input{${mainFile.name}}")
+            if (runConfig.compiler == LATEXMK) {
+                // latexmk has its own flag to do this
+                command.add("-usepretex=" + runConfig.beforeRunCommand)
+                command.add(mainFile.name)
+            }
+            else {
+                // pdflatex, lualatex and xelatex support this by being able to run on a given string as if it was in a file
+                command.add(runConfig.beforeRunCommand + " \\input{${mainFile.name}}")
+            }
         }
         else {
             command.add(mainFile.name)
         }
-
 
         return command
     }

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
@@ -68,6 +68,7 @@ class LatexRunConfiguration(
         private const val PDF_VIEWER = "pdf-viewer"
         private const val VIEWER_COMMAND = "viewer-command"
         private const val COMPILER_ARGUMENTS = "compiler-arguments"
+        private const val BEFORE_RUN_COMMAND = "before-run-command"
         private const val MAIN_FILE = "main-file"
         private const val OUTPUT_PATH = "output-path"
         private const val AUXIL_PATH = "auxil-path"
@@ -99,6 +100,7 @@ class LatexRunConfiguration(
         }
 
     var environmentVariables: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT
+    var beforeRunCommand: String? = null
 
     var mainFile: VirtualFile? = null
         set(value) {
@@ -277,6 +279,9 @@ class LatexRunConfiguration(
         // Read environment variables
         environmentVariables = EnvironmentVariablesData.readExternal(parent)
 
+        val beforeRunCommandRead = parent.getChildText(BEFORE_RUN_COMMAND)
+        beforeRunCommand = if (beforeRunCommandRead.isNullOrEmpty()) null else beforeRunCommandRead
+
         // Read main file.
         val filePath = parent.getChildText(MAIN_FILE)
         setMainFile(filePath)
@@ -373,6 +378,7 @@ class LatexRunConfiguration(
         parent.addContent(Element(VIEWER_COMMAND).also { it.text = viewerCommand ?: "" })
         parent.addContent(Element(COMPILER_ARGUMENTS).also { it.text = this.compilerArguments ?: "" })
         this.environmentVariables.writeExternal(parent)
+        parent.addContent(Element(BEFORE_RUN_COMMAND).also { it.text = this.beforeRunCommand ?: "" })
         parent.addContent(Element(MAIN_FILE).also { it.text = mainFile?.path ?: "" })
         parent.addContent(Element(OUTPUT_PATH).also { it.text = outputPath.virtualFile?.path ?: outputPath.pathString })
         parent.addContent(Element(AUXIL_PATH).also { it.text = auxilPath.virtualFile?.path ?: auxilPath.pathString })

--- a/src/nl/hannahsten/texifyidea/run/latex/ui/LatexSettingsEditor.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/ui/LatexSettingsEditor.kt
@@ -43,7 +43,7 @@ class LatexSettingsEditor(private var project: Project?) : SettingsEditor<LatexR
     private lateinit var compiler: LabeledComponent<ComboBox<LatexCompiler>>
     private lateinit var enableCompilerPath: JBCheckBox
     private lateinit var compilerPath: TextFieldWithBrowseButton
-    private lateinit var compilerArguments: EditorTextField
+    private lateinit var compilerArguments: LabeledComponent<EditorTextField>
     private lateinit var environmentVariables: EnvironmentVariablesComponent
     private lateinit var beforeRunCommand: LabeledComponent<RawCommandLineEditor>
     private lateinit var mainFile: LabeledComponent<ComponentWithBrowseButton<*>>
@@ -95,7 +95,7 @@ class LatexSettingsEditor(private var project: Project?) : SettingsEditor<LatexR
 
         // Reset compiler arguments
         val args = runConfiguration.compilerArguments
-        compilerArguments.text = args ?: ""
+        compilerArguments.component.text = args ?: ""
 
         // Reset environment variables
         environmentVariables.envData = runConfiguration.environmentVariables
@@ -199,7 +199,7 @@ class LatexSettingsEditor(private var project: Project?) : SettingsEditor<LatexR
         runConfiguration.viewerCommand = if (enableViewerCommand.isSelected) viewerCommand.text else null
 
         // Apply custom compiler arguments
-        runConfiguration.compilerArguments = compilerArguments.text
+        runConfiguration.compilerArguments = compilerArguments.component.text
 
         // Apply environment variables
         runConfiguration.environmentVariables = environmentVariables.envData
@@ -283,7 +283,7 @@ class LatexSettingsEditor(private var project: Project?) : SettingsEditor<LatexR
             LatexArgumentsCompletionProvider(options).apply(argumentsEditor)
         }
 
-        compilerArguments = argumentsEditor
+        compilerArguments = LabeledComponent.create(argumentsEditor, "Custom compiler arguments")
         panel.add(compilerArguments)
 
         environmentVariables = EnvironmentVariablesComponent()

--- a/src/nl/hannahsten/texifyidea/run/latex/ui/LatexSettingsEditor.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/ui/LatexSettingsEditor.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.ui.*
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.ui.EditorTextField
+import com.intellij.ui.RawCommandLineEditor
 import com.intellij.ui.SeparatorComponent
 import com.intellij.ui.TitledSeparator
 import com.intellij.ui.components.JBCheckBox
@@ -44,6 +45,7 @@ class LatexSettingsEditor(private var project: Project?) : SettingsEditor<LatexR
     private lateinit var compilerPath: TextFieldWithBrowseButton
     private lateinit var compilerArguments: EditorTextField
     private lateinit var environmentVariables: EnvironmentVariablesComponent
+    private lateinit var beforeRunCommand: LabeledComponent<RawCommandLineEditor>
     private lateinit var mainFile: LabeledComponent<ComponentWithBrowseButton<*>>
     private lateinit var outputPath: LabeledComponent<ComponentWithBrowseButton<*>>
 
@@ -97,6 +99,8 @@ class LatexSettingsEditor(private var project: Project?) : SettingsEditor<LatexR
 
         // Reset environment variables
         environmentVariables.envData = runConfiguration.environmentVariables
+
+        beforeRunCommand.component.text = runConfiguration.beforeRunCommand
 
         // Reset the main file to compile.
         val txtFile = mainFile.component as TextFieldWithBrowseButton
@@ -200,6 +204,8 @@ class LatexSettingsEditor(private var project: Project?) : SettingsEditor<LatexR
         // Apply environment variables
         runConfiguration.environmentVariables = environmentVariables.envData
 
+        runConfiguration.beforeRunCommand = beforeRunCommand.component.text
+
         // Apply main file.
         val txtFile = mainFile.component as TextFieldWithBrowseButton
         val filePath = txtFile.text
@@ -282,6 +288,9 @@ class LatexSettingsEditor(private var project: Project?) : SettingsEditor<LatexR
 
         environmentVariables = EnvironmentVariablesComponent()
         panel.add(environmentVariables)
+
+        beforeRunCommand = LabeledComponent.create(RawCommandLineEditor(), "LaTeX code to run before compiling the main file")
+        panel.add(beforeRunCommand)
 
         panel.add(SeparatorComponent())
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3040

#### Summary of additions and changes

* Allow running LaTeX before running the main file. There are certainly nicer ways to do this but I want to save that for the new run config

#### How to test this pull request

```latex
\documentclass{article}
\usepackage{etoolbox}

\providecommand{\waarde}{true}
\newbool{binair}
\setbool{binair}{\waarde}

\begin{document}
    \ifbool{binair}{waar}{onwaar}
\end{document}
```
then put `\newcommand{\waarde}{false} ` in run config

- [x] Updated the documentation, or no update necessary
- [x] Test on Windows
- [x] Fix latexmk
- [x] re-add 'compiler arguments' label