### PR TITLE
Prefer pasting tables as text instead of image

### DIFF
--- a/src/nl/hannahsten/texifyidea/editor/pasteproviders/ImagePasteProvider.kt
+++ b/src/nl/hannahsten/texifyidea/editor/pasteproviders/ImagePasteProvider.kt
@@ -75,6 +75,8 @@ open class ImagePasteProvider : PasteProvider {
     }
 
     override fun isPastePossible(dataContext: DataContext): Boolean {
+        // If both paste providers could handle the content, prefer the one that handles the text instead of pasting the text as an image
+        if (HtmlPasteProvider().isPastePossible(dataContext)) return false
         val file = dataContext.getData(PlatformDataKeys.PSI_FILE) ?: return false
         if (file.isLatexFile().not()) return false
 

--- a/src/nl/hannahsten/texifyidea/editor/pasteproviders/StyledTextHtmlToLatexConverter.kt
+++ b/src/nl/hannahsten/texifyidea/editor/pasteproviders/StyledTextHtmlToLatexConverter.kt
@@ -17,6 +17,7 @@ class StyledTextHtmlToLatexConverter : HtmlToLatexConverter {
             "b" to "\\textbf{",
             "u" to "\\underline{",
             "p" to "",
+            "body" to "",
             "ol" to "\\begin{enumerate}\n",
             "ul" to "\\begin{itemize}\n",
             "li" to "\\item ",
@@ -36,6 +37,7 @@ class StyledTextHtmlToLatexConverter : HtmlToLatexConverter {
             "b" to "}",
             "u" to "}",
             "p" to "\n\n",
+            "body" to "",
             "ol" to "\\end{enumerate}\n",
             "ul" to "\\end{itemize}\n",
             "li" to "\n",
@@ -74,10 +76,6 @@ class StyledTextHtmlToLatexConverter : HtmlToLatexConverter {
 
     override fun convertHtmlToLatex(htmlIn: Element, file: LatexFile): String {
         var latexString = ""
-        val environ = getCentering(htmlIn)
-        if (environ != "") {
-            latexString += "\\begin{$environ}"
-        }
 
         val prefix = getPrefix(htmlIn)
 
@@ -95,20 +93,7 @@ class StyledTextHtmlToLatexConverter : HtmlToLatexConverter {
         else {
             prefix + content + postfix
         }
-
-        if (environ != "") {
-            latexString += "\\end{$environ}"
-        }
         return latexString
-    }
-
-    private fun getCentering(node: Node) = when {
-        node.attr("align") == "center" -> "center"
-        node.attr("align") == "left" -> "flushleft"
-        node.attr("align") == "right" -> "flushright"
-        // latex doesnt have native support here
-        // node.attr("align") == "justify" ->
-        else -> ""
     }
 
     private fun getPrefix(element: Element): String {

--- a/src/nl/hannahsten/texifyidea/editor/pasteproviders/StyledTextHtmlToLatexConverter.kt
+++ b/src/nl/hannahsten/texifyidea/editor/pasteproviders/StyledTextHtmlToLatexConverter.kt
@@ -2,7 +2,6 @@ package nl.hannahsten.texifyidea.editor.pasteproviders
 
 import nl.hannahsten.texifyidea.file.LatexFile
 import org.jsoup.nodes.Element
-import org.jsoup.nodes.Node
 
 class StyledTextHtmlToLatexConverter : HtmlToLatexConverter {
 

--- a/test/nl/hannahsten/texifyidea/editor/HtmlPasteProviderTest.kt
+++ b/test/nl/hannahsten/texifyidea/editor/HtmlPasteProviderTest.kt
@@ -8,6 +8,47 @@ import org.jsoup.Jsoup
 
 class HtmlPasteProviderTest : BasePlatformTestCase() {
 
+    // Uses UI elements so cannot be run
+//    fun testTable() {
+//        myFixture.configureByText("main.tex", "")
+//        val html = """
+//            <body>
+//            <table cellspacing="0" border="0">
+//            	<colgroup span="2" width="85"></colgroup>
+//            	<tr>
+//            		<td height="17" align="left" valign=bottom>Column 1</td>
+//            		<td align="left" valign=bottom>Column 2</td>
+//            	</tr>
+//            	<tr>
+//            		<td height="17" align="left" valign=bottom>ABBR</td>
+//            		<td align="right" valign=bottom sdval="1.27" sdnum="1043;">1</td>
+//            	</tr>
+//            	<tr>
+//            		<td height="17" align="left" valign=bottom>DPTP</td>
+//            		<td align="right" valign=bottom sdval="1,18" sdnum="1043;">1,18</td>
+//            	</tr>
+//            </table>
+//            </body>
+//        """.trimIndent()
+//        val node = Jsoup.parse(html).select("body")[0]
+//        val latex = HtmlPasteProvider().convertHtmlToLatex(node, myFixture.file as LatexFile)
+//        TestCase.assertEquals("""
+//         \begin{table}
+//            \centering
+//            \begin{tabular}{ll}
+//                \toprule
+//                \textbf{Column 1} & \textbf{Column 2 cost} \\
+//                \midrule
+//                ABBR & 1.27 \\
+//                DPTP & 1,18 \\
+//                \bottomrule
+//            \end{tabular}
+//            \caption{}
+//            \label{tab:}
+//        \end{table}
+//        """.trimIndent(), latex)
+//    }
+
     fun testItalic() {
         myFixture.configureByText("main.tex", "")
         val html = "<i>italic</i>"


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix a part of #3463

#### Summary of additions and changes

* When both paste providers can do a paste, prefer the text instead of the image

#### How to test this pull request
Copy from LibreOffice Calc into a .tex file

