### PR TITLE
Fix pasting of LaTeX

### DIFF
--- a/src/nl/hannahsten/texifyidea/editor/pasteproviders/LatexPasteProviderUtil.kt
+++ b/src/nl/hannahsten/texifyidea/editor/pasteproviders/LatexPasteProviderUtil.kt
@@ -1,7 +1,6 @@
 package nl.hannahsten.texifyidea.editor.pasteproviders
 
 import nl.hannahsten.texifyidea.editor.pasteproviders.StyledTextHtmlToLatexConverter.Companion.closingTags
-import nl.hannahsten.texifyidea.editor.pasteproviders.StyledTextHtmlToLatexConverter.Companion.escapeText
 import nl.hannahsten.texifyidea.editor.pasteproviders.StyledTextHtmlToLatexConverter.Companion.openingTags
 import nl.hannahsten.texifyidea.file.LatexFile
 import nl.hannahsten.texifyidea.lang.LatexPackage
@@ -20,10 +19,11 @@ fun convertHtmlToLatex(nodes: List<Node>, latexFile: LatexFile): String {
     for (node in nodes) {
         if (node.childNodeSize() == 0) {
             when (node) {
-                is TextNode -> out += escapeText(node.text())
+                is TextNode -> out += node.text()
                 is Element -> {
                     out += handleElement(node, latexFile)
                 }
+
                 else -> {
                     Log.error("Did not plan for " + node.javaClass.name + " please implement a case for this")
                 }

--- a/src/nl/hannahsten/texifyidea/editor/pasteproviders/LatexPasteProviderUtil.kt
+++ b/src/nl/hannahsten/texifyidea/editor/pasteproviders/LatexPasteProviderUtil.kt
@@ -19,7 +19,8 @@ fun convertHtmlToLatex(nodes: List<Node>, latexFile: LatexFile): String {
     for (node in nodes) {
         if (node.childNodeSize() == 0) {
             when (node) {
-                is TextNode -> out += node.text()
+                // use wholeText to preserve newlines
+                is TextNode -> out += node.wholeText
                 is Element -> {
                     out += handleElement(node, latexFile)
                 }

--- a/src/nl/hannahsten/texifyidea/editor/pasteproviders/StyledTextHtmlToLatexConverter.kt
+++ b/src/nl/hannahsten/texifyidea/editor/pasteproviders/StyledTextHtmlToLatexConverter.kt
@@ -12,64 +12,44 @@ class StyledTextHtmlToLatexConverter : HtmlToLatexConverter {
          * Map HTML tags to LaTeX
          */
         val openingTags = hashMapOf(
-            "i" to "\\textit{",
-            "em" to "\\textit{",
             "b" to "\\textbf{",
-            "u" to "\\underline{",
-            "p" to "",
-            "ol" to "\\begin{enumerate}\n",
-            "ul" to "\\begin{itemize}\n",
-            "li" to "\\item ",
             "br" to "\n",
-            "sup" to "\\textsuperscript{",
-            "sub" to "\\textsubscript{",
+            "em" to "\\textit{",
             "h1" to "\\chapter*{",
             "h2" to "\\section*{",
             "h3" to "\\subsection*{",
             "h4" to "\\subsubsection*{",
             "h5" to "\\subsubsubsection*{",
+            "i" to "\\textit{",
+            "li" to "\\item ",
+            "ol" to "\\begin{enumerate}\n",
+            "p" to "",
+            "sub" to "\\textsubscript{",
+            "sup" to "\\textsuperscript{",
+            "u" to "\\underline{",
+            "ul" to "\\begin{itemize}\n",
         )
 
         val closingTags = hashMapOf(
-            "i" to "}",
-            "em" to "}",
-            "b" to "}",
-            "u" to "}",
-            "p" to "\n\n",
-            "ol" to "\\end{enumerate}\n",
-            "ul" to "\\end{itemize}\n",
-            "li" to "\n",
             "a" to "}",
+            "b" to "}",
             "br" to "",
-            "sup" to "}",
-            "sub" to "}",
+            "div" to "\n",
+            "em" to "}",
             "h1" to "}\n",
             "h2" to "}\n",
             "h3" to "}\n",
             "h4" to "}\n",
             "h5" to "}\n",
+            "i" to "}",
+            "li" to "\n",
+            "ol" to "\\end{enumerate}\n",
+            "p" to "\n\n",
+            "sub" to "}",
+            "sup" to "}",
+            "u" to "}",
+            "ul" to "\\end{itemize}\n",
         )
-
-        val escapeChars = hashMapOf(
-            "%" to "\\%",
-            "&" to "\\&",
-            "_" to "\\_",
-            "#" to "\\#",
-            "$" to "\\$",
-            "{" to "\\{",
-            "}" to "\\}",
-            "^" to "\\^",
-            "~" to "\\~",
-            "−" to "-"
-        )
-
-        fun escapeText(stringin: String): String {
-            var out = stringin.replace("\\", "\\textbackslash ")
-
-            escapeChars.forEach { out = out.replace(it.key, it.value) }
-
-            return out
-        }
     }
 
     override fun convertHtmlToLatex(htmlIn: Element, file: LatexFile): String {
@@ -84,7 +64,7 @@ class StyledTextHtmlToLatexConverter : HtmlToLatexConverter {
         val content = if (htmlIn.childNodeSize() > 0)
             convertHtmlToLatex(htmlIn.childNodes(), file)
         else
-            escapeText(htmlIn.text())
+            htmlIn.text()
 
         val postfix = getPostfix(htmlIn)
 
@@ -125,7 +105,7 @@ class StyledTextHtmlToLatexConverter : HtmlToLatexConverter {
                 if (element.attr("href").startsWith("#"))
                     "\\hyperlink{" + element.attr("href").replace(Regex("^#"), "") + "}{"
                 else
-                    "\\href{" + escapeText(element.attr("href")) + "}{"
+                    "\\href{" + element.attr("href") + "}{"
             else if (element.hasAttr("name"))
                 "\\hypertarget{" + element.attr("name") + "}{"
             else

--- a/test/nl/hannahsten/texifyidea/editor/HtmlPasteProviderTest.kt
+++ b/test/nl/hannahsten/texifyidea/editor/HtmlPasteProviderTest.kt
@@ -26,13 +26,19 @@ class HtmlPasteProviderTest : BasePlatformTestCase() {
 
     fun testNewlines() {
         myFixture.configureByText("main.tex", "")
+        // Source: github
         val html = """
+            <pre class="notranslate"><span class="pl-k">\newcommand</span>{<span class="pl-c1">\mylabel</span>}[1]{<span class="pl-k">\label</span>{#<span class="pl-v">1</span>}}
+
+            <span class="pl-c1">\section</span>{<span class="pl-en">One</span>}<span class="pl-c1">\mylabel</span>{sec:one}</pre>
+        """.trimIndent()
+        val result = """
             \newcommand{\mylabel}[1]{\label{#1}}
 
             \section{One}\mylabel{sec:one}
         """.trimIndent()
         val node = Jsoup.parse(html).select("body")[0]
         val latex = HtmlPasteProvider().convertHtmlToLatex(node, myFixture.file as LatexFile)
-        TestCase.assertEquals(html, latex)
+        TestCase.assertEquals(result, latex)
     }
 }

--- a/test/nl/hannahsten/texifyidea/editor/HtmlPasteProviderTest.kt
+++ b/test/nl/hannahsten/texifyidea/editor/HtmlPasteProviderTest.kt
@@ -15,4 +15,24 @@ class HtmlPasteProviderTest : BasePlatformTestCase() {
         val latex = HtmlPasteProvider().convertHtmlToLatex(node, myFixture.file as LatexFile)
         TestCase.assertEquals("\\textit{italic}", latex)
     }
+
+    fun testLatex() {
+        myFixture.configureByText("main.tex", "")
+        val html = "\\canpaste{\\LaTex}"
+        val node = Jsoup.parse(html).select("body")[0]
+        val latex = HtmlPasteProvider().convertHtmlToLatex(node, myFixture.file as LatexFile)
+        TestCase.assertEquals("\\canpaste{\\LaTex}", latex)
+    }
+
+    fun testNewlines() {
+        myFixture.configureByText("main.tex", "")
+        val html = """
+            \newcommand{\mylabel}[1]{\label{#1}}
+
+            \section{One}\mylabel{sec:one}
+        """.trimIndent()
+        val node = Jsoup.parse(html).select("body")[0]
+        val latex = HtmlPasteProvider().convertHtmlToLatex(node, myFixture.file as LatexFile)
+        TestCase.assertEquals(html, latex)
+    }
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3463

#### Summary of additions and changes

* Disable replacements which would break valid LaTeX (we cannot detect whether something is LaTeX)
* Preserve newlines

#### How to test this pull request

_Paste all of this, including this italic text to activate the html handler_
```latex
            \newcommand{\mylabel}[1]{\label{#1}}

            \section{One}\mylabel{sec:one}
```

- [ ] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary