### PR TITLE
Handle empty working directory in bibtex run configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/Hannah-Sten/TeXiFy-IDEA.svg)](http://isitmaintained.com/project/Hannah-Sten/TeXiFy-IDEA "Average time to resolve an issue")
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/Hannah-Sten/TeXiFy-IDEA.svg)](http://isitmaintained.com/project/Hannah-Sten/TeXiFy-IDEA "Percentage of issues still open")
 
+<a href="https://jb.gg/OpenSourceSupport"><img src="https://resources.jetbrains.com/storage/products/company/brand/logos/jetbrains.png" alt="JetBrains logo." width="170"></a>
+
 # TeXiFy-IDEA
 <sup><sub>(Pronounced as `/ˈtɛxɪfaɪ aɪˈdɪə/` with a greek letter Chi (χ), just as in LaTeX)</sub></sup>
 

--- a/src/nl/hannahsten/texifyidea/completion/pathcompletion/LatexPathProviderBase.kt
+++ b/src/nl/hannahsten/texifyidea/completion/pathcompletion/LatexPathProviderBase.kt
@@ -122,6 +122,7 @@ abstract class LatexPathProviderBase : CompletionProvider<CompletionParameters>(
      * add completion entries for absolute path
      */
     private fun addAbsolutePathCompletion(baseDir: String) {
+        if (baseDir.isBlank()) return
         LocalFileSystem.getInstance().findFileByPath(baseDir)?.let { dirFile ->
             if (searchFolders()) {
                 addFolderNavigations(baseDir)

--- a/src/nl/hannahsten/texifyidea/modules/LatexModuleBuilder.kt
+++ b/src/nl/hannahsten/texifyidea/modules/LatexModuleBuilder.kt
@@ -54,6 +54,7 @@ class LatexModuleBuilder : ModuleBuilder() {
 
         for (sourcePath in sourcePaths) {
             val path = sourcePath.first
+            if (path.isBlank()) continue
             File(path).mkdirs()
             val sourceRoot = fileSystem.refreshAndFindFileByPath(FileUtil.toSystemIndependentName(path))
 
@@ -69,6 +70,7 @@ class LatexModuleBuilder : ModuleBuilder() {
         // Create source directory.
         for (sourcePath in sourcePaths) {
             val path = sourcePath.first
+            if (path.isBlank()) continue
             File(path).mkdirs()
 
             val fileName = FileUtil.toSystemIndependentName(path)

--- a/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
@@ -204,7 +204,7 @@ class InputFileReference(
         if (targetFile == null && lookForInstalledPackages) {
             targetFile = element.getFileNameWithExtensions(processedKey)
                 .mapNotNull { LatexPackageLocationCache.getPackageLocation(it, element.project) }
-                .firstNotNullOfOrNull { getExternalFile(it) }
+                .firstNotNullOfOrNull { findFileByPath(it) }
         }
 
         if (targetFile == null) targetFile = searchFileByImportPaths(element)?.virtualFile

--- a/src/nl/hannahsten/texifyidea/run/bibtex/BibtexRunConfiguration.kt
+++ b/src/nl/hannahsten/texifyidea/run/bibtex/BibtexRunConfiguration.kt
@@ -94,7 +94,7 @@ class BibtexRunConfiguration(
         environmentVariables = EnvironmentVariablesData.readExternal(parent)
 
         val mainFilePath = parent.getChildText(MAIN_FILE)
-        mainFile = if (mainFilePath != null) {
+        mainFile = if (mainFilePath.isNullOrBlank().not()) {
             LocalFileSystem.getInstance().findFileByPath(mainFilePath)
         }
         else {
@@ -102,7 +102,7 @@ class BibtexRunConfiguration(
         }
 
         val auxDirPath = parent.getChildText(AUX_DIR)
-        bibWorkingDir = if (auxDirPath != null) {
+        bibWorkingDir = if (auxDirPath.isNullOrBlank().not()) {
             LocalFileSystem.getInstance().findFileByPath(auxDirPath)
         }
         else {

--- a/src/nl/hannahsten/texifyidea/run/bibtex/BibtexSettingsEditor.kt
+++ b/src/nl/hannahsten/texifyidea/run/bibtex/BibtexSettingsEditor.kt
@@ -53,8 +53,8 @@ class BibtexSettingsEditor(private val project: Project) : SettingsEditor<Bibtex
         runConfig.compilerPath = if (enableCompilerPath.isSelected) compilerPath.text else null
         runConfig.compilerArguments = compilerArguments.component.text
         runConfig.environmentVariables = environmentVariables.envData
-        runConfig.mainFile = LocalFileSystem.getInstance().findFileByPath(mainFile.component.text)
-        runConfig.bibWorkingDir = LocalFileSystem.getInstance().findFileByPath(bibWorkingDir.component.text)
+        runConfig.mainFile = if (mainFile.component.text.isNotBlank()) LocalFileSystem.getInstance().findFileByPath(mainFile.component.text) else null
+        runConfig.bibWorkingDir = if (bibWorkingDir.component.text.isNotBlank()) LocalFileSystem.getInstance().findFileByPath(bibWorkingDir.component.text) else null
     }
 
     private fun createUIComponents() {

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexOutputPath.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexOutputPath.kt
@@ -77,6 +77,7 @@ class LatexOutputPath(private val variant: String, var contentRoot: VirtualFile?
                 if (mainFile == null) return null
                 pathString.replace(MAIN_FILE_STRING, mainFile?.parent?.path ?: return null)
             }
+            if (pathString.isBlank()) return null
             val path = LocalFileSystem.getInstance().findFileByPath(pathString)
             if (path != null && path.isDirectory) {
                 return path

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
@@ -492,6 +492,10 @@ class LatexRunConfiguration(
      * Looks up the corresponding [VirtualFile] and sets [LatexRunConfiguration.mainFile].
      */
     fun setMainFile(mainFilePath: String) {
+        if (mainFilePath.isBlank()) {
+            this.mainFile = null
+            return
+        }
         val fileSystem = LocalFileSystem.getInstance()
         // Check if the file is valid and exists
         val mainFile = fileSystem.findFileByPath(mainFilePath)

--- a/src/nl/hannahsten/texifyidea/run/makeindex/MakeindexSettingsEditor.kt
+++ b/src/nl/hannahsten/texifyidea/run/makeindex/MakeindexSettingsEditor.kt
@@ -39,9 +39,9 @@ class MakeindexSettingsEditor(private val project: Project) : SettingsEditor<Mak
     // Save user selected settings to the given run config
     override fun applyEditorTo(runConfig: MakeindexRunConfiguration) {
         runConfig.makeindexProgram = makeindexProgram.component.selectedItem as MakeindexProgram
-        runConfig.mainFile = LocalFileSystem.getInstance().findFileByPath(mainFile.component.text)
+        runConfig.mainFile = if (mainFile.component.text.isNotBlank()) LocalFileSystem.getInstance().findFileByPath(mainFile.component.text) else null
         runConfig.commandLineArguments = commandLineArguments.component.text
-        runConfig.workingDirectory = LocalFileSystem.getInstance().findFileByPath(workingDirectory.component.text)
+        runConfig.workingDirectory = if (workingDirectory.component.text.isNotBlank()) LocalFileSystem.getInstance().findFileByPath(workingDirectory.component.text) else null
     }
 
     private fun createUIComponents() {

--- a/src/nl/hannahsten/texifyidea/settings/sdk/MiktexWindowsSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/MiktexWindowsSdk.kt
@@ -52,6 +52,7 @@ class MiktexWindowsSdk : LatexSdk("MiKTeX Windows SDK") {
 
     override fun getDefaultSourcesPath(homePath: String): VirtualFile? {
         val path = Paths.get(homePath, "source").toString()
+        if (path.isBlank()) return null
         return try {
             // To save space, MiKTeX leaves source/latex empty by default, but does leave the zipped files in source/
             LocalFileSystem.getInstance().findFileByPath(path)
@@ -64,6 +65,7 @@ class MiktexWindowsSdk : LatexSdk("MiKTeX Windows SDK") {
 
     override fun getDefaultStyleFilesPath(homePath: String): VirtualFile? {
         val path = Paths.get(homePath, "tex", "latex").toString()
+        if (path.isBlank()) return null
         return try {
             LocalFileSystem.getInstance().findFileByPath(path)
         }

--- a/src/nl/hannahsten/texifyidea/settings/sdk/NativeTexliveSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/NativeTexliveSdk.kt
@@ -63,6 +63,7 @@ class NativeTexliveSdk : TexliveSdk("Native TeX Live SDK") {
 
     override fun getDefaultStyleFilesPath(homePath: String): VirtualFile? {
         val articlePath = runCommand("$homePath/kpsewhich", "article.sty") ?: return null
+        if (articlePath.isBlank()) return null
         // Assume article.sty is in tex/latex/base/article.sty
         return LocalFileSystem.getInstance().findFileByPath(articlePath)?.parent?.parent
     }

--- a/src/nl/hannahsten/texifyidea/util/files/Files.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/Files.kt
@@ -240,8 +240,11 @@ fun getUniqueFileName(fileName: String, directory: String? = null): String {
 /**
  * Get a(n external) file by its absolute path.
  */
-fun getExternalFile(path: String): VirtualFile? =
-    LocalFileSystem.getInstance().findFileByPath(path)
+fun findFileByPath(path: String): VirtualFile? {
+    // A blank path will resolve to the jetbrains /bin directory, which is likely not intended
+    if (path.isBlank()) return null
+    return LocalFileSystem.getInstance().findFileByPath(path)
+}
 
 /**
  * Converts the absolute path to a relative path.

--- a/src/nl/hannahsten/texifyidea/util/files/VirtualFile.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/VirtualFile.kt
@@ -19,6 +19,7 @@ fun VirtualFile.psiFile(project: Project): PsiFile? {
 }
 
 fun VirtualFile.findVirtualFileByAbsoluteOrRelativePath(filePath: String): VirtualFile? {
+    if (filePath.isBlank()) return null
     val isAbsolute = File(filePath).isAbsolute
     return if (!isAbsolute) {
         findFileByRelativePath(filePath)
@@ -66,6 +67,7 @@ fun findVirtualFileByAbsoluteOrRelativePath(path: String, project: Project): Vir
  * @return The matching file, or `null` when the file couldn't be found.
  */
 fun VirtualFile.findFile(filePath: String, extensions: List<String> = emptyList()): VirtualFile? {
+    if (filePath.isBlank()) return null
     try {
         val isAbsolute = File(filePath).isAbsolute
         var file = if (!isAbsolute) {


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3354

#### Summary of additions and changes

* Don't use findFileByPath on empty strings as that will resolve to jetbrains /bin directory
