### PR TITLE
Do not select the extension when refactoring file names

### DIFF
--- a/resources/META-INF/extensions/files-and-project.xml
+++ b/resources/META-INF/extensions/files-and-project.xml
@@ -17,5 +17,7 @@
         <applicationService serviceInterface="nl.hannahsten.texifyidea.util.files.ReferencedFileSetService"
                             serviceImplementation="nl.hannahsten.texifyidea.util.files.impl.ReferencedFileSetServiceImpl"/>
         <indexPatternBuilder implementation="nl.hannahsten.texifyidea.index.LatexIndexPatternBuilder"/>
+
+        <renamePsiElementProcessor implementation="nl.hannahsten.texifyidea.LatexRenameProcessor"/>
     </extensions>
 </idea-plugin>

--- a/src/nl/hannahsten/texifyidea/LatexRenameProcessor.kt
+++ b/src/nl/hannahsten/texifyidea/LatexRenameProcessor.kt
@@ -1,0 +1,22 @@
+package nl.hannahsten.texifyidea
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.refactoring.rename.RenameDialog
+import com.intellij.refactoring.rename.RenamePsiElementProcessor
+import com.intellij.refactoring.rename.RenamePsiFileProcessor.PsiFileRenameDialog
+
+class LatexRenameProcessor: RenamePsiElementProcessor() {
+    override fun canProcessElement(element: PsiElement): Boolean {
+        return when (element) {
+            is PsiFile -> true
+            else -> true
+        }
+    }
+
+    override fun createRenameDialog(project: Project, element: PsiElement, nameSuggestionContext: PsiElement?, editor: Editor?): RenameDialog {
+        return PsiFileRenameDialog(project, element, nameSuggestionContext, null)
+    }
+}

--- a/src/nl/hannahsten/texifyidea/LatexRenameProcessor.kt
+++ b/src/nl/hannahsten/texifyidea/LatexRenameProcessor.kt
@@ -12,7 +12,7 @@ class LatexRenameProcessor : RenamePsiElementProcessor() {
     override fun canProcessElement(element: PsiElement): Boolean {
         return when (element) {
             is PsiFile -> true
-            else -> true
+            else -> false
         }
     }
 

--- a/src/nl/hannahsten/texifyidea/LatexRenameProcessor.kt
+++ b/src/nl/hannahsten/texifyidea/LatexRenameProcessor.kt
@@ -10,6 +10,7 @@ import com.intellij.refactoring.rename.RenamePsiFileProcessor.PsiFileRenameDialo
 
 class LatexRenameProcessor : RenamePsiElementProcessor() {
     override fun canProcessElement(element: PsiElement): Boolean {
+        // The reason below is only applicable for files
         return when (element) {
             is PsiFile -> true
             else -> false
@@ -17,6 +18,7 @@ class LatexRenameProcessor : RenamePsiElementProcessor() {
     }
 
     override fun createRenameDialog(project: Project, element: PsiElement, nameSuggestionContext: PsiElement?, editor: Editor?): RenameDialog {
+        // We want to not select the extension in the dialog when renaming files, and looking at RenameDialog#createNewNameComponent(), this is done by setting the editor to null
         return PsiFileRenameDialog(project, element, nameSuggestionContext, null)
     }
 }

--- a/src/nl/hannahsten/texifyidea/LatexRenameProcessor.kt
+++ b/src/nl/hannahsten/texifyidea/LatexRenameProcessor.kt
@@ -8,7 +8,7 @@ import com.intellij.refactoring.rename.RenameDialog
 import com.intellij.refactoring.rename.RenamePsiElementProcessor
 import com.intellij.refactoring.rename.RenamePsiFileProcessor.PsiFileRenameDialog
 
-class LatexRenameProcessor: RenamePsiElementProcessor() {
+class LatexRenameProcessor : RenamePsiElementProcessor() {
     override fun canProcessElement(element: PsiElement): Boolean {
         return when (element) {
             is PsiFile -> true


### PR DESCRIPTION
Fix #3551

So. The simplest solution was to simply make a custom Rename Processor that would gobble up **ALL** PsiFiles and automatically null the editor. This has the side effect of making *every* file refactor not select the extension by default, which covers my issue, but may cause problems?

I tested, every `\input` will have this behavior (which IMO is just another manifestation of this issue), refactoring commands from `\newcommand` is unaffected.

Attempting to refactor a package does *not* work.

Let me know if we need to go ahead and actually implement more logic. If anything, this opens the door to smarter refactoring? 

```latex
\includegraphics{IM<caret>G.jpg}
```