### PR TITLE
Fix copy from pdf file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ### Fixed
 
+## [0.9.6-alpha.2] - 2024-05-19
+
+### Fixed
+
+* Autocomplete \left* with \right* for all variants, by @jojo2357
+* Fix pasting text from pdf file
+* Fix table insertion wizard not inserting text
+
 ## [0.9.6-alpha.1] - 2024-05-03
 
 ### Fixed
@@ -344,7 +352,8 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Fix some intention previews. ([#2796](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2796))
 * Other small bug fixes and improvements. ([#2776](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2776), [#2774](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2774), [#2765](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2765)-[#2773](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2773))
 
-[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.6-alpha.1...HEAD
+[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.6-alpha.2...HEAD
+[0.9.6-alpha.2]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.6-alpha.1...v0.9.6-alpha.2
 [0.9.6-alpha.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5...v0.9.6-alpha.1
 [0.9.5]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3...v0.9.4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,13 +24,13 @@ plugins {
     id("de.undercouch.download") version "5.6.0"
 
     // Test coverage
-    id("org.jetbrains.kotlinx.kover") version "0.7.6"
+    id("org.jetbrains.kotlinx.kover") version "0.8.0"
 
     // Linting
     id("org.jlleitschuh.gradle.ktlint") version "12.1.0"
 
     // Vulnerability scanning
-    id("org.owasp.dependencycheck") version "9.1.0"
+    id("org.owasp.dependencycheck") version "9.2.0"
 
     id("org.jetbrains.changelog") version "2.2.0"
 
@@ -104,18 +104,18 @@ dependencies {
     implementation("com.beust:klaxon:5.6")
 
     // Parsing xml
-    implementation("com.fasterxml.jackson.core:jackson-core:2.17.0")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.17.0")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0")
+    implementation("com.fasterxml.jackson.core:jackson-core:2.17.1")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.17.1")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.1")
 
     // Http requests
-    implementation("io.ktor:ktor-client-core:2.3.10")
-    implementation("io.ktor:ktor-client-cio:2.3.10")
-    implementation("io.ktor:ktor-client-auth:2.3.10")
-    implementation("io.ktor:ktor-client-content-negotiation:2.3.10")
-    implementation("io.ktor:ktor-server-core:2.3.10")
-    implementation("io.ktor:ktor-server-jetty:2.3.10")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.10")
+    implementation("io.ktor:ktor-client-core:2.3.11")
+    implementation("io.ktor:ktor-client-cio:2.3.11")
+    implementation("io.ktor:ktor-client-auth:2.3.11")
+    implementation("io.ktor:ktor-client-content-negotiation:2.3.11")
+    implementation("io.ktor:ktor-server-core:2.3.11")
+    implementation("io.ktor:ktor-server-jetty:2.3.11")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.11")
 
     // Comparing versions
     implementation("org.apache.maven:maven-artifact:4.0.0-alpha-13")
@@ -144,7 +144,7 @@ dependencies {
     // Enable use of the JUnitPlatform Runner within the IDE
     testImplementation("org.junit.platform:junit-platform-runner:1.10.2")
 
-    testImplementation("io.mockk:mockk:1.13.10")
+    testImplementation("io.mockk:mockk:1.13.11")
 
     // Add custom ruleset from github.com/slideclimb/ktlint-ruleset
     ktlintRuleset(files("lib/ktlint-ruleset-0.2.jar"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.9.6-alpha.1
+pluginVersion = 0.9.6-alpha.2
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/editor/pasteproviders/LatexPasteProviderUtil.kt
+++ b/src/nl/hannahsten/texifyidea/editor/pasteproviders/LatexPasteProviderUtil.kt
@@ -17,11 +17,11 @@ fun convertHtmlToLatex(nodes: List<Node>, latexFile: LatexFile): String {
 
     for (node in nodes) {
         if (node.childNodeSize() == 0) {
-            when (node) {
+            out += when (node) {
                 // use wholeText to preserve newlines
-                is TextNode -> out += node.wholeText
+                is TextNode -> node.wholeText
                 is Element -> {
-                    out += handleElement(node, latexFile)
+                    handleElement(node, latexFile)
                 }
 
                 else -> {

--- a/src/nl/hannahsten/texifyidea/editor/pasteproviders/LatexPasteProviderUtil.kt
+++ b/src/nl/hannahsten/texifyidea/editor/pasteproviders/LatexPasteProviderUtil.kt
@@ -4,7 +4,6 @@ import nl.hannahsten.texifyidea.editor.pasteproviders.StyledTextHtmlToLatexConve
 import nl.hannahsten.texifyidea.editor.pasteproviders.StyledTextHtmlToLatexConverter.Companion.openingTags
 import nl.hannahsten.texifyidea.file.LatexFile
 import nl.hannahsten.texifyidea.lang.LatexPackage
-import nl.hannahsten.texifyidea.util.Log
 import nl.hannahsten.texifyidea.util.insertUsepackage
 import org.jsoup.nodes.Element
 import org.jsoup.nodes.Node
@@ -26,7 +25,8 @@ fun convertHtmlToLatex(nodes: List<Node>, latexFile: LatexFile): String {
                 }
 
                 else -> {
-                    Log.error("Did not plan for " + node.javaClass.name + " please implement a case for this")
+                    // We don't know what is in there, but it is probably not text so skip it
+                    continue
                 }
             }
         }

--- a/test/nl/hannahsten/texifyidea/editor/HtmlPasteProviderTest.kt
+++ b/test/nl/hannahsten/texifyidea/editor/HtmlPasteProviderTest.kt
@@ -82,4 +82,31 @@ class HtmlPasteProviderTest : BasePlatformTestCase() {
         val latex = HtmlPasteProvider().convertHtmlToLatex(node, myFixture.file as LatexFile)
         TestCase.assertEquals(result, latex)
     }
+
+    fun testList() {
+        myFixture.configureByText("main.tex", "")
+        // Source: pdf
+        val html = """
+            <!-- Version:0.9 -->
+            <html>
+            <body>
+            <!--StartFragment-->3. a list:
+            - one,
+            - two,
+            <!--EndFragment-->
+            </body>
+            </html>
+        """.trimIndent()
+        val result = """
+            
+            3. a list:
+            - one,
+            - two,
+
+
+        """.trimIndent()
+        val node = Jsoup.parse(html).select("body")[0]
+        val latex = HtmlPasteProvider().convertHtmlToLatex(node, myFixture.file as LatexFile)
+        TestCase.assertEquals(result, latex)
+    }
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->


#### Summary of additions and changes

* Pasting from a pdf was not working on Windows: `java.lang.AssertionError: Wrong line separators: '...Integrity.\r\n' at offset 606`
* Pasting contenting containing html comments did not work, now they are skipped


- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary