### PR TITLE
Fix #3472 by finishing implementation of urls in bib as verbatim

### DIFF
--- a/src/nl/hannahsten/texifyidea/grammar/BibtexLexer.flex
+++ b/src/nl/hannahsten/texifyidea/grammar/BibtexLexer.flex
@@ -49,6 +49,8 @@ QUOTES="\""
 
 WHITE_SPACE=[ \t\n\x0B\f\r]+
 TYPE_TOKEN=@[a-zA-Z_]+
+// BibTeX itself doesn't support % as a comment character (using it it the start of a line in an entry is illegal), but
+// biber explicitly supports it as a comment, so we do as well.
 COMMENT_TOKEN=%[^\r\n]*
 // Characters disallowed by bibtex or biber (non-ascii or not depends on LaTeX compiler)
 IDENTIFIER=[^,{}\(\)\"#%'=~\\ \n]+

--- a/src/nl/hannahsten/texifyidea/util/Bibtex.kt
+++ b/src/nl/hannahsten/texifyidea/util/Bibtex.kt
@@ -78,6 +78,8 @@ fun BibtexContent.evaluate(): String {
         for (string in childrenOfType(BibtexString::class)) {
             val braced = string.bracedString
             val quoted = string.quotedString
+            val bracedVerbatim = string.bracedVerbatim
+            val quotedVerbatim = string.quotedVerbatim
             val defined = string.definedString
 
             if (braced != null) {
@@ -88,6 +90,12 @@ fun BibtexContent.evaluate(): String {
             }
             else if (defined != null) {
                 result += defined.evaluate()
+            }
+            else if (bracedVerbatim != null) {
+                result += bracedVerbatim.evaluate()
+            }
+            else if (quotedVerbatim != null) {
+                result += quotedVerbatim.evaluate()
             }
         }
 
@@ -164,3 +172,17 @@ fun BibtexQuotedString.evaluate(): String {
     val text = text
     return text.substring(1 until text.length - 1)
 }
+
+/**
+ * Returns the contents of the quoted verbatim string.
+ *
+ * E.g. `"Test Hello"` becomes `Test Hello`.
+ */
+fun BibtexQuotedVerbatim.evaluate(): String = text.substring(1 until text.length - 1)
+
+/**
+ * Returns the contents of the braced verbatim string.
+ *
+ * E.g. `{Test Hello}` becomes `Test Hello`.
+ */
+fun BibtexBracedVerbatim.evaluate(): String = text.substring(1 until text.length - 1)

--- a/src/nl/hannahsten/texifyidea/util/parser/BibtexPsiUtil.kt
+++ b/src/nl/hannahsten/texifyidea/util/parser/BibtexPsiUtil.kt
@@ -39,13 +39,7 @@ fun BibtexEntry.getTagContent(tagName: String?): String {
 
     entryContent.tagList.forEach {
         if (tagName.equals(it.key.text, ignoreCase = true)) {
-            val text = it.content?.evaluate() ?: return ""
-
-            // Deal with braced strings.
-            return if (text.first() == '{' && text.last() == '}') {
-                text.substring(1, text.length - 1)
-            }
-            else text
+            return it.content?.evaluate() ?: ""
         }
     }
 

--- a/test/nl/hannahsten/texifyidea/psi/BibtexEntryImplUtilTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/BibtexEntryImplUtilTest.kt
@@ -23,7 +23,7 @@ class BibtexEntryImplUtilTest : BasePlatformTestCase() {
         journal = {GitHub},
         year = {2020},
         url = {$url},
-        biburl = {$url}
+        biburl = "$url"
     }"""
 
     private val entryElement by lazy {

--- a/test/nl/hannahsten/texifyidea/reference/BibtexIdCompletionTest.kt
+++ b/test/nl/hannahsten/texifyidea/reference/BibtexIdCompletionTest.kt
@@ -27,7 +27,7 @@ class BibtexIdCompletionTest : BasePlatformTestCase() {
         val entry1 = result.first { l -> l!!.lookupString == "Evans2015" }!!
         assertTrue(entry1.allLookupStrings.contains("Evans, Isaac"))
         assertTrue(entry1.allLookupStrings.contains("Evans2015"))
-        assertTrue(entry1.allLookupStrings.contains("Missing the Point(er): On the Effectiveness of Code Pointer Integrity"))
+        assertTrue(entry1.allLookupStrings.contains("{Missing the Point(er): On the Effectiveness of Code Pointer Integrity}"))
     }
 
     @Test


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3472 

#### Summary of additions and changes

* Finished the implementation of adding verbatim strings to bib elements.

#### How to test this pull request
<kbd>Ctrl</kbd> + click the link in
```bibtex
@online{TeXiFy-IDEA,
    url="https://github.com/Hannah-Sten/TeXiFy-IDEA"
}
```

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary