### PR TITLE
Ignore \begin and \end commands in \newcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -403,11 +403,6 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Other small bug fixes and improvements. ([#2776](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2776), [#2774](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2774), [#2765](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2765)-[#2773](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2773))
 
 [Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5-alpha.6...HEAD
-[0.9.5-alpha.2]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5-alpha.1...v0.9.5-alpha.2
-[0.9.5-alpha.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.4...v0.9.5-alpha.1
-[0.9.5-alpha.3]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5-alpha.2...v0.9.5-alpha.3
-[0.9.5-alpha.4]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5-alpha.3...v0.9.5-alpha.4
-[0.9.5-alpha.6]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5-alpha.4...v0.9.5-alpha.6
 [0.9.4]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3...v0.9.2
 [0.9.2]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.1...v0.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,47 @@
 
 ### Fixed
 
+## [0.9.5-alpha.8] - 2024-03-30
+
+### Added
+
+* Add \newcommandx and related commands from the xparse package, by @tmczar
+* Improve line wrapping by preferring line breaks at whitespace
+* Add support for the nomencl package
+* Add starred and capitalized versions of cleveref commands to exceptions for non-breaking space inspection, by @niknetniko
+* Add option to the run configuration settings to run LaTeX commands before compiling the main file
+* Autocompletion for compiler arguments in run configuration settings
+* Support a local Zotero instance in the remote libraries tool window via the BBT plugin
+* Support Zotero groups in the remote libraries tool window
+* Support local BibTeX files in the remote libraries tool window
+* Improve file filters for the LaTeX package index
+* Improve \DescribeMacro handling for the package doocumentation index
+* Automatically translate HTML from the clipboard to LaTeX, by @jojo2357
+* Add option to disable indentation of environments, by @slideclimb
+
+### Fixed
+
+* Fix quoted links in bibtex
+* Ignore \begin and \end commands in \newcommand definition in the parser
+* Fix a parser issue when having a single \begin or \end in a \newcommand definition
+* Fix exception #2976
+* Fix exception #3469
+* Avoid line breaks when reformatting in the middle of commands, math and words
+* Fix exception #3274 in the equation preview
+* Never use jlatexmath for the TikZ preview
+* Destroy invalid tokens for the remote libraries tool windows
+* Fix missing folding for commands in math environments, by @jojo2357
+* Fix an issue when inlining files with whitespace, by @jojo2357
+
 ## [0.9.5-alpha.7] - 2024-03-09
 
 ### Added
+
 * Add support for the nomencl package
 * Add starred and capitalized versions of cleveref commands to exceptions for non-breaking space inspection, by @niknetniko
 
 ### Fixed
+
 * Fix a parser issue when having a single \begin or \end in a \newcommand definition
 
 ## [0.9.5-alpha.6] - 2024-03-01
@@ -402,7 +436,7 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Fix some intention previews. ([#2796](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2796))
 * Other small bug fixes and improvements. ([#2776](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2776), [#2774](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2774), [#2765](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2765)-[#2773](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2773))
 
-[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5-alpha.6...HEAD
+[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5-alpha.8...HEAD
 [0.9.4]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3...v0.9.2
 [0.9.2]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.1...v0.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 
 ### Fixed
 
+## [0.9.5-alpha.7] - 2024-03-09
+
+### Added
+* Add support for the nomencl package
+* Add starred and capitalized versions of cleveref commands to exceptions for non-breaking space inspection, by @niknetniko
+
+### Fixed
+* Fix a parser issue when having a single \begin or \end in a \newcommand definition
+
 ## [0.9.5-alpha.6] - 2024-03-01
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ fun properties(key: String) = project.findProperty(key).toString()
 // Include the Gradle plugins which help building everything.
 // Supersedes the use of "buildscript" block and "apply plugin:"
 plugins {
-    id("org.jetbrains.intellij") version "1.17.2"
+    id("org.jetbrains.intellij") version "1.17.3"
     kotlin("jvm") version ("1.9.20")
     kotlin("plugin.serialization") version ("1.9.20")
 
@@ -30,7 +30,7 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "12.1.0"
 
     // Vulnerability scanning
-    id("org.owasp.dependencycheck") version "9.0.9"
+    id("org.owasp.dependencycheck") version "9.0.10"
 
     id("org.jetbrains.changelog") version "2.2.0"
 
@@ -98,15 +98,15 @@ dependencies {
     // Unzipping tar.xz/tar.bz2 files on Windows containing dtx files
     implementation("org.codehaus.plexus:plexus-component-api:1.0-alpha-33")
     implementation("org.codehaus.plexus:plexus-container-default:2.1.1")
-    implementation("org.codehaus.plexus:plexus-archiver:4.9.1")
+    implementation("org.codehaus.plexus:plexus-archiver:4.9.2")
 
     // Parsing json
     implementation("com.beust:klaxon:5.6")
 
     // Parsing xml
-    implementation("com.fasterxml.jackson.core:jackson-core:2.16.2")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.16.2")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.16.2")
+    implementation("com.fasterxml.jackson.core:jackson-core:2.17.0")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.17.0")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0")
 
     // Http requests
     implementation("io.ktor:ktor-client-core:2.3.9")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.changelog.Changelog
@@ -103,18 +104,18 @@ dependencies {
     implementation("com.beust:klaxon:5.6")
 
     // Parsing xml
-    implementation("com.fasterxml.jackson.core:jackson-core:2.16.1")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.16.1")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.16.1")
+    implementation("com.fasterxml.jackson.core:jackson-core:2.16.2")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.16.2")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.16.2")
 
     // Http requests
-    implementation("io.ktor:ktor-client-core:2.3.8")
-    implementation("io.ktor:ktor-client-cio:2.3.8")
-    implementation("io.ktor:ktor-client-auth:2.3.8")
-    implementation("io.ktor:ktor-client-content-negotiation:2.3.8")
-    implementation("io.ktor:ktor-server-core:2.3.8")
-    implementation("io.ktor:ktor-server-jetty:2.3.8")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.8")
+    implementation("io.ktor:ktor-client-core:2.3.9")
+    implementation("io.ktor:ktor-client-cio:2.3.9")
+    implementation("io.ktor:ktor-client-auth:2.3.9")
+    implementation("io.ktor:ktor-client-content-negotiation:2.3.9")
+    implementation("io.ktor:ktor-server-core:2.3.9")
+    implementation("io.ktor:ktor-server-jetty:2.3.9")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.9")
 
     // Comparing versions
     implementation("org.apache.maven:maven-artifact:4.0.0-alpha-12")
@@ -238,7 +239,7 @@ intellij {
 // Generate a Hub token at https://hub.jetbrains.com/users/me?tab=authentification
 // You should provide it either via environment variables (ORG_GRADLE_PROJECT_intellijPublishToken) or Gradle task parameters (-Dorg.gradle.project.intellijPublishToken=mytoken)
 tasks.publishPlugin {
-    dependsOn("patchChangelog")
+//    dependsOn("patchChangelog")
     dependsOn("useLatestVersions")
 //    dependsOn("dependencyCheckAnalyze")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.9.5-alpha.6
+pluginVersion = 0.9.5-alpha.7
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.9.5-alpha.7
+pluginVersion = 0.9.5-alpha.8
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/grammar/LatexLexer.flex
+++ b/src/nl/hannahsten/texifyidea/grammar/LatexLexer.flex
@@ -426,7 +426,7 @@ END_PSEUDOCODE_BLOCK="\\EndFor" | "\\EndIf" | "\\EndWhile" | "\\Until" | "\\EndL
 
 // We have to explicitly specify in which states the $ starts an inline math,
 // because definitely not in all states this should be the case (like inline math)
-<YYINITIAL,DISPLAY_MATH,PSEUDOCODE> {
+<YYINITIAL,DISPLAY_MATH,PSEUDOCODE,NEW_COMMAND_DEFINITION_PARAM2> {
     "$"                             { yypushState(INLINE_MATH); return INLINE_MATH_START; }
     {ROBUST_INLINE_MATH_START}      { yypushState(INLINE_MATH_LATEX); return INLINE_MATH_START; }
 }

--- a/src/nl/hannahsten/texifyidea/grammar/LatexParserDefinition.kt
+++ b/src/nl/hannahsten/texifyidea/grammar/LatexParserDefinition.kt
@@ -48,7 +48,7 @@ class LatexParserDefinition : ParserDefinition {
         val FILE: IStubFileElementType<*> = object : IStubFileElementType<LatexFileStub>(
             "LatexStubFileElementType", Language.findInstance(LatexLanguage::class.java)
         ) {
-            override fun getStubVersion(): Int = 69
+            override fun getStubVersion(): Int = 70
         }
     }
 

--- a/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
@@ -244,4 +244,18 @@ class LatexParserTest : BasePlatformTestCase() {
         )
         myFixture.checkHighlighting()
     }
+
+    fun testUnmatchedBeginInDefinition() {
+        myFixture.configureByText(
+            LatexFileType,
+            """
+            \newcommand{\tableMod}[0]{
+                \end{multicols}
+                \insertedObject
+                \begin{multicols}{2}
+            }
+            """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
 }

--- a/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
@@ -254,6 +254,7 @@ class LatexParserTest : BasePlatformTestCase() {
                 \insertedObject
                 \begin{multicols}{2}
             }
+            \newcommand{\cmd}{${'$'}x\$}
             """.trimIndent()
         )
         myFixture.checkHighlighting()

--- a/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
@@ -254,7 +254,7 @@ class LatexParserTest : BasePlatformTestCase() {
                 \insertedObject
                 \begin{multicols}{2}
             }
-            \newcommand{\cmd}{${'$'}x\$}
+            \newcommand{\cmd}{${'$'}x${'$'}}
             """.trimIndent()
         )
         myFixture.checkHighlighting()

--- a/test/nl/hannahsten/texifyidea/refactoring/IntroduceVariableTest.kt
+++ b/test/nl/hannahsten/texifyidea/refactoring/IntroduceVariableTest.kt
@@ -3,8 +3,8 @@ package nl.hannahsten.texifyidea.refactoring
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.refactoring.introducecommand.ExtractExpressionUi
-import nl.hannahsten.texifyidea.util.parser.LatexExtractablePSI
 import nl.hannahsten.texifyidea.refactoring.introducecommand.withMockTargetExpressionChooser
+import nl.hannahsten.texifyidea.util.parser.LatexExtractablePSI
 
 class IntroduceVariableTest : BasePlatformTestCase() {
     fun testBasicCaret() = doTest(
@@ -166,9 +166,9 @@ class IntroduceVariableTest : BasePlatformTestCase() {
         0,
         """
         \newcommand{\mycommand}{\begin{enumerate}
-                                    \item{Page Data: page id, namespace, title (File Schema: enwiki-latest-page.sql.gz)}
-                                    \item{Link Data: originating page, originating namespace, target page, target namespace (File Schema: enwiki-latest-pagelinks.sql.gz)}
-                                    \item{Redirect Data: originating page, originating namespace, target page, target namespace (File Schema: enwiki-latest-redirect.sql.gz)}
+        \item{Page Data: page id, namespace, title (File Schema: enwiki-latest-page.sql.gz)}
+        \item{Link Data: originating page, originating namespace, target page, target namespace (File Schema: enwiki-latest-pagelinks.sql.gz)}
+        \item{Redirect Data: originating page, originating namespace, target page, target namespace (File Schema: enwiki-latest-redirect.sql.gz)}
         \end{enumerate}}
     
         Hello Werld


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3101

#### Summary of additions and changes

* Lex \begin and \end in \newcommand and \providecommand as regular commands, as they are often unmatched

#### How to test this pull request

```latex
\newcommand{\tableMod}[0]{
    \end{multicols}
    \insertedObject
    \begin{multicols}{2}
}
```

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary
- [x] Parser issue: `\newcommand{\cmd}{$x$}`