### PR TITLE
Allow unmatched \begin and \end commands in \BeforeBeginEnvironment and \AfterEndEnvironment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@
 
 ### Fixed
 
-## [0.9.5-alpha.8] - 2024-03-30
+## [0.9.5-alpha.10] - 2024-04-27
 
 ### Added
 
+* Improve performance when editing run configurations
+* Add support for multiline todos by @slideclimb
+* Added multicite versions of biblatex commands by @frankbits
 * Add \newcommandx and related commands from the xparse package, by @tmczar
 * Improve line wrapping by preferring line breaks at whitespace
 * Add support for the nomencl package
@@ -26,6 +29,9 @@
 
 ### Fixed
 
+* Fix urls in quotes in bibtex
+* Fix exceptions #3510, #3462, #3512
+* Fix parse error when using \BeforeBeginEnvironment or \AfterEndEnvironment
 * Fix quoted links in bibtex
 * Ignore \begin and \end commands in \newcommand definition in the parser
 * Fix a parser issue when having a single \begin or \end in a \newcommand definition
@@ -35,114 +41,6 @@
 * Fix exception #3274 in the equation preview
 * Never use jlatexmath for the TikZ preview
 * Destroy invalid tokens for the remote libraries tool windows
-* Fix missing folding for commands in math environments, by @jojo2357
-* Fix an issue when inlining files with whitespace, by @jojo2357
-
-## [0.9.5-alpha.7] - 2024-03-09
-
-### Added
-
-* Add support for the nomencl package
-* Add starred and capitalized versions of cleveref commands to exceptions for non-breaking space inspection, by @niknetniko
-
-### Fixed
-
-* Fix a parser issue when having a single \begin or \end in a \newcommand definition
-
-## [0.9.5-alpha.6] - 2024-03-01
-
-### Added
-
-* Add option to the run configuration settings to run LaTeX commands before compiling the main file
-* Autocompletion for compiler arguments in run configuration settings
-* Support a local Zotero instance in the remote libraries tool window via the BBT plugin
-* Support Zotero groups in the remote libraries tool window
-* Support local BibTeX files in the remote libraries tool window
-* Improve file filters for the LaTeX package index
-* Improve \DescribeMacro handling for the package doocumentation index
-* Automatically translate HTML from the clipboard to LaTeX, by @jojo2357
-* Add option to disable indentation of environments, by @slideclimb
-
-### Fixed
-
-* Fix exception #2976
-* Fix exception #3469
-* Avoid line breaks when reformatting in the middle of commands, math and words
-* Fix exception #3274 in the equation preview
-* Never use jlatexmath for the TikZ preview
-* Destroy invalid tokens for the remote libraries tool windows
-* Fix missing folding for commands in math environments, by @jojo2357
-* Fix an issue when inlining files with whitespace, by @jojo2357
-
-## [0.9.5-alpha.4] - 2024-02-28
-
-### Added
-
-* Autocompletion for compiler arguments in run configuration settings
-* Support a local Zotero instance in the remote libraries tool window via the BBT plugin
-* Support Zotero groups in the remote libraries tool window
-* Support local BibTeX files in the remote libraries tool window
-* Improve file filters for the LaTeX package index
-* Improve \DescribeMacro handling for the package doocumentation index
-* Automatically translate HTML from the clipboard to LaTeX, by @jojo2357
-* Add option to disable indentation of environments, by @slideclimb
-
-### Fixed
-
-* Fix exception #3469
-* Avoid line breaks when reformatting in the middle of commands, math and words
-* Fix exception #3274 in the equation preview
-* Never use jlatexmath for the TikZ preview
-* Destroy invalid tokens for the remote libraries tool windows
-* Fix missing folding for commands in math environments, by @jojo2357
-* Fix an issue when inlining files with whitespace, by @jojo2357
-
-## [0.9.5-alpha.3] - 2024-02-11
-
-### Added
-
-* Support a local Zotero instance in the remote libraries tool window via the BBT plugin
-* Support Zotero groups in the remote libraries tool window
-* Support local BibTeX files in the remote libraries tool window
-* Improve file filters for the LaTeX package index
-* Improve \DescribeMacro handling for the package doocumentation index
-* Automatically translate HTML from the clipboard to LaTeX, by @jojo2357
-* Add option to disable indentation of environments, by @slideclimb
-
-### Fixed
-
-* Fix exception #3274 in the equation preview
-* Never use jlatexmath for the TikZ preview
-* Destroy invalid tokens for the remote libraries tool windows
-* Fix missing folding for commands in math environments, by @jojo2357
-* Fix an issue when inlining files with whitespace, by @jojo2357
-
-## [0.9.5-alpha.2] - 2024-02-10
-
-### Added
-
-* Improve file filters for the LaTeX package index
-* Improve \DescribeMacro handling for the package doocumentation index
-* Automatically translate HTML from the clipboard to LaTeX, by @jojo2357
-* Add option to disable indentation of environments, by @slideclimb
-
-### Fixed
-
-* Fix exception #3274 in the equation preview
-* Never use jlatexmath for the TikZ preview
-* Destroy invalid tokens for the remote libraries tool windows
-* Fix missing folding for commands in math environments, by @jojo2357
-* Fix an issue when inlining files with whitespace, by @jojo2357
-
-## [0.9.5-alpha.1] - 2024-02-06
-
-### Added
-
-* Automatically translate HTML from the clipboard to LaTeX, by @jojo2357
-* Add option to disable indentation of environments, by @slideclimb
-
-### Fixed
-
 * Fix missing folding for commands in math environments, by @jojo2357
 * Fix an issue when inlining files with whitespace, by @jojo2357
 
@@ -436,7 +334,8 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Fix some intention previews. ([#2796](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2796))
 * Other small bug fixes and improvements. ([#2776](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2776), [#2774](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2774), [#2765](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2765)-[#2773](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2773))
 
-[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5-alpha.8...HEAD
+[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5-alpha.10...HEAD
+[0.9.5-alpha.10]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.4...v0.9.5-alpha.10
 [0.9.4]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3...v0.9.2
 [0.9.2]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.1...v0.9.2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -192,7 +192,7 @@ tasks.patchPluginXml {
         provider {
             with(changelog) {
                 renderItem(
-                getOrNull(properties("pluginVersion")) ?: getLatest(),
+                    getOrNull(properties("pluginVersion")) ?: getLatest(),
                     Changelog.OutputType.HTML
                 )
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -182,6 +182,8 @@ changelog {
 }
 
 tasks.patchPluginXml {
+    dependsOn("patchChangelog")
+
     // Required to run pluginVerifier
     sinceBuild.set(properties("pluginSinceBuild"))
 
@@ -190,12 +192,7 @@ tasks.patchPluginXml {
         provider {
             with(changelog) {
                 renderItem(
-                    // When publishing alpha versions, we want the unreleased changes to be shown, otherwise we assume that patchChangelog has been run and we need to get the latest released version (otherwise it will show 'Unreleased' as title)
-                    if (properties("pluginVersion").split("-").size != 1) {
-                        changelog.getUnreleased()
-                    } else {
-                        getOrNull(properties("pluginVersion")) ?: getLatest()
-                    },
+                getOrNull(properties("pluginVersion")) ?: getLatest(),
                     Changelog.OutputType.HTML
                 )
             }
@@ -239,7 +236,6 @@ intellij {
 // Generate a Hub token at https://hub.jetbrains.com/users/me?tab=authentification
 // You should provide it either via environment variables (ORG_GRADLE_PROJECT_intellijPublishToken) or Gradle task parameters (-Dorg.gradle.project.intellijPublishToken=mytoken)
 tasks.publishPlugin {
-//    dependsOn("patchChangelog")
     dependsOn("useLatestVersions")
 //    dependsOn("dependencyCheckAnalyze")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.9.5-alpha.9
+pluginVersion = 0.9.5-alpha.10
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/LatexErrorReportSubmitter.kt
+++ b/src/nl/hannahsten/texifyidea/LatexErrorReportSubmitter.kt
@@ -126,24 +126,24 @@ class LatexErrorReportSubmitter : ErrorReportSubmitter() {
             // Create xml mapper that doesn't fail on unknown properties. This allows us to only define the properties we need.
             val mapper = XmlMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 
-            with(URL(JETBRAINS_API_URL).openConnection() as HttpURLConnection) {
+            val connection = (URL(JETBRAINS_API_URL).openConnection() as HttpURLConnection).apply {
                 requestMethod = "GET"
                 connectTimeout = 1000
                 readTimeout = 1000
+            }
 
-                val inputString: String = try {
-                    inputStream.reader().use { it.readText() }
-                }
-                catch (e: SocketTimeoutException) {
-                    return latestVersionCached
-                }
-                latestVersionCached = mapper.readValue(inputString, PluginRepo::class.java)
-                    .category
-                    ?.maxByOrNull { it.version }
-                    ?: latestVersionCached
-
+            val inputString: String = try {
+                connection.inputStream.reader().use { it.readText() }
+            }
+            catch (e: SocketTimeoutException) {
                 return latestVersionCached
             }
+            latestVersionCached = mapper.readValue(inputString, PluginRepo::class.java)
+                .category
+                ?.maxByOrNull { it.version }
+                ?: latestVersionCached
+
+            return latestVersionCached
         }
 
         val currentVersion by lazy {

--- a/src/nl/hannahsten/texifyidea/grammar/LatexLexer.flex
+++ b/src/nl/hannahsten/texifyidea/grammar/LatexLexer.flex
@@ -83,7 +83,8 @@ COMMAND_TOKEN_LATEX3=\\([a-zA-Z@_:0-9]+|.|\r) // _ and : are only LaTeX3 syntax
 LATEX3_ON=\\(ExplSyntaxOn|ProvidesExplPackage)
 LATEX3_OFF=\\ExplSyntaxOff
 NEWENVIRONMENT=\\(re)?newenvironment
-NEWCOMMAND=\\(new|provide)command
+// BeforeBegin/AfterEnd are from etoolbox, and just happen to also have two parameters where the second can contain loose \begin or \end
+NEWCOMMAND=\\(new|provide)command | \\BeforeBeginEnvironment | \\AfterEndEnvironment
 NEWDOCUMENTENVIRONMENT=\\(New|Renew|Provide|Declare)DocumentEnvironment
 
 // Verbatim commands which will be delimited by the same character

--- a/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
@@ -255,6 +255,10 @@ class LatexParserTest : BasePlatformTestCase() {
                 \begin{multicols}{2}
             }
             \newcommand{\cmd}{${'$'}x${'$'}}
+            
+            \AfterEndEnvironment{minted}{
+                \end{tcolorbox}
+            }
             """.trimIndent()
         )
         myFixture.checkHighlighting()


### PR DESCRIPTION


<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3488 or at least the example at the end of the discussion

#### Summary of additions and changes

* The two commands happen to be similar to \newcommand in number of parameters

#### How to test this pull request

see https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/3488#issuecomment-2075807203

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary