### PR TITLE
Don't insert \right when brace is already matched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@
 
 ### Fixed
 
+## [0.9.6-alpha.3] - 2024-05-27
+
+### Added
+
+* Don't insert \right when brace is already matched, by @slideclimb
+* Show file and line number in 'go to definition' view, by @slideclimb
+* Do not select the extension when refactoring file names, by @jojo2357
+
+### Fixed
+
+* Handle file extensions case sensitive, by @jojo2357
+* Autocomplete \left* with \right* for all variants, by @jojo2357
+* Fix pasting text from pdf file
+* Fix table insertion wizard not inserting text
+
 ## [0.9.6-alpha.2] - 2024-05-19
 
 ### Fixed
@@ -352,7 +367,8 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Fix some intention previews. ([#2796](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2796))
 * Other small bug fixes and improvements. ([#2776](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2776), [#2774](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2774), [#2765](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2765)-[#2773](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2773))
 
-[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.6-alpha.2...HEAD
+[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.6-alpha.3...HEAD
+[0.9.6-alpha.3]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.6-alpha.2...v0.9.6-alpha.3
 [0.9.6-alpha.2]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.6-alpha.1...v0.9.6-alpha.2
 [0.9.6-alpha.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5...v0.9.6-alpha.1
 [0.9.5]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.4...v0.9.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.9.6-alpha.2
+pluginVersion = 0.9.6-alpha.3
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/completion/handlers/RightInsertHandler.kt
+++ b/src/nl/hannahsten/texifyidea/completion/handlers/RightInsertHandler.kt
@@ -4,7 +4,6 @@ import com.intellij.codeInsight.completion.InsertHandler
 import com.intellij.codeInsight.completion.InsertionContext
 import com.intellij.codeInsight.highlighting.BraceMatchingUtil
 import com.intellij.codeInsight.lookup.LookupElement
-import com.intellij.openapi.editor.Editor
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.lang.commands.LatexCommand
 import nl.hannahsten.texifyidea.lang.commands.LatexDelimiterCommand

--- a/src/nl/hannahsten/texifyidea/completion/handlers/RightInsertHandler.kt
+++ b/src/nl/hannahsten/texifyidea/completion/handlers/RightInsertHandler.kt
@@ -2,8 +2,10 @@ package nl.hannahsten.texifyidea.completion.handlers
 
 import com.intellij.codeInsight.completion.InsertHandler
 import com.intellij.codeInsight.completion.InsertionContext
+import com.intellij.codeInsight.highlighting.BraceMatchingUtil
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.openapi.editor.Editor
+import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.lang.commands.LatexCommand
 import nl.hannahsten.texifyidea.lang.commands.LatexDelimiterCommand
 
@@ -19,12 +21,13 @@ open class RightInsertHandler : InsertHandler<LookupElement> {
         val command = element.`object` as? LatexCommand ?: return
 
         if (command is LatexDelimiterCommand && command.isLeft) {
-            insertRightCommand(editor, command)
+            val hasMatchingBrace = BraceMatchingUtil.matchBrace(context.editor.document.text, LatexFileType, editor.highlighter.createIterator(context.editor.caretModel.offset - 1), true)
+            if (hasMatchingBrace) {
+                editor.document.insertString(editor.caretModel.offset, " ")
+            } else {
+                editor.document.insertString(editor.caretModel.offset, "  \\" + command.matchingName)
+            }
+            editor.caretModel.moveToOffset(editor.caretModel.offset + 1)
         }
-    }
-
-    private fun insertRightCommand(editor: Editor, leftCommand: LatexDelimiterCommand) {
-        editor.document.insertString(editor.caretModel.offset, "  \\" + leftCommand.matchingName)
-        editor.caretModel.moveToOffset(editor.caretModel.offset + 1)
     }
 }

--- a/test/nl/hannahsten/texifyidea/completion/RightInsertHandlerTest.kt
+++ b/test/nl/hannahsten/texifyidea/completion/RightInsertHandlerTest.kt
@@ -12,4 +12,11 @@ class RightInsertHandlerTest : BasePlatformTestCase() {
         myFixture.finishLookup(Lookup.NORMAL_SELECT_CHAR)
         myFixture.checkResult("""$\left( <caret> \right) $""")
     }
+
+    fun testLeftRightMatchingBraces() {
+        myFixture.configureByText(LatexFileType, """$\lef<caret> )$""")
+        myFixture.complete(CompletionType.BASIC)
+        myFixture.finishLookup(Lookup.NORMAL_SELECT_CHAR)
+        myFixture.checkResult("""$\left( <caret> )$""")
+    }
 }


### PR DESCRIPTION
…tched brace pairs)

<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3493 

#### Summary of additions and changes

* Don't insert \right when brace is already matched for existing brace pairs

#### How to test this pull request

See test

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary