### PR TITLE
Add progress bar when creating output directories

### DIFF
--- a/src/nl/hannahsten/texifyidea/action/library/SyncLibraryAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/library/SyncLibraryAction.kt
@@ -60,7 +60,7 @@ class SyncLibraryAction : AnAction() {
                     }
                     RemoteLibraryManager.getInstance().updateLibrary(library, bibItems)
                     expandedPaths =
-                        tree?.let { it.getExpandedDescendants(TreePath(it.model.root)) } ?: return@runBlocking
+                        tree?.let { it.getExpandedDescendants(TreePath(it.model.root)) } ?: throw ProcessCanceledException()
                 }
             }
 

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexCommandLineState.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexCommandLineState.kt
@@ -44,12 +44,16 @@ open class LatexCommandLineState(environment: ExecutionEnvironment, private val 
         val compiler = runConfig.compiler ?: throw ExecutionException("No valid compiler specified.")
         val mainFile = runConfig.mainFile ?: throw ExecutionException("Main file is not specified.")
 
-        // If the outdirs do not exist, we assume this is because either something went wrong and an incorrect output path was filled in,
-        // or the user did not create a new project, for example by opening or importing existing resources,
-        // so they still need to be created.
-        if (runConfig.outputPath.virtualFile == null) {
-            runConfig.outputPath.getAndCreatePath()
-        }
+        ProgressManager.getInstance().runProcessWithProgressSynchronously(
+            {
+                if (runConfig.outputPath.virtualFile == null) {
+                    runConfig.outputPath.getAndCreatePath()
+                }
+            },
+            "Creating Output Directories...",
+            false,
+            runConfig.project
+        )
 
         if (!runConfig.hasBeenRun) {
             // Show to the user what we're doing that takes so long (up to 30 seconds for a large project)


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3510
also fix #3462 UninitializedPropertyAccessException: lateinit property expandedPaths has not been initialized

#### Summary of additions and changes

* Apparently getting module info is slow enough to require a model progress bar
