### PR TITLE
Support conversion of arguments in \def -> \newcommand quickfix

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/codematurity/LatexDiscouragedUseOfDefInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codematurity/LatexDiscouragedUseOfDefInspection.kt
@@ -77,7 +77,7 @@ open class LatexDiscouragedUseOfDefInspection : TexifyInspectionBase() {
             val startOFfset = command.textOffset
             val endOffset = max(cmd.textOffset + cmd.textLength, value.textOffset + value.textLength)
 
-            val numberArgumentsText = nArgs?.let { "[${nArgs}]" } ?: ""
+            val numberArgumentsText = nArgs?.let { "[$nArgs]" } ?: ""
             val valueText = if (value.text.startsWith("{") && value.text.endsWith("}")) value.text.drop(1).dropLast(1) else value.text
 
             document.replaceString(startOFfset, endOffset, "$commandName{${cmd.text}}$numberArgumentsText{$valueText}")

--- a/src/nl/hannahsten/texifyidea/inspections/latex/codematurity/LatexDiscouragedUseOfDefInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codematurity/LatexDiscouragedUseOfDefInspection.kt
@@ -72,17 +72,18 @@ open class LatexDiscouragedUseOfDefInspection : TexifyInspectionBase() {
             val command = descriptor.psiElement as LatexCommands
             val file = command.containingFile
             val document = file.document() ?: return
-            val (cmd, value) = getArguments(command) ?: return
+            val (cmd, nArgs, value) = getArguments(command) ?: return
 
             val startOFfset = command.textOffset
             val endOffset = max(cmd.textOffset + cmd.textLength, value.textOffset + value.textLength)
 
+            val numberArgumentsText = nArgs?.let { "[${nArgs}]" } ?: ""
             val valueText = if (value.text.startsWith("{") && value.text.endsWith("}")) value.text.drop(1).dropLast(1) else value.text
 
-            document.replaceString(startOFfset, endOffset, "$commandName{${cmd.text}}{$valueText}")
+            document.replaceString(startOFfset, endOffset, "$commandName{${cmd.text}}$numberArgumentsText{$valueText}")
         }
 
-        open fun getArguments(command: LatexCommands): Pair<PsiElement, PsiElement>? {
+        open fun getArguments(command: LatexCommands): Triple<PsiElement, Int?, PsiElement>? {
             val parent = command.parent
             val definedCommand = parent.nextSiblingIgnoreWhitespace()?.firstChildOfType(LatexCommands::class) ?: return null
             // Either the definition is wrapped in braces, in which case it will be parsed as a parameter of the command being defined, or it is a sibling of the command
@@ -90,7 +91,13 @@ open class LatexDiscouragedUseOfDefInspection : TexifyInspectionBase() {
                 ?: definedCommand.nextSiblingIgnoreWhitespace()
                 ?: definedCommand.parent.nextSiblingIgnoreWhitespace()
                 ?: return null
-            return Pair(definedCommand.commandToken, value)
+            if (value.text.matches(Regex("""(#\d)+#?"""))) {
+                val numberOfArguments = Regex("""#\d""").findAll(value.text).count()
+                val bracedValue = value.nextSiblingIgnoreWhitespace() ?: return null
+                return Triple(definedCommand.commandToken, numberOfArguments, bracedValue)
+            } else {
+                return Triple(definedCommand.commandToken, null, value)
+            }
         }
     }
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/codematurity/LatexDiscouragedUseOfDefInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/codematurity/LatexDiscouragedUseOfDefInspectionTest.kt
@@ -28,6 +28,30 @@ class LatexDiscouragedUseOfDefInspectionTest : TexifyInspectionTestBase(LatexDis
         quickFixName = "Convert to \\newcommand"
     )
 
+    fun `test quick fix def with argument`() = testNamedQuickFix(
+        before = """\def\testa#1{#1}""",
+        after = """\newcommand{\testa}[1]{#1}""",
+        numberOfFixes = 2,
+        quickFixName = "Convert to \\newcommand"
+    )
+
+    fun `test quick fix def with multiple arguments`() = testNamedQuickFix(
+        before = """\def\testa#1#2#3#4{#3#4}""",
+        after = """\newcommand{\testa}[4]{#3#4}""",
+        numberOfFixes = 2,
+        quickFixName = "Convert to \\newcommand"
+    )
+
+    /**
+     * \newcommand doesn't actually support this, but the inspection is triggered and this seems like the most sensible thing to do.
+     */
+    fun `test quick fix def with argument until next brace`() = testNamedQuickFix(
+        before = """\def\testa#1#{#1}""",
+        after = """\newcommand{\testa}[1]{#1}""",
+        numberOfFixes = 2,
+        quickFixName = "Convert to \\newcommand"
+    )
+
     fun `test quick fix def to renewcommand`() = testNamedQuickFix(
         before = """\def\a1""",
         after = """\renewcommand{\a}{1}""",


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3576

#### Summary of additions and changes

* Support `#1` syntax in inspection that converts `\def` to `\newcommand`.

#### How to test this pull request

See tests.

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary