### PR TITLE
Add support for commands from xparse package, and document how to do it again

### DIFF
--- a/Writerside/topics/Contributing-to-the-source-code.md
+++ b/Writerside/topics/Contributing-to-the-source-code.md
@@ -15,6 +15,21 @@ You can also look at previous pull requests for inspiration, for example [#2245]
 
 Note, if commands are just missing from the autocompletion, this is likely more complicated because these shouldn’t be hardcoded, but detected automatically.
 
+### Adding support for command: example
+Note: [#2245](https://github.com/Hannah-Sten/TeXiFy-IDEA/pull/2245 presents it very clearly and if You just want to see some code, go that way. Stay here, if You want explanations.
+
+Let's use `\newcommandx` as our example. As the name suggests, this is alternative form of `\newcommand` with additional features.
+First, optional step: add the package the command is from to the list of predefined packages (if it's not already there). List is located in [nl/hannahsten/texifyidea/lang/LatexPackage](https://github.com/Hannah-Sten/TeXiFy-IDEA/tree/master/src/nl/hannahsten/texifyidea/lang/LatexPackage.kt)
+
+Second step: declare the command. Commands are declared in [src/nl/hannahsten/texifyidea/lang/commands](https://github.com/Hannah-Sten/TeXiFy-IDEA/tree/master/src/nl/hannahsten/texifyidea/lang/commands) package and in our example we are going to use [LatexNewDefinitionCommand](https://github.com/Hannah-Sten/TeXiFy-IDEA/tree/master/src/nl/hannahsten/texifyidea/lang/commands/LatexNewDefinitionCommand.kt) class.
+Other types of commands should go to respective classes (names should be self-explanatory).
+Add your command using the syntax analogous to the already existing commands.
+
+Third, and the last step: add handling for the command. Usual place is: [src/nl/hannahsten/texifyidea/util/magic](https://github.com/Hannah-Sten/TeXiFy-IDEA/tree/master/src/nl/hannahsten/texifyidea/util/magic), with the class [CommandMagic](https://github.com/Hannah-Sten/TeXiFy-IDEA/tree/master/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt) in our example.
+Here we add `\newcommandx` to the `regularStrictCommandDefinitions`, which is the set of all standard command defining commands.
+
+And here You go: it's done (at least for this simple example)
+
 [//]: # (todo: separate topic?)
 ## Building from source
 

--- a/src/nl/hannahsten/texifyidea/lang/LatexPackage.kt
+++ b/src/nl/hannahsten/texifyidea/lang/LatexPackage.kt
@@ -88,6 +88,7 @@ open class LatexPackage @JvmOverloads constructor(
         val VARIOREF = LatexPackage("varioref")
         val WASYSYM = LatexPackage("wasysym")
         val WIDETABLE = LatexPackage("widetable")
+        val XARGS = LatexPackage("xargs")
         val XCOLOR = LatexPackage("xcolor")
         val XPARSE = LatexPackage("xparse")
 

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexNewDefinitionCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexNewDefinitionCommand.kt
@@ -2,6 +2,7 @@ package nl.hannahsten.texifyidea.lang.commands
 
 import nl.hannahsten.texifyidea.lang.LatexPackage
 import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.TCOLORBOX
+import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.XARGS
 
 /**
  * @author Hannah Schellekens
@@ -31,6 +32,12 @@ enum class LatexNewDefinitionCommand(
     NEWTCOLORBOX_("NewTColorBox", "init options".asOptional(), "name".asRequired(), "specification".asRequired(), "options".asRequired(), dependency = TCOLORBOX),
     RENEWTCOLORBOX_("ReNewTColorBox", "init options".asOptional(), "name".asRequired(), "specification".asRequired(), "options".asRequired(), dependency = TCOLORBOX),
     PROVIDETCOLORBOX("ProvideTColorBox", "init options".asOptional(), "name".asRequired(), "specification".asRequired(), "options".asRequired(), dependency = TCOLORBOX),
+    NEWCOMMANDX("newcommandx", "cmd".asRequired(), "args".asOptional(), "default".asOptional(), "def".asRequired(Argument.Type.TEXT), dependency = XARGS),
+    RENEWCOMMANDX("renewcommandx", "cmd".asRequired(), "args".asOptional(), "default".asOptional(), "def".asRequired(Argument.Type.TEXT), dependency = XARGS),
+    PROVIDECOMMANDX("providecommandx", "cmd".asRequired(), "args".asOptional(), "default".asOptional(), "def".asRequired(Argument.Type.TEXT), dependency = XARGS),
+    DECLAREROBUSTCOMMANDX("DeclareRobustCommandx", "cmd".asRequired(), "args".asOptional(), "default".asOptional(), "def".asRequired(Argument.Type.TEXT), dependency = XARGS),
+    NEWENVIRONMENTX("newenvironmentx", "cmd".asRequired(), "args".asOptional(), "default".asOptional(), "begdef".asRequired(Argument.Type.TEXT), "enddef".asRequired(Argument.Type.TEXT), dependency = XARGS),
+    RENEWENVIRONMENTX("renewenvironmentx", "cmd".asRequired(), "args".asOptional(), "default".asOptional(), "begdef".asRequired(Argument.Type.TEXT), "enddef".asRequired(Argument.Type.TEXT), dependency = XARGS),
     ;
 
     override val identifier: String

--- a/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
@@ -240,6 +240,7 @@ object CommandMagic {
         NEWCOMMAND_STAR.cmd,
         NEWIF.cmd,
         NEWDOCUMENTCOMMAND.cmd,
+        NEWCOMMANDX.cmd,
     )
 
     /**
@@ -252,6 +253,8 @@ object CommandMagic {
         DECLAREDOCUMENTCOMMAND,
         DEF,
         LET,
+        PROVIDECOMMANDX,
+        DECLAREROBUSTCOMMANDX,
     ).map { it.cmd }
 
     /**
@@ -261,6 +264,7 @@ object CommandMagic {
         RENEWCOMMAND,
         RENEWCOMMAND_STAR,
         CATCODE, // Not really redefining commands, but characters
+        RENEWCOMMANDX,
     ).map { it.cmd } + flexibleCommandDefinitions
 
     /**
@@ -312,6 +316,7 @@ object CommandMagic {
         DECLARETCOLORBOX,
         NEWTCOLORBOX_,
         PROVIDETCOLORBOX,
+        NEWENVIRONMENTX,
     ).map { it.cmd }
 
     /**
@@ -321,6 +326,7 @@ object CommandMagic {
         RENEWENVIRONMENT.cmd,
         RENEWTCOLORBOX.cmd,
         RENEWTCOLORBOX_.cmd,
+        RENEWENVIRONMENTX.cmd,
     )
 
     /**


### PR DESCRIPTION

#### Summary of additions and changes

Support for 6 commands from `xargs` package.

Also, a little bit documentation for potential contributors. (I'm perfectly fine with throwing this part off the window, if it's deemed garbage - I have no confidence in my doc writing)

#### How to test this pull request

Use `\newcommandx` in project, see that it's treated exactly like `newcommand`.

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary