### PR TITLE
#3547 go to definition view

### DIFF
--- a/src/nl/hannahsten/texifyidea/psi/impl/LatexCommandsImplMixin.kt
+++ b/src/nl/hannahsten/texifyidea/psi/impl/LatexCommandsImplMixin.kt
@@ -2,6 +2,8 @@ package nl.hannahsten.texifyidea.psi.impl
 
 import com.intellij.extapi.psi.StubBasedPsiElementBase
 import com.intellij.lang.ASTNode
+import com.intellij.navigation.ItemPresentation
+import com.intellij.navigation.NavigationItem
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiNameIdentifierOwner
@@ -14,6 +16,7 @@ import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexPsiHelper
 import nl.hannahsten.texifyidea.psi.LatexVisitor
 import nl.hannahsten.texifyidea.reference.CommandDefinitionReference
+import nl.hannahsten.texifyidea.structure.latex.LatexPresentationFactory
 import nl.hannahsten.texifyidea.util.labels.getLabelReferenceCommands
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.parser.*
@@ -115,6 +118,10 @@ abstract class LatexCommandsImplMixin : StubBasedPsiElementBase<LatexCommandsStu
      */
     override fun getReference(): PsiReference? {
         return this.references.firstOrNull()
+    }
+
+    override fun getPresentation(): ItemPresentation? {
+        return LatexPresentationFactory.getPresentation(this)
     }
 
     override fun getOptionalParameterMap() = getOptionalParameterMapFromParameters(this.parameterList)

--- a/src/nl/hannahsten/texifyidea/psi/impl/LatexCommandsImplMixin.kt
+++ b/src/nl/hannahsten/texifyidea/psi/impl/LatexCommandsImplMixin.kt
@@ -3,7 +3,6 @@ package nl.hannahsten.texifyidea.psi.impl
 import com.intellij.extapi.psi.StubBasedPsiElementBase
 import com.intellij.lang.ASTNode
 import com.intellij.navigation.ItemPresentation
-import com.intellij.navigation.NavigationItem
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiNameIdentifierOwner

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexNewCommandPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexNewCommandPresentation.kt
@@ -43,8 +43,9 @@ class LatexNewCommandPresentation(newCommand: LatexCommands) : ItemPresentation 
 
         // Get the definition to show in place of the location string.
         locationString = when {
-            newCommand.commandToken.text == "\\" + LatexNewDefinitionCommand.NEWCOMMAND.command && required.size >= 2 -> required[1]
-            newCommand.commandToken.text == "\\" + LatexXparseCommand.NEWDOCUMENTCOMMAND.command && required.size >= 3 -> required[2]
+            newCommand.name == LatexNewDefinitionCommand.NEWCOMMAND.commandWithSlash && required.size >= 2 -> required[1]
+            newCommand.name == LatexNewDefinitionCommand.RENEWCOMMAND.commandWithSlash && required.size >= 2 -> required[1]
+            newCommand.name == LatexXparseCommand.NEWDOCUMENTCOMMAND.commandWithSlash && required.size >= 3 -> required[2]
             else -> ""
         }
     }

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexOtherCommandPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexOtherCommandPresentation.kt
@@ -14,7 +14,7 @@ class LatexOtherCommandPresentation(val command: LatexCommands, private val icon
 
     override fun getPresentableText() = command.name
 
-    override fun getLocationString() = command.lineNumber().toString()
+    override fun getLocationString() = command.containingFile.name + ":" + command.lineNumber().toString()
 
     override fun getIcon(b: Boolean) = icon
 }

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexOtherCommandPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexOtherCommandPresentation.kt
@@ -2,9 +2,7 @@ package nl.hannahsten.texifyidea.structure.latex
 
 import com.intellij.navigation.ItemPresentation
 import nl.hannahsten.texifyidea.psi.LatexCommands
-import nl.hannahsten.texifyidea.util.files.document
 import nl.hannahsten.texifyidea.util.parser.lineNumber
-import nl.hannahsten.texifyidea.util.parser.nextCommand
 import javax.swing.Icon
 
 /**

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexOtherCommandPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexOtherCommandPresentation.kt
@@ -2,30 +2,19 @@ package nl.hannahsten.texifyidea.structure.latex
 
 import com.intellij.navigation.ItemPresentation
 import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.util.files.document
+import nl.hannahsten.texifyidea.util.parser.lineNumber
 import nl.hannahsten.texifyidea.util.parser.nextCommand
 import javax.swing.Icon
 
 /**
  * @author Hannah Schellekens
  */
-class LatexOtherCommandPresentation(command: LatexCommands, private val icon: Icon) : ItemPresentation {
+class LatexOtherCommandPresentation(val command: LatexCommands, private val icon: Icon) : ItemPresentation {
 
-    private val commandName = command.name
-    private var locationString: String
+    override fun getPresentableText() = command.name
 
-    init {
-        val firstNext = command.nextCommand()
-        if (firstNext != null) {
-            val lookup = firstNext.commandToken.text
-            this.locationString = lookup ?: ""
-        }
-
-        locationString = ""
-    }
-
-    override fun getPresentableText() = commandName
-
-    override fun getLocationString() = locationString
+    override fun getLocationString() = command.lineNumber().toString()
 
     override fun getIcon(b: Boolean) = icon
 }

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexPresentationFactory.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexPresentationFactory.kt
@@ -4,7 +4,6 @@ import com.intellij.navigation.ItemPresentation
 import nl.hannahsten.texifyidea.TexifyIcons
 import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand.*
 import nl.hannahsten.texifyidea.lang.commands.LatexMathtoolsRegularCommand.*
-import nl.hannahsten.texifyidea.lang.commands.LatexNewDefinitionCommand
 import nl.hannahsten.texifyidea.lang.commands.LatexNewDefinitionCommand.NEWCOMMAND
 import nl.hannahsten.texifyidea.lang.commands.LatexNewDefinitionCommand.RENEWCOMMAND
 import nl.hannahsten.texifyidea.lang.commands.LatexXparseCommand

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexPresentationFactory.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexPresentationFactory.kt
@@ -4,7 +4,9 @@ import com.intellij.navigation.ItemPresentation
 import nl.hannahsten.texifyidea.TexifyIcons
 import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand.*
 import nl.hannahsten.texifyidea.lang.commands.LatexMathtoolsRegularCommand.*
+import nl.hannahsten.texifyidea.lang.commands.LatexNewDefinitionCommand
 import nl.hannahsten.texifyidea.lang.commands.LatexNewDefinitionCommand.NEWCOMMAND
+import nl.hannahsten.texifyidea.lang.commands.LatexNewDefinitionCommand.RENEWCOMMAND
 import nl.hannahsten.texifyidea.lang.commands.LatexXparseCommand
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.util.getIncludeCommands
@@ -30,7 +32,7 @@ object LatexPresentationFactory {
             SUBSUBSECTION.cmd -> LatexSubSubSectionPresentation(commands)
             PARAGRAPH.cmd -> LatexParagraphPresentation(commands)
             SUBPARAGRAPH.cmd -> LatexSubParagraphPresentation(commands)
-            NEWCOMMAND.cmd, DECLARE_MATH_OPERATOR.cmd, LatexXparseCommand.NEWDOCUMENTCOMMAND.cmd -> LatexNewCommandPresentation(commands)
+            NEWCOMMAND.cmd, RENEWCOMMAND.cmd, DECLARE_MATH_OPERATOR.cmd, LatexXparseCommand.NEWDOCUMENTCOMMAND.cmd -> LatexNewCommandPresentation(commands)
             DECLARE_PAIRED_DELIMITER.cmd, DECLARE_PAIRED_DELIMITER_X.cmd, DECLARE_PAIRED_DELIMITER_XPP.cmd -> LatexPairedDelimiterPresentation(
                 commands
             )

--- a/src/nl/hannahsten/texifyidea/util/parser/Psi.kt
+++ b/src/nl/hannahsten/texifyidea/util/parser/Psi.kt
@@ -17,6 +17,7 @@ import nl.hannahsten.texifyidea.lang.DefaultEnvironment
 import nl.hannahsten.texifyidea.lang.Environment
 import nl.hannahsten.texifyidea.lang.magic.TextBasedMagicCommentParser
 import nl.hannahsten.texifyidea.psi.*
+import nl.hannahsten.texifyidea.util.files.document
 import nl.hannahsten.texifyidea.util.magic.EnvironmentMagic
 import kotlin.reflect.KClass
 
@@ -24,6 +25,8 @@ import kotlin.reflect.KClass
  * Get the offset where the psi element ends.
  */
 fun PsiElement.endOffset(): Int = textOffset + textLength
+
+fun PsiElement.lineNumber(): Int? = containingFile.document()?.getLineNumber(textOffset)
 
 /**
  * @see [PsiTreeUtil.getChildrenOfType]


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3547 

#### Summary of additions and changes

* Show `fileName:lineNumber` in go to defition popup item.

#### How to test this pull request

```latex
\documentclass{article}

\newcommand{\tree}{tree}
\renewcommand{\tree}{tr}

\begin{document}
    \tree
\end{document}
```

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary