### PR TITLE
Editable postfix templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 ### Fixed
 
+## [0.9.7-alpha.2] - 2024-06-09
+
+### Added
+
+* Add a simple editor for postfix templates, by @slideclimb
+* Add support for \ProvidesExpl(Class|File), by @Sirraide
+* Support TeX Live docker image
+* Formatter support for plain TeX \if-statements
+* Index files from the TEXINPUTS variable, for autocompletion
+
 ## [0.9.7-alpha.1] - 2024-06-06
 
 ### Added
@@ -366,8 +376,9 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Fix some intention previews. ([#2796](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2796))
 * Other small bug fixes and improvements. ([#2776](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2776), [#2774](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2774), [#2765](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2765)-[#2773](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2773))
 
-[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.7-alpha.1...HEAD
+[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.7-alpha.2...HEAD
 [0.9.7-alpha.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.6...v0.9.7-alpha.1
+[0.9.7-alpha.2]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.7-alpha.1...v0.9.7-alpha.2
 [0.9.6]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.5...v0.9.6
 [0.9.5]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.3...v0.9.4

--- a/Writerside/topics/Code-completion.md
+++ b/Writerside/topics/Code-completion.md
@@ -136,7 +136,8 @@ Currently available are commands for text decoration, and some commonly used mat
 
 ![math-postfix](math-postfix.gif)
 
-A list of available templates is in <ui-path>File | Settings | Editor | General | Postfix Completion</ui-path>, where you can edit the key of a template. If you want to add your own postfix templates, have a look at the [Custom Postfix Templates](https://plugins.jetbrains.com/plugin/9862-custom-postfix-templates) plugin. The plugin allows the creation of custom postfix templates for a number of languages, including Latex.
+A list of available templates is in <ui-path>File | Settings | Editor | General | Postfix Completion</ui-path>, where you can edit the key of a template. You can also add your own templates.
+For more advanced editing of postfix templates, have a look at the [Custom Postfix Templates](https://plugins.jetbrains.com/plugin/9862-custom-postfix-templates) plugin. The plugin allows the creation of custom postfix templates for a number of languages, including LaTeX.
 
 See also [https://www.jetbrains.com/help/idea/auto-completing-code.html#postfix_completion](https://www.jetbrains.com/help/idea/auto-completing-code.html#postfix_completion).
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.9.7-alpha.1
+pluginVersion = 0.9.7-alpha.2
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/editor/postfix/LatexPostFixTemplateProvider.kt
+++ b/src/nl/hannahsten/texifyidea/editor/postfix/LatexPostFixTemplateProvider.kt
@@ -1,11 +1,9 @@
 package nl.hannahsten.texifyidea.editor.postfix
 
 import com.intellij.codeInsight.completion.CompletionContributor
-import com.intellij.codeInsight.template.postfix.templates.JavaPostfixTemplateProvider
 import com.intellij.codeInsight.template.postfix.templates.PostfixTemplate
 import com.intellij.codeInsight.template.postfix.templates.PostfixTemplateProvider
 import com.intellij.codeInsight.template.postfix.templates.PostfixTemplatesUtils
-import com.intellij.codeInsight.template.postfix.templates.editable.JavaEditablePostfixTemplate
 import com.intellij.codeInsight.template.postfix.templates.editable.PostfixTemplateEditor
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiFile
@@ -13,7 +11,6 @@ import nl.hannahsten.texifyidea.editor.postfix.editable.LatexEditablePostfixTemp
 import nl.hannahsten.texifyidea.editor.postfix.editable.LatexPostfixTemplateEditor
 import nl.hannahsten.texifyidea.editor.postfix.editable.LatexPostfixTemplateExpressionCondition
 import org.jdom.Element
-import org.jetbrains.jps.model.java.JpsJavaSdkType
 
 class LatexPostFixTemplateProvider : PostfixTemplateProvider, CompletionContributor() {
 
@@ -51,6 +48,9 @@ class LatexPostFixTemplateProvider : PostfixTemplateProvider, CompletionContribu
         return if (templateToEdit == null) {
             LatexPostfixTemplateEditor(this)
         }
+        else if (templateToEdit is LatexEditablePostfixTemplate && !templateToEdit.isBuiltin) {
+            LatexPostfixTemplateEditor(this).apply { setTemplate(templateToEdit) }
+        }
         else null
     }
 
@@ -65,9 +65,9 @@ class LatexPostFixTemplateProvider : PostfixTemplateProvider, CompletionContribu
 
     override fun readExternalTemplate(id: String, name: String, template: Element): PostfixTemplate? {
         val liveTemplate = PostfixTemplatesUtils.readExternalLiveTemplate(template, this) ?: return null
-        val condition = PostfixTemplatesUtils.readExternalConditions(template) { condition: Element? -> LatexPostfixTemplateExpressionCondition.readExternal(condition!!) }.first()
+        val conditions = PostfixTemplatesUtils.readExternalConditions(template) { condition: Element? -> LatexPostfixTemplateExpressionCondition.readExternal(condition!!) }
 
-        return LatexEditablePostfixTemplate(id, name, liveTemplate, condition, this)
+        return LatexEditablePostfixTemplate(id, name, liveTemplate, conditions, this)
     }
 
     override fun writeExternalTemplate(template: PostfixTemplate, parentElement: Element) {

--- a/src/nl/hannahsten/texifyidea/editor/postfix/LatexPostFixTemplateProvider.kt
+++ b/src/nl/hannahsten/texifyidea/editor/postfix/LatexPostFixTemplateProvider.kt
@@ -1,10 +1,19 @@
 package nl.hannahsten.texifyidea.editor.postfix
 
 import com.intellij.codeInsight.completion.CompletionContributor
+import com.intellij.codeInsight.template.postfix.templates.JavaPostfixTemplateProvider
 import com.intellij.codeInsight.template.postfix.templates.PostfixTemplate
 import com.intellij.codeInsight.template.postfix.templates.PostfixTemplateProvider
+import com.intellij.codeInsight.template.postfix.templates.PostfixTemplatesUtils
+import com.intellij.codeInsight.template.postfix.templates.editable.JavaEditablePostfixTemplate
+import com.intellij.codeInsight.template.postfix.templates.editable.PostfixTemplateEditor
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiFile
+import nl.hannahsten.texifyidea.editor.postfix.editable.LatexEditablePostfixTemplate
+import nl.hannahsten.texifyidea.editor.postfix.editable.LatexPostfixTemplateEditor
+import nl.hannahsten.texifyidea.editor.postfix.editable.LatexPostfixTemplateExpressionCondition
+import org.jdom.Element
+import org.jetbrains.jps.model.java.JpsJavaSdkType
 
 class LatexPostFixTemplateProvider : PostfixTemplateProvider, CompletionContributor() {
 
@@ -33,6 +42,18 @@ class LatexPostFixTemplateProvider : PostfixTemplateProvider, CompletionContribu
 
     override fun getTemplates(): MutableSet<PostfixTemplate> = (templates + wrapWithTextCommandTemplates + wrapWithMathCommandTemplates) as MutableSet<PostfixTemplate>
 
+    /**
+     * To decide whether this template provider can add new templates, idea checks it its presentable name is non-null.
+     */
+    override fun getPresentableName() = "LaTeX"
+
+    override fun createEditor(templateToEdit: PostfixTemplate?): PostfixTemplateEditor? {
+        return if (templateToEdit == null) {
+            LatexPostfixTemplateEditor(this)
+        }
+        else null
+    }
+
     override fun isTerminalSymbol(currentChar: Char): Boolean = (currentChar == '.')
 
     override fun afterExpand(file: PsiFile, editor: Editor) {}
@@ -41,4 +62,17 @@ class LatexPostFixTemplateProvider : PostfixTemplateProvider, CompletionContribu
         copyFile
 
     override fun preExpand(file: PsiFile, editor: Editor) {}
+
+    override fun readExternalTemplate(id: String, name: String, template: Element): PostfixTemplate? {
+        val liveTemplate = PostfixTemplatesUtils.readExternalLiveTemplate(template, this) ?: return null
+        val condition = PostfixTemplatesUtils.readExternalConditions(template) { condition: Element? -> LatexPostfixTemplateExpressionCondition.readExternal(condition!!) }.first()
+
+        return LatexEditablePostfixTemplate(id, name, liveTemplate, condition, this)
+    }
+
+    override fun writeExternalTemplate(template: PostfixTemplate, parentElement: Element) {
+        if (template is LatexEditablePostfixTemplate) {
+            PostfixTemplatesUtils.writeExternalTemplate(template, parentElement)
+        }
+    }
 }

--- a/src/nl/hannahsten/texifyidea/editor/postfix/LatexPostfixExpressionSelector.kt
+++ b/src/nl/hannahsten/texifyidea/editor/postfix/LatexPostfixExpressionSelector.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.util.elementType
 import com.intellij.util.Function
 import nl.hannahsten.texifyidea.psi.*
+import nl.hannahsten.texifyidea.util.files.document
 import nl.hannahsten.texifyidea.util.parser.firstParentOfType
 import nl.hannahsten.texifyidea.util.parser.inMathContext
 
@@ -38,5 +39,10 @@ class LatexPostfixExpressionSelector(private val mathOnly: Boolean = false, priv
             LatexTypes.DISPLAY_MATH_END -> mutableListOf(context.firstParentOfType(LatexDisplayMath::class) as PsiElement)
             else -> mutableListOf(context)
         }
+    }
+
+    fun getTopMostExpression(element: PsiElement): PsiElement {
+        return getExpressions(element, element.containingFile.fileDocument, element.textOffset).firstOrNull()
+            ?: element
     }
 }

--- a/src/nl/hannahsten/texifyidea/editor/postfix/LatexPostfixExpressionSelector.kt
+++ b/src/nl/hannahsten/texifyidea/editor/postfix/LatexPostfixExpressionSelector.kt
@@ -6,7 +6,6 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.util.elementType
 import com.intellij.util.Function
 import nl.hannahsten.texifyidea.psi.*
-import nl.hannahsten.texifyidea.util.files.document
 import nl.hannahsten.texifyidea.util.parser.firstParentOfType
 import nl.hannahsten.texifyidea.util.parser.inMathContext
 

--- a/src/nl/hannahsten/texifyidea/editor/postfix/LatexStringBasedPostfixTemplates.kt
+++ b/src/nl/hannahsten/texifyidea/editor/postfix/LatexStringBasedPostfixTemplates.kt
@@ -83,4 +83,8 @@ internal abstract class ConstantStringBasedPostfixTemplate(
     override fun getTemplateString(element: PsiElement) = template
 
     override fun getElementToRemove(expr: PsiElement?) = expr
+
+    override fun isBuiltin(): Boolean {
+        return true
+    }
 }

--- a/src/nl/hannahsten/texifyidea/editor/postfix/editable/LatexEditablePostfixTemplate.kt
+++ b/src/nl/hannahsten/texifyidea/editor/postfix/editable/LatexEditablePostfixTemplate.kt
@@ -1,0 +1,31 @@
+package nl.hannahsten.texifyidea.editor.postfix.editable
+
+import com.intellij.codeInsight.template.impl.TemplateImpl
+import com.intellij.codeInsight.template.postfix.templates.editable.EditablePostfixTemplateWithMultipleExpressions
+import com.intellij.openapi.editor.Document
+import com.intellij.psi.PsiElement
+import nl.hannahsten.texifyidea.editor.postfix.LatexPostFixTemplateProvider
+
+class LatexEditablePostfixTemplate(templateId: String, templateName: String, template: TemplateImpl, private val condition: LatexPostfixTemplateExpressionCondition, provider: LatexPostFixTemplateProvider)
+    : EditablePostfixTemplateWithMultipleExpressions<LatexPostfixTemplateExpressionCondition>(templateId, templateName, template, "", setOf(condition), true, provider) {
+
+        constructor(templateId: String, templateName: String, templateText: String, condition: LatexPostfixTemplateExpressionCondition, provider: LatexPostFixTemplateProvider)
+            : this(templateId, templateName, createTemplateFromText(templateText), condition, provider)
+
+    override fun getExpressions(context: PsiElement, document: Document, offset: Int): MutableList<PsiElement> {
+        return condition.expressionSelector().getExpressions(context, document, offset)
+    }
+
+    override fun getTopmostExpression(element: PsiElement): PsiElement {
+        return condition.expressionSelector().getTopMostExpression(element)
+    }
+
+    companion object {
+        private fun createTemplateFromText(templateText: String): TemplateImpl {
+            return TemplateImpl("fakeKey", templateText, "").apply {
+                isToReformat = true
+                parseSegments()
+            }
+        }
+    }
+}

--- a/src/nl/hannahsten/texifyidea/editor/postfix/editable/LatexEditablePostfixTemplate.kt
+++ b/src/nl/hannahsten/texifyidea/editor/postfix/editable/LatexEditablePostfixTemplate.kt
@@ -5,19 +5,31 @@ import com.intellij.codeInsight.template.postfix.templates.editable.EditablePost
 import com.intellij.openapi.editor.Document
 import com.intellij.psi.PsiElement
 import nl.hannahsten.texifyidea.editor.postfix.LatexPostFixTemplateProvider
+import nl.hannahsten.texifyidea.editor.postfix.LatexPostfixExpressionSelector
 
-class LatexEditablePostfixTemplate(templateId: String, templateName: String, template: TemplateImpl, private val condition: LatexPostfixTemplateExpressionCondition, provider: LatexPostFixTemplateProvider)
-    : EditablePostfixTemplateWithMultipleExpressions<LatexPostfixTemplateExpressionCondition>(templateId, templateName, template, "", setOf(condition), true, provider) {
+class LatexEditablePostfixTemplate(templateId: String, templateName: String, template: TemplateImpl, conditions: Set<LatexPostfixTemplateExpressionCondition>, provider: LatexPostFixTemplateProvider)
+    : EditablePostfixTemplateWithMultipleExpressions<LatexPostfixTemplateExpressionCondition>(templateId, templateName, template, "", conditions, true, provider) {
 
-        constructor(templateId: String, templateName: String, templateText: String, condition: LatexPostfixTemplateExpressionCondition, provider: LatexPostFixTemplateProvider)
-            : this(templateId, templateName, createTemplateFromText(templateText), condition, provider)
+        constructor(templateId: String, templateName: String, templateText: String, conditions: Set<LatexPostfixTemplateExpressionCondition>, provider: LatexPostFixTemplateProvider)
+            : this(templateId, templateName, createTemplateFromText(templateText), conditions, provider)
 
     override fun getExpressions(context: PsiElement, document: Document, offset: Int): MutableList<PsiElement> {
-        return condition.expressionSelector().getExpressions(context, document, offset)
+        return if (myExpressionConditions.isEmpty()) {
+            LatexPostfixExpressionSelector().getExpressions(context, document, offset)
+        }
+        else myExpressionConditions.flatMap { condition ->
+            condition.expressionSelector().getExpressions(context, document, offset).filter { condition.value(it) }
+        }.toSet().toMutableList()
     }
 
     override fun getTopmostExpression(element: PsiElement): PsiElement {
-        return condition.expressionSelector().getTopMostExpression(element)
+        return getExpressions(element, element.containingFile.fileDocument, element.textOffset)
+            .minByOrNull { it.textOffset }!!
+
+    }
+
+    override fun isBuiltin(): Boolean {
+        return false
     }
 
     companion object {

--- a/src/nl/hannahsten/texifyidea/editor/postfix/editable/LatexEditablePostfixTemplate.kt
+++ b/src/nl/hannahsten/texifyidea/editor/postfix/editable/LatexEditablePostfixTemplate.kt
@@ -7,11 +7,11 @@ import com.intellij.psi.PsiElement
 import nl.hannahsten.texifyidea.editor.postfix.LatexPostFixTemplateProvider
 import nl.hannahsten.texifyidea.editor.postfix.LatexPostfixExpressionSelector
 
-class LatexEditablePostfixTemplate(templateId: String, templateName: String, template: TemplateImpl, conditions: Set<LatexPostfixTemplateExpressionCondition>, provider: LatexPostFixTemplateProvider)
-    : EditablePostfixTemplateWithMultipleExpressions<LatexPostfixTemplateExpressionCondition>(templateId, templateName, template, "", conditions, true, provider) {
+class LatexEditablePostfixTemplate(templateId: String, templateName: String, template: TemplateImpl, conditions: Set<LatexPostfixTemplateExpressionCondition>, provider: LatexPostFixTemplateProvider) :
+    EditablePostfixTemplateWithMultipleExpressions<LatexPostfixTemplateExpressionCondition>(templateId, templateName, template, "", conditions, true, provider) {
 
-        constructor(templateId: String, templateName: String, templateText: String, conditions: Set<LatexPostfixTemplateExpressionCondition>, provider: LatexPostFixTemplateProvider)
-            : this(templateId, templateName, createTemplateFromText(templateText), conditions, provider)
+    constructor(templateId: String, templateName: String, templateText: String, conditions: Set<LatexPostfixTemplateExpressionCondition>, provider: LatexPostFixTemplateProvider) :
+        this(templateId, templateName, createTemplateFromText(templateText), conditions, provider)
 
     override fun getExpressions(context: PsiElement, document: Document, offset: Int): MutableList<PsiElement> {
         return if (myExpressionConditions.isEmpty()) {
@@ -25,7 +25,6 @@ class LatexEditablePostfixTemplate(templateId: String, templateName: String, tem
     override fun getTopmostExpression(element: PsiElement): PsiElement {
         return getExpressions(element, element.containingFile.fileDocument, element.textOffset)
             .minByOrNull { it.textOffset }!!
-
     }
 
     override fun isBuiltin(): Boolean {

--- a/src/nl/hannahsten/texifyidea/editor/postfix/editable/LatexPostfixTemplateEditor.kt
+++ b/src/nl/hannahsten/texifyidea/editor/postfix/editable/LatexPostfixTemplateEditor.kt
@@ -4,6 +4,7 @@ import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
 import com.intellij.codeInsight.template.postfix.settings.PostfixTemplateEditorBase
 import com.intellij.codeInsight.template.postfix.templates.PostfixTemplate
 import com.intellij.grazie.utils.toSet
+import com.intellij.icons.AllIcons
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
@@ -18,6 +19,7 @@ import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.psi.LatexPsiHelper
 import nl.hannahsten.texifyidea.util.isLatexProject
 import javax.swing.JComponent
+import javax.swing.JLabel
 import javax.swing.JPanel
 
 class LatexPostfixTemplateEditor(private val templateProvider: LatexPostFixTemplateProvider) :
@@ -25,6 +27,7 @@ class LatexPostfixTemplateEditor(private val templateProvider: LatexPostFixTempl
 
     private val panel: JPanel = FormBuilder.createFormBuilder()
         .addComponentFillVertically(myEditTemplateAndConditionsPanel, UIUtil.DEFAULT_VGAP)
+        .addComponent(JLabel("Use the Custom Postfix Templates plugin to create more complex postfix templates.").apply { setIcon(AllIcons.General.Information) })
         .panel
 
     override fun createTemplate(templateId: String, templateName: String): PostfixTemplate {

--- a/src/nl/hannahsten/texifyidea/editor/postfix/editable/LatexPostfixTemplateEditor.kt
+++ b/src/nl/hannahsten/texifyidea/editor/postfix/editable/LatexPostfixTemplateEditor.kt
@@ -1,35 +1,34 @@
 package nl.hannahsten.texifyidea.editor.postfix.editable
 
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
-import com.intellij.codeInsight.template.impl.TemplateImpl
 import com.intellij.codeInsight.template.postfix.settings.PostfixTemplateEditorBase
 import com.intellij.codeInsight.template.postfix.templates.PostfixTemplate
+import com.intellij.grazie.utils.toSet
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.EditorFactory
-import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
-import com.intellij.openapi.ui.ComboBox
-import com.intellij.psi.JavaCodeFragmentFactory
 import com.intellij.psi.PsiDocumentManager
-import com.intellij.psi.PsiFile
 import com.intellij.util.ui.FormBuilder
+import com.intellij.util.ui.UIUtil
 import nl.hannahsten.texifyidea.editor.postfix.LatexPostFixTemplateProvider
+import nl.hannahsten.texifyidea.file.LatexFileType
+import nl.hannahsten.texifyidea.psi.LatexPsiHelper
+import nl.hannahsten.texifyidea.util.isLatexProject
 import javax.swing.JComponent
 import javax.swing.JPanel
 
-class LatexPostfixTemplateEditor(
-    private val templateProvider: LatexPostFixTemplateProvider,
-    private val panel: JPanel = FormBuilder.createFormBuilder()
-        .addLabeledComponent("Context", ComboBox(LatexPostfixTemplateExpressionCondition.values().toTypedArray()))
-        .panel
-)
+class LatexPostfixTemplateEditor(private val templateProvider: LatexPostFixTemplateProvider)
     : PostfixTemplateEditorBase<LatexPostfixTemplateExpressionCondition>(templateProvider, createEditor(), true) {
 
+    private val panel: JPanel = FormBuilder.createFormBuilder()
+        .addComponentFillVertically(myEditTemplateAndConditionsPanel, UIUtil.DEFAULT_VGAP)
+        .panel
+
     override fun createTemplate(templateId: String, templateName: String): PostfixTemplate {
-        return LatexEditablePostfixTemplate(templateId, templateName, myTemplateEditor.document.text, LatexPostfixTemplateDefaultExpressionCondition(), templateProvider)
+        return LatexEditablePostfixTemplate(templateId, templateName, myTemplateEditor.document.text, myExpressionTypesListModel.elements().toSet(), templateProvider)
     }
 
     override fun getComponent(): JComponent {
@@ -37,22 +36,21 @@ class LatexPostfixTemplateEditor(
     }
 
     override fun fillConditions(group: DefaultActionGroup) {
-        group.add(AddConditionAction(LatexPostfixTemplateDefaultExpressionCondition()))
         group.add(AddConditionAction(LatexPostfixTemplateMathOnlyExpressionCondition()))
         group.add(AddConditionAction(LatexPostfixTemplateTextOnlyExpressionCondition()))
     }
 
     companion object {
         private fun createEditor(): Editor {
-            return createEditor(null, createDocument(ProjectManager.getInstance().defaultProject))
+            val project = ProjectManager.getInstance().openProjects.firstOrNull { it.isLatexProject() } ?: ProjectManager.getInstance().defaultProject
+            return EditorFactory.getInstance().createEditor(createDocument(project), project, LatexFileType, false)
         }
 
         private fun createDocument(project: Project?): Document {
             if (project == null) {
                 return EditorFactory.getInstance().createDocument("")
             }
-            val factory = JavaCodeFragmentFactory.getInstance(project)
-            val fragment = factory.createCodeBlockCodeFragment("", null, true)
+            val fragment = LatexPsiHelper(project).createFromText("")
             DaemonCodeAnalyzer.getInstance(project).setHighlightingEnabled(fragment, false)
             return PsiDocumentManager.getInstance(project).getDocument(fragment)
                 ?: EditorFactory.getInstance().createDocument("")

--- a/src/nl/hannahsten/texifyidea/editor/postfix/editable/LatexPostfixTemplateEditor.kt
+++ b/src/nl/hannahsten/texifyidea/editor/postfix/editable/LatexPostfixTemplateEditor.kt
@@ -1,0 +1,61 @@
+package nl.hannahsten.texifyidea.editor.postfix.editable
+
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.codeInsight.template.impl.TemplateImpl
+import com.intellij.codeInsight.template.postfix.settings.PostfixTemplateEditorBase
+import com.intellij.codeInsight.template.postfix.templates.PostfixTemplate
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.ui.ComboBox
+import com.intellij.psi.JavaCodeFragmentFactory
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiFile
+import com.intellij.util.ui.FormBuilder
+import nl.hannahsten.texifyidea.editor.postfix.LatexPostFixTemplateProvider
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+class LatexPostfixTemplateEditor(
+    private val templateProvider: LatexPostFixTemplateProvider,
+    private val panel: JPanel = FormBuilder.createFormBuilder()
+        .addLabeledComponent("Context", ComboBox(LatexPostfixTemplateExpressionCondition.values().toTypedArray()))
+        .panel
+)
+    : PostfixTemplateEditorBase<LatexPostfixTemplateExpressionCondition>(templateProvider, createEditor(), true) {
+
+    override fun createTemplate(templateId: String, templateName: String): PostfixTemplate {
+        return LatexEditablePostfixTemplate(templateId, templateName, myTemplateEditor.document.text, LatexPostfixTemplateDefaultExpressionCondition(), templateProvider)
+    }
+
+    override fun getComponent(): JComponent {
+        return panel
+    }
+
+    override fun fillConditions(group: DefaultActionGroup) {
+        group.add(AddConditionAction(LatexPostfixTemplateDefaultExpressionCondition()))
+        group.add(AddConditionAction(LatexPostfixTemplateMathOnlyExpressionCondition()))
+        group.add(AddConditionAction(LatexPostfixTemplateTextOnlyExpressionCondition()))
+    }
+
+    companion object {
+        private fun createEditor(): Editor {
+            return createEditor(null, createDocument(ProjectManager.getInstance().defaultProject))
+        }
+
+        private fun createDocument(project: Project?): Document {
+            if (project == null) {
+                return EditorFactory.getInstance().createDocument("")
+            }
+            val factory = JavaCodeFragmentFactory.getInstance(project)
+            val fragment = factory.createCodeBlockCodeFragment("", null, true)
+            DaemonCodeAnalyzer.getInstance(project).setHighlightingEnabled(fragment, false)
+            return PsiDocumentManager.getInstance(project).getDocument(fragment)
+                ?: EditorFactory.getInstance().createDocument("")
+        }
+    }
+}

--- a/src/nl/hannahsten/texifyidea/editor/postfix/editable/LatexPostfixTemplateEditor.kt
+++ b/src/nl/hannahsten/texifyidea/editor/postfix/editable/LatexPostfixTemplateEditor.kt
@@ -27,7 +27,7 @@ class LatexPostfixTemplateEditor(private val templateProvider: LatexPostFixTempl
 
     private val panel: JPanel = FormBuilder.createFormBuilder()
         .addComponentFillVertically(myEditTemplateAndConditionsPanel, UIUtil.DEFAULT_VGAP)
-        .addComponent(JLabel("Use the Custom Postfix Templates plugin to create more complex postfix templates.").apply { setIcon(AllIcons.General.Information) })
+        .addComponent(JLabel("Use the Custom Postfix Templates plugin to create more complex postfix templates.").apply { icon = AllIcons.General.Information })
         .panel
 
     override fun createTemplate(templateId: String, templateName: String): PostfixTemplate {

--- a/src/nl/hannahsten/texifyidea/editor/postfix/editable/LatexPostfixTemplateEditor.kt
+++ b/src/nl/hannahsten/texifyidea/editor/postfix/editable/LatexPostfixTemplateEditor.kt
@@ -20,8 +20,8 @@ import nl.hannahsten.texifyidea.util.isLatexProject
 import javax.swing.JComponent
 import javax.swing.JPanel
 
-class LatexPostfixTemplateEditor(private val templateProvider: LatexPostFixTemplateProvider)
-    : PostfixTemplateEditorBase<LatexPostfixTemplateExpressionCondition>(templateProvider, createEditor(), true) {
+class LatexPostfixTemplateEditor(private val templateProvider: LatexPostFixTemplateProvider) :
+    PostfixTemplateEditorBase<LatexPostfixTemplateExpressionCondition>(templateProvider, createEditor(), true) {
 
     private val panel: JPanel = FormBuilder.createFormBuilder()
         .addComponentFillVertically(myEditTemplateAndConditionsPanel, UIUtil.DEFAULT_VGAP)

--- a/src/nl/hannahsten/texifyidea/editor/postfix/editable/LatexPostfixTemplateExpressionCondition.kt
+++ b/src/nl/hannahsten/texifyidea/editor/postfix/editable/LatexPostfixTemplateExpressionCondition.kt
@@ -1,20 +1,19 @@
 package nl.hannahsten.texifyidea.editor.postfix.editable
 
 import com.intellij.codeInsight.template.postfix.templates.editable.PostfixTemplateExpressionCondition
-import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiElement
 import nl.hannahsten.texifyidea.editor.postfix.LatexPostfixExpressionSelector
 import nl.hannahsten.texifyidea.util.parser.inMathContext
 import org.jdom.Element
 
-sealed class LatexPostfixTemplateExpressionCondition : PostfixTemplateExpressionCondition<PsiExpression> {
+sealed class LatexPostfixTemplateExpressionCondition : PostfixTemplateExpressionCondition<PsiElement> {
 
     abstract fun expressionSelector(): LatexPostfixExpressionSelector
 
     companion object {
-        fun values() = listOf(
-            LatexPostfixTemplateDefaultExpressionCondition(),
+        fun selectableValues() = setOf(
             LatexPostfixTemplateTextOnlyExpressionCondition(),
-            LatexPostfixTemplateTextOnlyExpressionCondition()
+            LatexPostfixTemplateMathOnlyExpressionCondition()
         )
 
         fun readExternal(condition: Element): LatexPostfixTemplateExpressionCondition {
@@ -22,23 +21,9 @@ sealed class LatexPostfixTemplateExpressionCondition : PostfixTemplateExpression
             return when (id) {
                 LatexPostfixTemplateMathOnlyExpressionCondition.ID -> LatexPostfixTemplateMathOnlyExpressionCondition()
                 LatexPostfixTemplateTextOnlyExpressionCondition.ID -> LatexPostfixTemplateTextOnlyExpressionCondition()
-                else -> LatexPostfixTemplateDefaultExpressionCondition()
+                else -> throw IllegalStateException("Invalid condition $condition")
             }
         }
-    }
-}
-
-class LatexPostfixTemplateDefaultExpressionCondition : LatexPostfixTemplateExpressionCondition() {
-    override fun expressionSelector(): LatexPostfixExpressionSelector = LatexPostfixExpressionSelector()
-
-    override fun value(t: PsiExpression): Boolean = true
-
-    override fun getPresentableName(): String = ID
-
-    override fun getId(): String = ID
-
-    companion object {
-        const val ID = "default"
     }
 }
 
@@ -46,7 +31,7 @@ class LatexPostfixTemplateMathOnlyExpressionCondition : LatexPostfixTemplateExpr
 
     override fun expressionSelector(): LatexPostfixExpressionSelector = LatexPostfixExpressionSelector(mathOnly = true, textOnly = false)
 
-    override fun value(t: PsiExpression): Boolean = t.inMathContext()
+    override fun value(t: PsiElement): Boolean = t.inMathContext()
 
     override fun getPresentableName(): String = ID
 
@@ -61,7 +46,7 @@ class LatexPostfixTemplateTextOnlyExpressionCondition : LatexPostfixTemplateExpr
 
     override fun expressionSelector(): LatexPostfixExpressionSelector = LatexPostfixExpressionSelector(mathOnly = false, textOnly = true)
 
-    override fun value(t: PsiExpression): Boolean = !t.inMathContext()
+    override fun value(t: PsiElement): Boolean = !t.inMathContext()
 
     override fun getPresentableName(): String = ID
 

--- a/src/nl/hannahsten/texifyidea/editor/postfix/editable/LatexPostfixTemplateExpressionCondition.kt
+++ b/src/nl/hannahsten/texifyidea/editor/postfix/editable/LatexPostfixTemplateExpressionCondition.kt
@@ -1,0 +1,73 @@
+package nl.hannahsten.texifyidea.editor.postfix.editable
+
+import com.intellij.codeInsight.template.postfix.templates.editable.PostfixTemplateExpressionCondition
+import com.intellij.psi.PsiExpression
+import nl.hannahsten.texifyidea.editor.postfix.LatexPostfixExpressionSelector
+import nl.hannahsten.texifyidea.util.parser.inMathContext
+import org.jdom.Element
+
+sealed class LatexPostfixTemplateExpressionCondition : PostfixTemplateExpressionCondition<PsiExpression> {
+
+    abstract fun expressionSelector(): LatexPostfixExpressionSelector
+
+    companion object {
+        fun values() = listOf(
+            LatexPostfixTemplateDefaultExpressionCondition(),
+            LatexPostfixTemplateTextOnlyExpressionCondition(),
+            LatexPostfixTemplateTextOnlyExpressionCondition()
+        )
+
+        fun readExternal(condition: Element): LatexPostfixTemplateExpressionCondition {
+            val id = condition.getAttributeValue(PostfixTemplateExpressionCondition.ID_ATTR)
+            return when (id) {
+                LatexPostfixTemplateMathOnlyExpressionCondition.ID -> LatexPostfixTemplateMathOnlyExpressionCondition()
+                LatexPostfixTemplateTextOnlyExpressionCondition.ID -> LatexPostfixTemplateTextOnlyExpressionCondition()
+                else -> LatexPostfixTemplateDefaultExpressionCondition()
+            }
+        }
+    }
+}
+
+class LatexPostfixTemplateDefaultExpressionCondition : LatexPostfixTemplateExpressionCondition() {
+    override fun expressionSelector(): LatexPostfixExpressionSelector = LatexPostfixExpressionSelector()
+
+    override fun value(t: PsiExpression): Boolean = true
+
+    override fun getPresentableName(): String = ID
+
+    override fun getId(): String = ID
+
+    companion object {
+        const val ID = "default"
+    }
+}
+
+class LatexPostfixTemplateMathOnlyExpressionCondition : LatexPostfixTemplateExpressionCondition() {
+
+    override fun expressionSelector(): LatexPostfixExpressionSelector = LatexPostfixExpressionSelector(mathOnly = true, textOnly = false)
+
+    override fun value(t: PsiExpression): Boolean = t.inMathContext()
+
+    override fun getPresentableName(): String = ID
+
+    override fun getId(): String = ID
+
+    companion object {
+        const val ID = "math only"
+    }
+}
+
+class LatexPostfixTemplateTextOnlyExpressionCondition : LatexPostfixTemplateExpressionCondition() {
+
+    override fun expressionSelector(): LatexPostfixExpressionSelector = LatexPostfixExpressionSelector(mathOnly = false, textOnly = true)
+
+    override fun value(t: PsiExpression): Boolean = !t.inMathContext()
+
+    override fun getPresentableName(): String = ID
+
+    override fun getId(): String = ID
+
+    companion object {
+        const val ID = "text only"
+    }
+}

--- a/src/nl/hannahsten/texifyidea/file/LatexFileType.kt
+++ b/src/nl/hannahsten/texifyidea/file/LatexFileType.kt
@@ -7,7 +7,7 @@ import nl.hannahsten.texifyidea.TexifyIcons
 /**
  * @author Sten Wessel
  */
-object LatexFileType : LanguageFileType(LatexLanguage) {
+object  LatexFileType : LanguageFileType(LatexLanguage) {
 
     override fun getName() = "LaTeX source file"
 

--- a/src/nl/hannahsten/texifyidea/file/LatexFileType.kt
+++ b/src/nl/hannahsten/texifyidea/file/LatexFileType.kt
@@ -7,7 +7,7 @@ import nl.hannahsten.texifyidea.TexifyIcons
 /**
  * @author Sten Wessel
  */
-object  LatexFileType : LanguageFileType(LatexLanguage) {
+object LatexFileType : LanguageFileType(LatexLanguage) {
 
     override fun getName() = "LaTeX source file"
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3466 

#### Summary of additions and changes

* Added simple editor so users can create their own very simple postfix templates. For now users are directed to the [Custom Postfix Templates](https://plugins.jetbrains.com/plugin/9862-custom-postfix-templates) plugin to create more complex postfix templates.

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary