### PR TITLE
Fix #3456: Add support for multiline todo's for latex

### DIFF
--- a/resources/META-INF/extensions/files-and-project.xml
+++ b/resources/META-INF/extensions/files-and-project.xml
@@ -16,5 +16,6 @@
 
         <applicationService serviceInterface="nl.hannahsten.texifyidea.util.files.ReferencedFileSetService"
                             serviceImplementation="nl.hannahsten.texifyidea.util.files.impl.ReferencedFileSetServiceImpl"/>
+        <indexPatternBuilder implementation="nl.hannahsten.texifyidea.index.LatexIndexPatternBuilder"/>
     </extensions>
 </idea-plugin>

--- a/src/nl/hannahsten/texifyidea/index/LatexIndexPatternBuilder.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexIndexPatternBuilder.kt
@@ -1,0 +1,35 @@
+package nl.hannahsten.texifyidea.index
+
+import com.intellij.lexer.Lexer
+import com.intellij.psi.PsiFile
+import com.intellij.psi.impl.search.IndexPatternBuilder
+import com.intellij.psi.tree.IElementType
+import com.intellij.psi.tree.TokenSet
+import nl.hannahsten.texifyidea.file.LatexFile
+import nl.hannahsten.texifyidea.grammar.LatexParserDefinition
+import nl.hannahsten.texifyidea.grammar.LatexTokenSets
+
+class LatexIndexPatternBuilder : IndexPatternBuilder {
+    override fun getIndexingLexer(file: PsiFile): Lexer? {
+        return if (file is LatexFile) {
+            LatexParserDefinition().createLexer(file.project)
+        }
+        else {
+            null
+        }
+    }
+
+    override fun getCommentTokenSet(file: PsiFile): TokenSet = LatexTokenSets.COMMENTS
+
+    override fun getCommentStartDelta(tokenType: IElementType?): Int {
+        return 0
+    }
+
+    override fun getCommentEndDelta(tokenType: IElementType?): Int {
+        return 0
+    }
+
+    override fun getCharsAllowedInContinuationPrefix(tokenType: IElementType): String {
+        return "%"
+    }
+}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3456

#### Summary of additions and changes

* Added support for multiline todo's in latex

#### How to test this pull request

```latex
% TODO this is a test
%  this is still a test
```

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary