### PR TITLE
[Lexer] Add support for `\ProvidesExpl(Class|File)`

### DIFF
--- a/src/nl/hannahsten/texifyidea/grammar/LatexLexer.flex
+++ b/src/nl/hannahsten/texifyidea/grammar/LatexLexer.flex
@@ -80,7 +80,7 @@ END_TOKEN="\\end"
 COMMAND_IFNEXTCHAR=\\@ifnextchar.
 COMMAND_TOKEN=\\([a-zA-Z@]+|.|\r)
 COMMAND_TOKEN_LATEX3=\\([a-zA-Z@_:0-9]+|.|\r) // _ and : are only LaTeX3 syntax
-LATEX3_ON=\\(ExplSyntaxOn|ProvidesExplPackage)
+LATEX3_ON=\\(ExplSyntaxOn|ProvidesExplPackage|ProvidesExplClass|ProvidesExplFile)
 LATEX3_OFF=\\ExplSyntaxOff
 NEWENVIRONMENT=\\(re)?newenvironment
 // BeforeBegin/AfterEnd are from etoolbox, and just happen to also have two parameters where the second can contain loose \begin or \end


### PR DESCRIPTION
#### Summary of additions and changes

In addition to `\ProvidesExplPackage`, LaTeX3 also introduces `\ProvidesExplClass`
and `\ProvidesExplFile`, which also have the effect of enabling LaTeX3 syntax. This
pr adds support for the latter two.

See the [LaTeX 3 interfaces manual](https://texdoc.org/serve/interface3/0), § 2.1 ‘Using the LaTeX3 modules’.

#### How to test this pull request

```latex
\NeedsTeXFormat{LaTeX2e}
\ProvidesExplClass{myclass}{2024/06/08}{v1.0}{A class implemented in LaTeX3}
\cs_new:Npn \__my_internal_class_command:n #1 { Hello, ~ #1 ! }
```

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary

(Ticked the second box on the grounds that there were no tests for `\ProvidesExplPackage` either...)