### PR TITLE
Fix EvinceListener not starting and refactor DBus support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,7 @@ dependencies {
 
     // D-Bus Java bindings
     implementation("com.github.hypfvieh:dbus-java-core:5.0.0")
+    implementation("com.github.hypfvieh:dbus-java-transport-native-unixsocket:5.0.0")
     implementation("org.slf4j:slf4j-simple:2.0.13")
 
     // Unzipping tar.xz/tar.bz2 files on Windows containing dtx files

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,7 +92,7 @@ dependencies {
 //    implementation(files("lib/JavaDDEx64.dll"))
 
     // D-Bus Java bindings
-    implementation("com.github.hypfvieh:dbus-java:3.3.2")
+    implementation("com.github.hypfvieh:dbus-java-core:5.0.0")
     implementation("org.slf4j:slf4j-simple:2.0.13")
 
     // Unzipping tar.xz/tar.bz2 files on Windows containing dtx files

--- a/src/nl/hannahsten/texifyidea/action/ForwardSearchAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/ForwardSearchAction.kt
@@ -31,9 +31,10 @@ open class ForwardSearchAction(var viewer: PdfViewer? = null) : EditorAction(
     }
 
     override fun update(e: AnActionEvent) {
-        e.presentation.isEnabledAndVisible = (e.project?.selectedRunConfig()?.pdfViewer == viewer
-                || (e.project?.selectedRunConfig() == null && e.project?.latexTemplateRunConfig()?.pdfViewer == viewer ))
-            && e.getData(CommonDataKeys.VIRTUAL_FILE)?.fileType is LatexFileType
+        e.presentation.isEnabledAndVisible = (
+            e.project?.selectedRunConfig()?.pdfViewer == viewer
+                || (e.project?.selectedRunConfig() == null && e.project?.latexTemplateRunConfig()?.pdfViewer == viewer)
+            ) && e.getData(CommonDataKeys.VIRTUAL_FILE)?.fileType is LatexFileType
     }
 
     override fun getActionUpdateThread() = ActionUpdateThread.BGT

--- a/src/nl/hannahsten/texifyidea/action/ForwardSearchAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/ForwardSearchAction.kt
@@ -10,6 +10,7 @@ import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.run.linuxpdfviewer.InternalPdfViewer
 import nl.hannahsten.texifyidea.run.pdfviewer.ExternalPdfViewer
 import nl.hannahsten.texifyidea.run.pdfviewer.PdfViewer
+import nl.hannahsten.texifyidea.util.latexTemplateRunConfig
 import nl.hannahsten.texifyidea.util.selectedRunConfig
 
 open class ForwardSearchAction(var viewer: PdfViewer? = null) : EditorAction(
@@ -30,7 +31,8 @@ open class ForwardSearchAction(var viewer: PdfViewer? = null) : EditorAction(
     }
 
     override fun update(e: AnActionEvent) {
-        e.presentation.isEnabledAndVisible = e.project?.selectedRunConfig()?.pdfViewer == viewer
+        e.presentation.isEnabledAndVisible = (e.project?.selectedRunConfig()?.pdfViewer == viewer
+                || (e.project?.selectedRunConfig() == null && e.project?.latexTemplateRunConfig()?.pdfViewer == viewer ))
             && e.getData(CommonDataKeys.VIRTUAL_FILE)?.fileType is LatexFileType
     }
 

--- a/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/evince/EvinceConversation.kt
+++ b/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/evince/EvinceConversation.kt
@@ -5,11 +5,14 @@ import com.intellij.notification.NotificationType
 import com.intellij.openapi.project.Project
 import nl.hannahsten.texifyidea.TeXception
 import nl.hannahsten.texifyidea.run.linuxpdfviewer.ViewerConversation
-import nl.hannahsten.texifyidea.util.runCommand
-import org.freedesktop.dbus.connections.impl.DBusConnection
+import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder
 import org.freedesktop.dbus.errors.NoReply
 import org.freedesktop.dbus.errors.ServiceUnknown
+import org.freedesktop.dbus.exceptions.DBusException
+import org.freedesktop.dbus.types.UInt32
 import org.gnome.evince.Daemon
+import org.gnome.evince.SyncViewSourcePointStruct
+import org.gnome.evince.Window
 
 /**
  * Send commands to Evince.
@@ -30,6 +33,13 @@ object EvinceConversation : ViewerConversation() {
      * Object name of the Evince daemon.
      */
     private const val EVINCE_DAEMON_NAME = "org.gnome.evince.Daemon"
+
+    /**
+     * Object path of the Evince daemon. Together with the object name, this allows us to find the
+     * D-Bus object which allows us to execute the FindDocument function, which is exported on the D-Bus
+     * by Evince.
+     */
+    private const val EVINCE_WINDOW_PATH = "/org/gnome/evince/Window/0"
 
     /**
      * This variable will hold the latest known Evince process owner. We need to know the owner of the pdf file in order to execute forward search.
@@ -63,10 +73,25 @@ object EvinceConversation : ViewerConversation() {
         }
 
         if (processOwner != null) {
-            // Theoretically we should use the Java D-Bus bindings as well to call SyncView, but that did
-            // not succeed with a NoReply exception, so we will execute a command via the shell
-            val command = "gdbus call --session --dest $processOwner --object-path /org/gnome/evince/Window/0 --method org.gnome.evince.Window.SyncView $sourceFilePath '($line, 1)' 0"
-            runCommand("bash", "-c", command)
+            try {
+                // Get DBusConnection
+                DBusConnectionBuilder.forSessionBus().build().use { connection ->
+                    // Get the Object corresponding to the interface and call the functions to the processOwner
+                    val window = connection.getRemoteObject(processOwner, EVINCE_WINDOW_PATH, Window::class.java)
+
+                    // Sync the Evince view to the current position
+                    try {
+                        window.SyncView(sourceFilePath, SyncViewSourcePointStruct(line, -1), UInt32(0))
+                    }
+                    catch (ignored: NoReply) {}
+                    catch (e: ServiceUnknown) {
+                        Notification("LaTeX", "Cannot sync position to Evince", "Please update Evince and then try again.", NotificationType.ERROR).notify(project)
+                    }
+                }
+            }
+            catch (e: DBusException) {
+                Notification("LaTeX", "Cannot sync position to Evince", "The Connection could not be established.", NotificationType.ERROR).notify(project)
+            }
         }
         else {
             // If the user used the forward search menu action
@@ -87,20 +112,25 @@ object EvinceConversation : ViewerConversation() {
      * @param pdfFilePath Full path to the pdf file to find the owner of.
      */
     private fun findProcessOwner(pdfFilePath: String, project: Project) {
-        // Initialize a session bus
-        val connection = DBusConnection.getConnection(DBusConnection.DBusBusType.SESSION)
-
-        // Get the Daemon object using its bus name and object path
-        val daemon = connection.getRemoteObject(EVINCE_DAEMON_NAME, EVINCE_DAEMON_PATH, Daemon::class.java)
-
-        // Call the method on the D-Bus by using the function we defined in the Daemon interface
-        // Catch a NoReply, because it is unknown why Evince cannot start so we don't try to fix that
         try {
-            processOwner = daemon.FindDocument("file://$pdfFilePath", true)
+            // Get DBusConnection
+            DBusConnectionBuilder.forSessionBus().build().use { connection ->
+                // Get the Daemon object using its bus name and object path
+                val daemon = connection.getRemoteObject(EVINCE_DAEMON_NAME, EVINCE_DAEMON_PATH, Daemon::class.java)
+
+                // Call the method on the D-Bus by using the function we defined in the Daemon interface
+                // Catch a NoReply, because it is unknown why Evince cannot start so we don't try to fix that
+                try {
+                    processOwner = daemon.FindDocument("file://$pdfFilePath", true)
+                }
+                catch (ignored: NoReply) {}
+                catch (e: ServiceUnknown) {
+                    Notification("LaTeX", "Cannot communicate to Evince", "Please update Evince and then try again.", NotificationType.ERROR).notify(project)
+                }
+            }
         }
-        catch (ignored: NoReply) {}
-        catch (e: ServiceUnknown) {
-            Notification("LaTeX", "Cannot communicate to Evince", "Please update Evince and then try again.", NotificationType.ERROR).notify(project)
+        catch (e: DBusException) {
+            Notification("LaTeX", "Cannot communicate to Evince", "The connection could not be established.", NotificationType.ERROR).notify(project)
         }
     }
 }

--- a/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/evince/EvinceInverseSearchListener.kt
+++ b/src/nl/hannahsten/texifyidea/run/linuxpdfviewer/evince/EvinceInverseSearchListener.kt
@@ -7,9 +7,10 @@ import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.project.Project
 import kotlinx.coroutines.*
 import nl.hannahsten.texifyidea.util.SystemEnvironment
-import java.io.BufferedReader
+import org.freedesktop.dbus.connections.impl.DBusConnection
+import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder
+import org.gnome.evince.Window
 import java.io.IOException
-import java.io.InputStreamReader
 
 /**
  * Listen on the D-Bus for inverse search signals coming from Evince.
@@ -22,6 +23,10 @@ object EvinceInverseSearchListener {
 
     private var currentCoroutineScope = CoroutineScope(Dispatchers.Default)
 
+    private val sessionConnection: DBusConnection = DBusConnectionBuilder.forSessionBus().build()
+
+    private var syncSourceHandler: AutoCloseable? = null
+
     /**
      * Starts a listener which listens for inverse search actions from Evince.
      */
@@ -30,6 +35,11 @@ object EvinceInverseSearchListener {
         // The exact version required is not know, but 3.28 works and 3.0.2 does not (#2087), even though dbus is supported since 2.32
         if (SystemEnvironment.evinceVersion.majorVersion <= 3 && SystemEnvironment.evinceVersion.minorVersion <= 28) {
             Notification("LaTeX", "Old Evince version found", "Please update Evince to at least version 3.28 to use forward/backward search", NotificationType.ERROR).notify(project)
+            return
+        }
+
+        // Check if we already have a listener
+        if (syncSourceHandler != null) {
             return
         }
 
@@ -44,44 +54,9 @@ object EvinceInverseSearchListener {
      * Start listening for backward search calls on the D-Bus.
      */
     private fun startListening() {
-        try {
-            // Listen on the session D-Bus to catch SyncSource signals emitted by Evince
-            val commands = arrayOf("dbus-monitor", "--session")
-            val process = Runtime.getRuntime().exec(commands)
-            val bufferedReader = BufferedReader(InputStreamReader(process.inputStream))
-            var line: String? = bufferedReader.readLine()
-
-            while (line != null && currentCoroutineScope.isActive) {
-                // Check if a SyncSource signal appeared from Evince and if so, read the contents
-                if (line.contains("interface=org.gnome.evince.Window; member=SyncSource")) {
-                    // Get the value between quotes
-                    val filenameLine = bufferedReader.readLine()
-                    var filename = filenameLine.substring(filenameLine.indexOf("\"") + 1, filenameLine.lastIndexOf("\""))
-                    filename = filename.replaceFirst("file://".toRegex(), "")
-
-                    // Pass over the "struct {" line
-                    bufferedReader.readLine()
-
-                    // Get the location represented by the struct
-                    val lineNumberLine = bufferedReader.readLine()
-                    val lineNumberString = lineNumberLine.substring(lineNumberLine.indexOf("int32") + 6, lineNumberLine.length).trim()
-                    val lineNumber = Integer.parseInt(lineNumberString)
-
-                    // Sync the IDE
-                    syncSource(filename, lineNumber)
-                }
-
-                // Check whether we would block before doing a blocking readLine call
-                // This is to ensure we can quickly stop this coroutine on plugin unload
-                while (!bufferedReader.ready()) {
-                    Thread.sleep(100)
-                    if (!currentCoroutineScope.isActive) return
-                }
-                line = bufferedReader.readLine()
-            }
-        }
-        catch (e: IOException) {
-            e.printStackTrace()
+        syncSourceHandler = sessionConnection.addSigHandler(Window.SyncSource::class.java) { signal ->
+            val filename = signal.sourceFile.replaceFirst("file://".toRegex(), "")
+            syncSource(filename, signal.sourcePoint.line)
         }
     }
 
@@ -95,7 +70,7 @@ object EvinceInverseSearchListener {
         val path = PathManager.getBinPath()
         val name = ApplicationNamesInfo.getInstance().scriptName
 
-        val command = "$path/$name.sh --line $lineNumber \"$filePath\""
+        val command = arrayOf("$path/$name.sh", "--line", lineNumber.toString(), "\"$filePath\"")
 
         try {
             Runtime.getRuntime().exec(command)
@@ -106,6 +81,10 @@ object EvinceInverseSearchListener {
     }
 
     fun unload() {
+        // Remove the listener
+        syncSourceHandler?.close()
+        // Properly close the connection
+        sessionConnection.close()
         currentCoroutineScope.cancel(CancellationException(("Unloading the plugin")))
     }
 }

--- a/src/nl/hannahsten/texifyidea/startup/StartEvinceInverseSearchListener.kt
+++ b/src/nl/hannahsten/texifyidea/startup/StartEvinceInverseSearchListener.kt
@@ -15,7 +15,7 @@ class StartEvinceInverseSearchListener : ProjectActivity, DumbAware {
 
     override suspend fun execute(project: Project) {
         if (project.selectedRunConfig()?.pdfViewer == InternalPdfViewer.EVINCE ||
-            project.latexTemplateRunConfig()?.pdfViewer == InternalPdfViewer.EVINCE
+            (project.selectedRunConfig() == null && project.latexTemplateRunConfig()?.pdfViewer == InternalPdfViewer.EVINCE)
         ) {
             EvinceInverseSearchListener.start(project)
         }

--- a/src/nl/hannahsten/texifyidea/startup/StartEvinceInverseSearchListener.kt
+++ b/src/nl/hannahsten/texifyidea/startup/StartEvinceInverseSearchListener.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 import nl.hannahsten.texifyidea.run.linuxpdfviewer.InternalPdfViewer
 import nl.hannahsten.texifyidea.run.linuxpdfviewer.evince.EvinceInverseSearchListener
+import nl.hannahsten.texifyidea.util.latexTemplateRunConfig
 import nl.hannahsten.texifyidea.util.selectedRunConfig
 
 /**
@@ -13,7 +14,9 @@ import nl.hannahsten.texifyidea.util.selectedRunConfig
 class StartEvinceInverseSearchListener : ProjectActivity, DumbAware {
 
     override suspend fun execute(project: Project) {
-        if (project.selectedRunConfig()?.pdfViewer == InternalPdfViewer.EVINCE) {
+        if (project.selectedRunConfig()?.pdfViewer == InternalPdfViewer.EVINCE ||
+            project.latexTemplateRunConfig()?.pdfViewer == InternalPdfViewer.EVINCE
+        ) {
             EvinceInverseSearchListener.start(project)
         }
     }

--- a/src/nl/hannahsten/texifyidea/util/Projects.kt
+++ b/src/nl/hannahsten/texifyidea/util/Projects.kt
@@ -19,7 +19,9 @@ import nl.hannahsten.texifyidea.index.LatexCommandsIndex
 import nl.hannahsten.texifyidea.index.LatexDefinitionIndex
 import nl.hannahsten.texifyidea.modules.LatexModuleType
 import nl.hannahsten.texifyidea.psi.LatexCommands
+import nl.hannahsten.texifyidea.run.latex.LatexConfigurationFactory
 import nl.hannahsten.texifyidea.run.latex.LatexRunConfiguration
+import nl.hannahsten.texifyidea.run.latex.LatexRunConfigurationType
 import nl.hannahsten.texifyidea.util.files.allChildFiles
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 
@@ -88,6 +90,13 @@ fun Project.getLatexRunConfigurations(): Collection<LatexRunConfiguration> {
  */
 fun Project?.selectedRunConfig(): LatexRunConfiguration? = this?.let {
     RunManager.getInstance(it).selectedConfiguration?.configuration as? LatexRunConfiguration
+}
+
+/**
+ * Get the run configuration of the template.
+ */
+fun Project?.latexTemplateRunConfig(): LatexRunConfiguration? = this?.let {
+    RunManager.getInstance(it).getConfigurationTemplate(LatexConfigurationFactory(LatexRunConfigurationType())).configuration as? LatexRunConfiguration
 }
 
 /**

--- a/src/org/gnome/evince/Daemon.kt
+++ b/src/org/gnome/evince/Daemon.kt
@@ -18,5 +18,5 @@ interface Daemon : DBusInterface {
      * @param spawn Whether to spawn Evince or not.
      * @return The name owner of the evince process for the given document URI.
      */
-    fun FindDocument(uri: String, spawn: Boolean?): String
+    fun FindDocument(uri: String?, spawn: Boolean): String?
 }

--- a/src/org/gnome/evince/SyncViewSourcePointStruct.kt
+++ b/src/org/gnome/evince/SyncViewSourcePointStruct.kt
@@ -1,0 +1,14 @@
+package org.gnome.evince
+
+import org.freedesktop.dbus.Struct
+import org.freedesktop.dbus.annotations.Position
+
+/**
+ * Nested Object in DBus communication with evince, this specifies the position in the document
+ *
+ * @author Tim Klocke
+ */
+class SyncViewSourcePointStruct(
+    @field:Position(0) val line: Int,
+    @field:Position(1) val column: Int
+) : Struct()

--- a/src/org/gnome/evince/Window.kt
+++ b/src/org/gnome/evince/Window.kt
@@ -1,0 +1,42 @@
+package org.gnome.evince
+
+import org.freedesktop.dbus.annotations.DBusInterfaceName
+import org.freedesktop.dbus.interfaces.DBusInterface
+import org.freedesktop.dbus.messages.DBusSignal
+import org.freedesktop.dbus.types.UInt32
+
+/**
+ * Interface to communicate with an Evince Window over DBus, such as syncing in both directions
+ *
+ * @author Tim Klocke
+ */
+@Suppress("FunctionName")
+@DBusInterfaceName("org.gnome.evince.Window")
+interface Window : DBusInterface {
+
+    /**
+     * Sync the position of Evince to the corresponding position.
+     *
+     * @param sourceFile Path to the tex file, prepended with file://
+     * @param sourcePoint Position in the document to jump to.
+     * @param timestamp Timestamp
+     * @return
+     */
+    fun SyncView(sourceFile: String?, sourcePoint: SyncViewSourcePointStruct?, timestamp: UInt32?)
+
+    /**
+     * Signal to sync the position of the editor to the specified position.
+     *
+     * @param path Path to the DBusObject
+     * @param sourceFile Path to the tex file, prepended with file://
+     * @param sourcePoint Position in the document to jump to.
+     * @param timestamp Timestamp
+     * @return
+     */
+    class SyncSource(
+        path: String?,
+        val sourceFile: String,
+        val sourcePoint: SyncViewSourcePointStruct,
+        timestamp: UInt32
+    ) : DBusSignal(path, sourceFile, sourcePoint, timestamp)
+}


### PR DESCRIPTION
Fix https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/3590 and refactor the DBus support to use `dbus-java` for all interactions with Evince instead of spawning command line processes. I hope you agree with the changes I made here and thank you for maintaining this plugin!

#### Summary of additions and changes
* Start EvinceInverseSearchListener even if no runConfiguration exists, but the default template has Evince as PDF viewer
* Use `dbus-java` for sending the `SyncView` DBus message and for connection to the `SyncSource` DBus signal

#### How to test this pull request
1. Open a latex file and set Evince as PDF viewer for the template, the choose current file and run the configuration
2. Open a latex file and set Evince as PDF viewer for the current runConfiguration
-> In both cases Forward and Backward search should work out of box.

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary