### PR TITLE
Fix crash in structure view if section command has no parameters, fix #3626

### DIFF
--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexSectionPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexSectionPresentation.kt
@@ -17,7 +17,7 @@ class LatexSectionPresentation(sectionCommand: LatexCommands) : EditableHintPres
             throw IllegalArgumentException("command is no \\section-command")
         }
 
-        this.sectionName = sectionCommand.getRequiredParameters()[0]
+        this.sectionName = sectionCommand.getRequiredParameters().firstOrNull() ?: "Unnamed section"
     }
 
     override fun getPresentableText() = sectionName


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3626


To reproduce: hover over a \section command without a parameter