### PR TITLE
Support plain TeX \if formatting

### DIFF
--- a/src/nl/hannahsten/texifyidea/formatting/LatexBlock.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexBlock.kt
@@ -11,10 +11,10 @@ import nl.hannahsten.texifyidea.editor.typedhandlers.LatexEnterHandler
 import nl.hannahsten.texifyidea.lang.commands.LatexCommand
 import nl.hannahsten.texifyidea.psi.*
 import nl.hannahsten.texifyidea.settings.codestyle.LatexCodeStyleSettings
-import nl.hannahsten.texifyidea.util.parser.firstChildOfType
-import nl.hannahsten.texifyidea.util.parser.firstParentOfType
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.magic.cmd
+import nl.hannahsten.texifyidea.util.parser.firstChildOfType
+import nl.hannahsten.texifyidea.util.parser.firstParentOfType
 import java.lang.Integer.max
 
 /**
@@ -158,7 +158,7 @@ class LatexBlock(
             else -> shouldIndentEnvironments
         }
 
-        if (shouldIndentEnvironment || myNode.elementType === LatexTypes.PSEUDOCODE_BLOCK_CONTENT ||
+        if (shouldIndentEnvironment || myNode.elementType === LatexTypes.PSEUDOCODE_BLOCK_CONTENT || myNode.elementType === LatexTypes.IF_BLOCK_CONTENT ||
             // Fix for leading comments inside an environment, because somehow they are not placed inside environments.
             // Note that this does not help to insert the indentation, but at least the indent is not removed
             // when formatting.

--- a/src/nl/hannahsten/texifyidea/formatting/LatexSpacingRules.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexSpacingRules.kt
@@ -2,16 +2,16 @@ package nl.hannahsten.texifyidea.formatting
 
 import com.intellij.formatting.Spacing
 import com.intellij.psi.codeStyle.CodeStyleSettings
-import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.formatting.spacingrules.leftTableSpaceAlign
 import nl.hannahsten.texifyidea.formatting.spacingrules.rightTableSpaceAlign
+import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexTypes.*
 import nl.hannahsten.texifyidea.settings.codestyle.LatexCodeStyleSettings
-import nl.hannahsten.texifyidea.util.parser.firstChildOfType
-import nl.hannahsten.texifyidea.util.parser.inDirectEnvironment
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.magic.EnvironmentMagic
+import nl.hannahsten.texifyidea.util.parser.firstChildOfType
+import nl.hannahsten.texifyidea.util.parser.inDirectEnvironment
 import nl.hannahsten.texifyidea.util.parser.parentOfType
 import java.util.*
 
@@ -49,6 +49,7 @@ fun createSpacingBuilder(settings: CodeStyleSettings): TexSpacingBuilder {
             between(NORMAL_TEXT_WORD, NORMAL_TEXT_WORD).spaces(1)
             before(ENVIRONMENT_CONTENT).lineBreakInCode()
             before(PSEUDOCODE_BLOCK_CONTENT).lineBreakInCode()
+            before(IF_BLOCK_CONTENT).lineBreakInCode()
         }
 
         // Newline before certain algorithm pseudocode commands
@@ -73,6 +74,9 @@ fun createSpacingBuilder(settings: CodeStyleSettings): TexSpacingBuilder {
                 Spacing.createSpacing(0, Int.MAX_VALUE, 1, latexCommonSettings.KEEP_LINE_BREAKS, latexCommonSettings.KEEP_BLANK_LINES_IN_CODE)
             )
             inPosition(parent = PSEUDOCODE_BLOCK, left = PSEUDOCODE_BLOCK_CONTENT, right = END_PSEUDOCODE_BLOCK).spacing(
+                Spacing.createSpacing(0, Int.MAX_VALUE, 1, latexCommonSettings.KEEP_LINE_BREAKS, latexCommonSettings.KEEP_BLANK_LINES_IN_CODE)
+            )
+            inPosition(parent = IF_BLOCK, left = IF_BLOCK_CONTENT, right = END_IF).spacing(
                 Spacing.createSpacing(0, Int.MAX_VALUE, 1, latexCommonSettings.KEEP_LINE_BREAKS, latexCommonSettings.KEEP_BLANK_LINES_IN_CODE)
             )
         }

--- a/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
+++ b/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
@@ -56,7 +56,8 @@ latexFile ::= content
 // Make sure that there is a root element with multiple children, for example for Grazie to allow ignoring certain types of no_math_content
 content ::= no_math_content*
 
-no_math_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | normal_text
+// When updating this list, consider updating other _content lists
+no_math_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | if_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | normal_text | END_IF
 
 normal_text ::= (NORMAL_TEXT_WORD | STAR | AMPERSAND | QUOTATION_MARK | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET | OPEN_PAREN | CLOSE_PAREN | OPEN_BRACKET | CLOSE_BRACKET | PIPE | EXCLAMATION_MARK | BACKSLASH | EQUALS | COMMA | ANGLE_PARAM)+
 
@@ -74,6 +75,12 @@ environment_content ::= <<injection_env_content raw_text>> | no_math_content+
 pseudocode_block ::= BEGIN_PSEUDOCODE_BLOCK parameter* pseudocode_block_content? (MIDDLE_PSEUDOCODE_BLOCK pseudocode_block_content?)* (END_PSEUDOCODE_BLOCK parameter*) { pin=5 }
 
 pseudocode_block_content ::= no_math_content*
+
+// Plain TeX \if...\fi, note that user defined ifs are not included so there may be unmatched \fi
+if_block ::= START_IF if_block_content? (ELSE if_block_content?)* END_IF { pin=1 }
+
+// no_math_content without end_if
+if_block_content ::= (raw_text | magic_comment | comment | environment | pseudocode_block | if_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | normal_text)*
 
 commands ::= COMMAND_TOKEN STAR? parameter* {
     pin=1
@@ -118,10 +125,10 @@ picture_param ::= OPEN_PAREN picture_param_content* CLOSE_PAREN { pin=3 }
 // These are like content, but no brackets and with parameter_text instead of normal_text
 // We have to separate optional and required parameter content, because required parameter content
 // can contain mismatched brackets, but optional parameters not (then we wouldn't know what to match)
-optional_param_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | OPEN_PAREN | CLOSE_PAREN | parameter_text | BACKSLASH | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET
-required_param_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | group | OPEN_PAREN | CLOSE_PAREN | parameter_text | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET | BACKSLASH | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET
+optional_param_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | if_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | OPEN_PAREN | CLOSE_PAREN | parameter_text | BACKSLASH | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET | END_IF
+required_param_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | if_block | math_environment | COMMAND_IFNEXTCHAR | group | OPEN_PAREN | CLOSE_PAREN | parameter_text | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET | BACKSLASH | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET | END_IF
 // Cannot contain ( or )
-picture_param_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | parameter_text | BACKSLASH | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET
+picture_param_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | if_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | parameter_text | BACKSLASH | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET | END_IF
 
 strict_key_val_pair ::= key_val_key EQUALS key_val_value?
 

--- a/src/nl/hannahsten/texifyidea/grammar/LatexLexer.flex
+++ b/src/nl/hannahsten/texifyidea/grammar/LatexLexer.flex
@@ -125,6 +125,11 @@ BEGIN_PSEUDOCODE_BLOCK="\\For" | "\\ForAll" | "\\If" | "\\While" | "\\Repeat" | 
 MIDDLE_PSEUDOCODE_BLOCK="\\ElsIf" | "\\Else"
 END_PSEUDOCODE_BLOCK="\\EndFor" | "\\EndIf" | "\\EndWhile" | "\\Until" | "\\EndLoop" | "\\EndFunction" | "\\EndProcedure"
 
+// See TeX by Topic chapter 13
+START_IFS=\\if | \\ifcat | \\ifx | \\ifcase | \\ifnum | \\ifodd | \\ifhmode | \\ifvmode | \\ifmmode | \\ifinner | \\ifdim | \\ifvoid | \\ifhbox | \\ifvbox | \\ifeof | \\iftrue | \\iffalse
+ELSE=\\else
+END_IFS=\\fi
+
 %states INLINE_MATH INLINE_MATH_LATEX DISPLAY_MATH TEXT_INSIDE_INLINE_MATH NESTED_INLINE_MATH PARTIAL_DEFINITION
 %states NEW_ENVIRONMENT_DEFINITION_NAME NEW_ENVIRONMENT_DEFINITION NEW_ENVIRONMENT_SKIP_BRACE NEW_ENVIRONMENT_DEFINITION_END NEW_DOCUMENT_ENV_DEFINITION_NAME NEW_DOCUMENT_ENV_DEFINITION_ARGS_SPEC NEW_COMMAND_DEFINITION_PARAM1 NEW_COMMAND_DEFINITION_PARAM2
 
@@ -524,6 +529,9 @@ END_PSEUDOCODE_BLOCK="\\EndFor" | "\\EndIf" | "\\EndWhile" | "\\Until" | "\\EndL
 {ENDINPUT}              { yypushState(OFF); return COMMAND_TOKEN; }
 {BEGIN_TOKEN}           { yypushState(POSSIBLE_VERBATIM_BEGIN); return BEGIN_TOKEN; }
 {END_TOKEN}             { return END_TOKEN; }
+{START_IFS}             { return START_IF; }
+{ELSE}                  { return ELSE; }
+{END_IFS}               { return END_IF; }
 {COMMAND_TOKEN}         { return COMMAND_TOKEN; }
 {COMMAND_IFNEXTCHAR}    { return COMMAND_IFNEXTCHAR; }
 {MAGIC_COMMENT_TOKEN}   { return MAGIC_COMMENT_TOKEN; }

--- a/src/nl/hannahsten/texifyidea/grammar/LatexParserDefinition.kt
+++ b/src/nl/hannahsten/texifyidea/grammar/LatexParserDefinition.kt
@@ -48,7 +48,7 @@ class LatexParserDefinition : ParserDefinition {
         val FILE: IStubFileElementType<*> = object : IStubFileElementType<LatexFileStub>(
             "LatexStubFileElementType", Language.findInstance(LatexLanguage::class.java)
         ) {
-            override fun getStubVersion(): Int = 71
+            override fun getStubVersion(): Int = 72
         }
     }
 

--- a/src/nl/hannahsten/texifyidea/highlighting/LatexPairedBraceMatcher.kt
+++ b/src/nl/hannahsten/texifyidea/highlighting/LatexPairedBraceMatcher.kt
@@ -18,7 +18,8 @@ class LatexPairedBraceMatcher : PairedBraceMatcher {
         BracePair(LatexTypes.OPEN_PAREN, LatexTypes.CLOSE_PAREN, false),
         BracePair(LatexTypes.OPEN_BRACE, LatexTypes.CLOSE_BRACE, false),
         BracePair(LatexTypes.OPEN_BRACKET, LatexTypes.CLOSE_BRACKET, false),
-        BracePair(LatexTypes.BEGIN_PSEUDOCODE_BLOCK, LatexTypes.END_PSEUDOCODE_BLOCK, false)
+        BracePair(LatexTypes.BEGIN_PSEUDOCODE_BLOCK, LatexTypes.END_PSEUDOCODE_BLOCK, false),
+        BracePair(LatexTypes.START_IF, LatexTypes.END_IF, false),
     )
 
     override fun getPairs() = bracePairs

--- a/src/nl/hannahsten/texifyidea/highlighting/LatexSyntaxHighlighter.kt
+++ b/src/nl/hannahsten/texifyidea/highlighting/LatexSyntaxHighlighter.kt
@@ -83,7 +83,10 @@ class LatexSyntaxHighlighter : SyntaxHighlighterBase() {
             LatexTypes.END_TOKEN,
             LatexTypes.BEGIN_PSEUDOCODE_BLOCK,
             LatexTypes.MIDDLE_PSEUDOCODE_BLOCK,
-            LatexTypes.END_PSEUDOCODE_BLOCK
+            LatexTypes.END_PSEUDOCODE_BLOCK,
+            LatexTypes.START_IF,
+            LatexTypes.ELSE,
+            LatexTypes.END_IF,
         )
 
         /*

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexNonMatchingIfInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexNonMatchingIfInspection.kt
@@ -11,8 +11,6 @@ import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.util.files.commandsInFile
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.magic.GeneralMagic
-import nl.hannahsten.texifyidea.util.magic.PatternMagic
-import nl.hannahsten.texifyidea.util.matches
 import nl.hannahsten.texifyidea.util.parser.previousCommand
 import java.util.*
 
@@ -52,7 +50,7 @@ open class LatexNonMatchingIfInspection : TexifyInspectionBase() {
 
                 stack.pop()
             }
-            else if (PatternMagic.ifCommand.matches(name) && name !in CommandMagic.ignoredIfs && command.previousCommand()?.name != LatexNewDefinitionCommand.NEWIF.commandWithSlash) {
+            else if (name in CommandMagic.startIfs && command.previousCommand()?.name != LatexNewDefinitionCommand.NEWIF.commandWithSlash) {
                 stack.push(command)
             }
         }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexNonMatchingIfInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexNonMatchingIfInspection.kt
@@ -6,9 +6,11 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.inspections.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
+import nl.hannahsten.texifyidea.lang.LatexPackage
 import nl.hannahsten.texifyidea.lang.commands.LatexNewDefinitionCommand
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.util.files.commandsInFile
+import nl.hannahsten.texifyidea.util.includedPackages
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.magic.GeneralMagic
 import nl.hannahsten.texifyidea.util.parser.previousCommand
@@ -27,6 +29,11 @@ open class LatexNonMatchingIfInspection : TexifyInspectionBase() {
 
     override fun inspectFile(file: PsiFile, manager: InspectionManager, isOntheFly: Boolean): List<ProblemDescriptor> {
         val descriptors = descriptorList()
+
+        // etoolbox has many \if... commands without a \fi
+        if (file.includedPackages().contains(LatexPackage.ETOOLBOX)) {
+            return emptyList()
+        }
 
         // Find matches.
         val stack = ArrayDeque<LatexCommands>()

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexNonMatchingIfInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexNonMatchingIfInspection.kt
@@ -44,7 +44,7 @@ open class LatexNonMatchingIfInspection : TexifyInspectionBase() {
         // Find matches.
         val stack = ArrayDeque<PsiElement>()
         val commands = file.commandsInFile()
-        val ifs = file.childrenOfType<LeafPsiElement>().filter { it.elementType == LatexTypes.END_IF || it.elementType == LatexTypes.START_IF}
+        val ifs = file.childrenOfType<LeafPsiElement>().filter { it.elementType == LatexTypes.END_IF || it.elementType == LatexTypes.START_IF }
         val all = (commands + ifs).sortedBy { it.textOffset }
         for (command in all) {
             val name = if (command is LatexCommands) command.name else command.text

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexNonMatchingIfInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexNonMatchingIfInspection.kt
@@ -13,6 +13,8 @@ import nl.hannahsten.texifyidea.util.files.commandsInFile
 import nl.hannahsten.texifyidea.util.includedPackages
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.magic.GeneralMagic
+import nl.hannahsten.texifyidea.util.magic.PatternMagic
+import nl.hannahsten.texifyidea.util.matches
 import nl.hannahsten.texifyidea.util.parser.previousCommand
 import java.util.*
 
@@ -57,7 +59,7 @@ open class LatexNonMatchingIfInspection : TexifyInspectionBase() {
 
                 stack.pop()
             }
-            else if (name in CommandMagic.startIfs && command.previousCommand()?.name != LatexNewDefinitionCommand.NEWIF.commandWithSlash) {
+            else if (PatternMagic.ifCommand.matches(name) && name !in CommandMagic.ignoredIfs && command.previousCommand()?.name != LatexNewDefinitionCommand.NEWIF.commandWithSlash) {
                 stack.push(command)
             }
         }

--- a/src/nl/hannahsten/texifyidea/lang/LatexPackage.kt
+++ b/src/nl/hannahsten/texifyidea/lang/LatexPackage.kt
@@ -43,6 +43,7 @@ open class LatexPackage @JvmOverloads constructor(
         val COLOR = LatexPackage("color")
         val COMMENT = LatexPackage("comment")
         val CSQUOTES = LatexPackage("csquotes")
+        val ETOOLBOX = LatexPackage("etoolbox")
         val EUROSYM = LatexPackage("eurosym")
         val FLOAT = LatexPackage("float")
         val FONTENC = LatexPackage("fontenc")

--- a/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
@@ -432,6 +432,7 @@ object CommandMagic {
      */
     val bibliographyIncludeCommands = includeOnlyExtensions.entries.filter { it.value.contains("bib") }.map { it.key }
 
+    @Suppress("unused")
     val startIfs = hashSetOf(
         IF, IFCAT, IFX,
         IFCASE, IFNUM, IFODD,
@@ -445,6 +446,11 @@ object CommandMagic {
      * All commands that end if.
      */
     val endIfs = hashSetOf(FI.cmd)
+
+    /**
+     * All commands that at first glance look like \if-esque commands, but that actually aren't.
+     */
+    val ignoredIfs = hashSetOf("\\newif", "\\iff", "\\ifthenelse", "\\iftoggle", "\\ifoot", "\\ifcsvstrcmp")
 
     /**
      * List of all TeX style primitives.

--- a/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
@@ -433,11 +433,6 @@ object CommandMagic {
     val bibliographyIncludeCommands = includeOnlyExtensions.entries.filter { it.value.contains("bib") }.map { it.key }
 
     /**
-     * All commands that end if.
-     */
-    val endIfs = hashSetOf(FI.cmd)
-
-    /**
      * All commands that at first glance look like \if-esque commands, but that actually aren't.
      */
     val ignoredIfs = hashSetOf("\\newif", "\\iff", "\\ifthenelse", "\\iftoggle", "\\ifoot", "\\ifcsvstrcmp")

--- a/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
@@ -11,7 +11,6 @@ import nl.hannahsten.texifyidea.lang.commands.LatexCommand
 import nl.hannahsten.texifyidea.lang.commands.LatexGenericMathCommand.*
 import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand.*
 import nl.hannahsten.texifyidea.lang.commands.LatexGlossariesCommand.*
-import nl.hannahsten.texifyidea.lang.commands.LatexIfCommand.*
 import nl.hannahsten.texifyidea.lang.commands.LatexListingCommand.*
 import nl.hannahsten.texifyidea.lang.commands.LatexMathtoolsRegularCommand.*
 import nl.hannahsten.texifyidea.lang.commands.LatexNatbibCommand.*

--- a/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
@@ -432,7 +432,6 @@ object CommandMagic {
      */
     val bibliographyIncludeCommands = includeOnlyExtensions.entries.filter { it.value.contains("bib") }.map { it.key }
 
-    @Suppress("unused")
     val startIfs = hashSetOf(
         IF, IFCAT, IFX,
         IFCASE, IFNUM, IFODD,
@@ -446,11 +445,6 @@ object CommandMagic {
      * All commands that end if.
      */
     val endIfs = hashSetOf(FI.cmd)
-
-    /**
-     * All commands that at first glance look like \if-esque commands, but that actually aren't.
-     */
-    val ignoredIfs = hashSetOf("\\newif", "\\iff", "\\ifthenelse", "\\iftoggle", "\\ifoot", "\\ifcsvstrcmp")
 
     /**
      * List of all TeX style primitives.

--- a/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
@@ -432,16 +432,6 @@ object CommandMagic {
      */
     val bibliographyIncludeCommands = includeOnlyExtensions.entries.filter { it.value.contains("bib") }.map { it.key }
 
-    @Suppress("unused")
-    val startIfs = hashSetOf(
-        IF, IFCAT, IFX,
-        IFCASE, IFNUM, IFODD,
-        IFHMODE, IFVMODE, IFMMODE,
-        IFINNER, IFDIM, IFVOID,
-        IFHBOX, IFVBOX, IFEOF,
-        IFTRUE, IFFALSE
-    ).map { it.cmd }
-
     /**
      * All commands that end if.
      */

--- a/src/nl/hannahsten/texifyidea/util/magic/PatternMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/PatternMagic.kt
@@ -114,11 +114,6 @@ object PatternMagic {
     val htmlTag = RegexPattern.compile("""<.*?/?>""")!!
 
     /**
-     * Matches a LaTeX command that is the start of an \if-\fi structure.
-     */
-    val ifCommand = RegexPattern.compile("\\\\if[a-zA-Z@]*")!!
-
-    /**
      * Matches the begin and end commands of the cases and split environments.
      */
     val casesOrSplitCommands = Regex(

--- a/src/nl/hannahsten/texifyidea/util/magic/PatternMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/PatternMagic.kt
@@ -114,6 +114,11 @@ object PatternMagic {
     val htmlTag = RegexPattern.compile("""<.*?/?>""")!!
 
     /**
+     * Matches a LaTeX command that is the start of an \if-\fi structure.
+     */
+    val ifCommand = RegexPattern.compile("\\\\if[a-zA-Z@]*")!!
+
+    /**
      * Matches the begin and end commands of the cases and split environments.
      */
     val casesOrSplitCommands = Regex(

--- a/src/nl/hannahsten/texifyidea/util/parser/LatexCommandsUtil.kt
+++ b/src/nl/hannahsten/texifyidea/util/parser/LatexCommandsUtil.kt
@@ -101,7 +101,7 @@ fun LatexCommands.nextCommand(): LatexCommands? {
  *
  * @return The previous command in the file, or `null` when there is no such command.
  */
-fun LatexCommands.previousCommand(): LatexCommands? {
+fun PsiElement.previousCommand(): LatexCommands? {
     val content = parentOfType(LatexNoMathContent::class) ?: return null
     val previous = content.previousSiblingIgnoreWhitespace() as? LatexNoMathContent
         ?: return null

--- a/test/nl/hannahsten/texifyidea/formatting/LatexFormattingTest.kt
+++ b/test/nl/hannahsten/texifyidea/formatting/LatexFormattingTest.kt
@@ -230,6 +230,57 @@ fun Int?.ifPositiveAddTwo(): Int =
         """.trimIndent()
     }
 
+    fun testPlainIf() {
+        """
+            \ifx\mycmd\undefined
+            undefed
+            \else
+          \if\mycmd1
+          defed, 1
+          \else
+          defed
+          \fi
+            \fi
+        """.trimIndent() `should be reformatted to` """
+            \ifx
+                \mycmd\undefined
+                undefed
+            \else
+                \if
+                    \mycmd1
+                    defed, 1
+                \else
+                    defed
+                \fi
+            \fi
+        """.trimIndent()
+    }
+
+    fun testPlainUnknownIf() {
+        """
+            \ifx\mycmd\undefined
+            undefed
+            \else
+          \ifaxp\mycmd1%\ifaxp is not a known if
+          defed, 1
+          \else
+          defed
+          \fi
+            \fi
+        """.trimIndent() `should be reformatted to` """
+            \ifx
+                \mycmd\undefined
+                undefed
+            \else
+                \ifaxp\mycmd1%\ifaxp is not a known if
+                defed, 1
+            \else
+                defed
+            \fi
+            \fi
+        """.trimIndent()
+    }
+
     fun `test section used in command definition`() {
         """
             \documentclass{article}

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexNonMatchingIfInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexNonMatchingIfInspectionTest.kt
@@ -11,7 +11,8 @@ class LatexNonMatchingIfInspectionTest : TexifyInspectionTestBase(LatexNonMatchi
         """.trimIndent()
     )
 
-    fun `test if not closed`() = testHighlighting("<warning descr=\"If statement should probably be closed with \\fi\">\\if</warning>")
+    // This is a parse error
+    fun `test if not closed`() = testHighlighting("<warning descr=\"If statement should probably be closed with \\fi\">\\if</warning><EOLError>")
 
     fun `test fi not opened`() = testHighlighting("<warning descr=\"No matching \\if-command found\">\\fi</warning>")
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3121

#### Summary of additions and changes

* Support plain TeX \if formatting
* Does not support user defined \ifs, but it will not lead to a parse error, just weird formatting
* I don't know why anyone would use plain TeX instead of e.g. etoolbox

#### How to test this pull request

```latex
\ifx\mycmd\undefined
            undefed
            \else
          \if\mycmd1
          defed, 1
          \else
          defed
          \fi
            \fi
```

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary