### PR TITLE
When wrapping, only break lines at whitespace

### DIFF
--- a/src/nl/hannahsten/texifyidea/formatting/LatexBlock.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexBlock.kt
@@ -57,7 +57,7 @@ class LatexBlock(
         if (child == null && (sectionIndent > 0 || fakeSectionIndent > 0)) {
             val block = LatexBlock(
                 myNode,
-                wrappingStrategy.getWrap(),
+                wrappingStrategy.getNormalWrap(myNode),
                 null,
                 spacingBuilder,
                 wrappingStrategy,
@@ -67,6 +67,7 @@ class LatexBlock(
             blocks.add(block)
         }
 
+        var isPreviousWhiteSpace = child != null && child.elementType !== TokenType.WHITE_SPACE && child !is PsiWhiteSpace
         // Create child blocks
         while (child != null) {
             val isSectionCommand =
@@ -86,7 +87,8 @@ class LatexBlock(
             if (child.elementType !== TokenType.WHITE_SPACE && child !is PsiWhiteSpace) {
                 val block = LatexBlock(
                     child,
-                    wrappingStrategy.getWrap(),
+                    // Only allow wrapping if the previous element is a white space.
+                    if (isPreviousWhiteSpace) wrappingStrategy.getNormalWrap(myNode) else wrappingStrategy.getNoneWrap(),
                     null,
                     spacingBuilder,
                     wrappingStrategy,
@@ -94,7 +96,9 @@ class LatexBlock(
                     newFakeSectionIndent
                 )
                 blocks.add(block)
+                isPreviousWhiteSpace = false
             }
+            else isPreviousWhiteSpace = true
             child = child.treeNext
         }
         return blocks

--- a/src/nl/hannahsten/texifyidea/formatting/LatexWrappingStrategy.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexWrappingStrategy.kt
@@ -1,7 +1,12 @@
 package nl.hannahsten.texifyidea.formatting
 
+import com.intellij.application.options.CodeStyle
+import com.intellij.execution.configurations.runConfigurationType
 import com.intellij.formatting.Wrap
 import com.intellij.formatting.WrapType
+import com.intellij.lang.ASTNode
+import com.intellij.psi.codeStyle.CodeStyleSettingsManager
+import nl.hannahsten.texifyidea.settings.codestyle.LatexCodeStyleSettings
 
 /**
  *
@@ -9,7 +14,15 @@ import com.intellij.formatting.WrapType
  */
 class LatexWrappingStrategy {
 
-    fun getWrap(): Wrap? {
+    fun getNormalWrap(node: ASTNode): Wrap? {
+        val settings = CodeStyle.getLanguageSettings(node.psi.containingFile)
+        return if (settings.WRAP_LONG_LINES) {
+            Wrap.createWrap(WrapType.NORMAL, false)
+        }
+        else getNoneWrap()
+    }
+
+    fun getNoneWrap(): Wrap? {
         return Wrap.createWrap(WrapType.NONE, false)
     }
 }

--- a/src/nl/hannahsten/texifyidea/formatting/LatexWrappingStrategy.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexWrappingStrategy.kt
@@ -1,12 +1,9 @@
 package nl.hannahsten.texifyidea.formatting
 
 import com.intellij.application.options.CodeStyle
-import com.intellij.execution.configurations.runConfigurationType
 import com.intellij.formatting.Wrap
 import com.intellij.formatting.WrapType
 import com.intellij.lang.ASTNode
-import com.intellij.psi.codeStyle.CodeStyleSettingsManager
-import nl.hannahsten.texifyidea.settings.codestyle.LatexCodeStyleSettings
 
 /**
  *

--- a/test/nl/hannahsten/texifyidea/formatting/LatexLineWrapStrategyTest.kt
+++ b/test/nl/hannahsten/texifyidea/formatting/LatexLineWrapStrategyTest.kt
@@ -96,4 +96,18 @@ class LatexLineWrapStrategyTest : BasePlatformTestCase() {
         """.trimIndent()
         myFixture.checkResult(expected)
     }
+
+    fun testParenthesisWrap() {
+        setUpTest()
+        val text = """
+            Lorem ipsum dolor amet (aaaaaaaa)
+        """.trimIndent()
+        myFixture.configureByText(LatexFileType, text)
+        myFixture.performEditorAction("ReformatCode")
+        val expected = """
+            Lorem ipsum dolor amet
+            (aaaaaaaa)
+        """.trimIndent()
+        myFixture.checkResult(expected)
+    }
 }

--- a/test/nl/hannahsten/texifyidea/formatting/LatexLineWrapStrategyTest.kt
+++ b/test/nl/hannahsten/texifyidea/formatting/LatexLineWrapStrategyTest.kt
@@ -39,8 +39,11 @@ class LatexLineWrapStrategyTest : BasePlatformTestCase() {
         myFixture.configureByText(LatexFileType, text)
         myFixture.performEditorAction("ReformatCode")
         val expected = """
-            \section{This includes permissions.}
-            \href{https://the-very-very-long.url}{This includes}
+            \section
+            {This includes permissions.}
+            \href
+            {https://the-very-very-long.url}
+            {This includes}
             permissions.
         """.trimIndent()
         myFixture.checkResult(expected)
@@ -82,14 +85,14 @@ class LatexLineWrapStrategyTest : BasePlatformTestCase() {
         \documentclass{article}
         \begin{document}
             Über die grüne Wiese hüpft
-            er das gemeinsame 
+            er das gemeinsame
             Frühstück
         
-            Beisammensein, onders 
+            Beisammensein, onders
             ${'$'}^{,}${'$'} bei
         
-            jedoch 
-            \footfullcite{author} 
+            jedoch
+            \footfullcite{author}
             abhielt
         
         \end{document}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3491 

#### Summary of additions and changes

* Only break lines at whitespace when wrapping.
* Somehow, wrapping behaviour while typing is still the same as before.

#### How to test this pull request

```latex
\documentclass{article}
\begin{document}
    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore (aaaaa)
\end{document}
```

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary