### PR TITLE
Fix table insertion wizard not inserting text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Fixed
 
+## [0.9.6-alpha.1] - 2024-05-03
+
+### Fixed
+
+* Fix table insertion wizard not inserting text
+
 ## [0.9.5] - 2024-05-01
 
 Welcome to TeXiFy IDEA 0.9.5! This release automatically translates HTML from the clipboard to LaTeX when pasting, by @jojo2357, and includes a lot of additions and bug fixes!
@@ -338,7 +344,8 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Fix some intention previews. ([#2796](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2796))
 * Other small bug fixes and improvements. ([#2776](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2776), [#2774](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2774), [#2765](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2765)-[#2773](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2773))
 
-[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5...HEAD
+[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.6-alpha.1...HEAD
+[0.9.6-alpha.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5...v0.9.6-alpha.1
 [0.9.5]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3...v0.9.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.9.5
+pluginVersion = 0.9.6-alpha.1
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/action/InsertEditorAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/InsertEditorAction.kt
@@ -5,6 +5,8 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import nl.hannahsten.texifyidea.file.LatexFileType
+import nl.hannahsten.texifyidea.util.files.isLatexFile
 import nl.hannahsten.texifyidea.util.files.psiFile
 import nl.hannahsten.texifyidea.util.parser.isLatexOrBibtex
 
@@ -43,10 +45,10 @@ open class InsertEditorAction(
         val start = selection.selectionStart
         val end = selection.selectionEnd
 
-        // Don't touch any file content that is not related to TeXiFy
-        if (file.psiFile(project)?.findElementAt(start)?.isLatexOrBibtex() != true) return
-
-        runWriteAction(project, file) { insert(document, start, end, editor.caretModel) }
+        // Only touch files that are either LaTeX files or have LaTeX content in them
+        if (file.isLatexFile() || file.psiFile(project)?.findElementAt(start)?.isLatexOrBibtex() == true) {
+            runWriteAction(project, file) { insert(document, start, end, editor.caretModel) }
+        }
     }
 
     private fun insert(document: Document, start: Int, end: Int, caretModel: CaretModel) {

--- a/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/PsiFile.kt
@@ -48,8 +48,10 @@ fun PsiFile.findInclusions(): List<PsiFile> {
 /**
  * Checks if the file has LaTeX syntax.
  */
-fun PsiFile.isLatexFile() = fileType == LatexFileType ||
-    fileType == StyleFileType || fileType == ClassFileType
+fun PsiFile.isLatexFile() = virtualFile.isLatexFile()
+
+fun VirtualFile.isLatexFile() = fileType == LatexFileType ||
+        fileType == StyleFileType || fileType == ClassFileType
 
 /**
  * Checks if the file has a `.sty` extention. This is a workaround for file type checking.


### PR DESCRIPTION
Broken in b718cd4172a019a66ada2347bd550ed51c145792, now always inserts in LaTeX files (element at caret may be null)