### PR TITLE
Insert `\right)` when typing `\left(` without using autocomplete

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
   merge_group:
 # Cancel builds if a new commit is pushed, except on master
 concurrency:

--- a/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandlerTest.kt
+++ b/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandlerTest.kt
@@ -83,4 +83,22 @@ class LatexTypedHandlerTest : BasePlatformTestCase() {
         myFixture.type("\\{")
         myFixture.checkResult("""Hello World \{<caret>\}""")
     }
+
+    fun testCorrectPairedParenthesis() {
+        myFixture.configureByText(LatexFileType, """$\left<caret>$""")
+        myFixture.type('(')
+        myFixture.checkResult("""$\left(<caret>\right)$""")
+    }
+
+    fun testCorrectPairedBraces() {
+        myFixture.configureByText(LatexFileType, """$\left<caret>$""")
+        myFixture.type('{')
+        myFixture.checkResult("""$\left{<caret>\right}$""")
+    }
+
+    fun testCorrectPairedBrackets() {
+        myFixture.configureByText(LatexFileType, """$\left<caret>$""")
+        myFixture.type('[')
+        myFixture.checkResult("""$\left[<caret>\right]$""")
+    }
 }

--- a/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandlerTest.kt
+++ b/test/nl/hannahsten/texifyidea/editor/typedhandlers/LatexTypedHandlerTest.kt
@@ -90,6 +90,18 @@ class LatexTypedHandlerTest : BasePlatformTestCase() {
         myFixture.checkResult("""$\left(<caret>\right)$""")
     }
 
+    fun testCorrectPairedExistingParenthesis() {
+        myFixture.configureByText(LatexFileType, """$\left<caret>)$""")
+        myFixture.type('(')
+        myFixture.checkResult("""$\left(<caret>\right)$""")
+    }
+
+    fun testCorrectPairedExistingRightParenthesis() {
+        myFixture.configureByText(LatexFileType, """$\left<caret>\right)$""")
+        myFixture.type('(')
+        myFixture.checkResult("""$\left(<caret>\right)$""")
+    }
+
     fun testCorrectPairedBraces() {
         myFixture.configureByText(LatexFileType, """$\left<caret>$""")
         myFixture.type('{')


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3493 

#### Summary of additions and changes

* Fixed behaviour described in https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/3493#issuecomment-2133974052 for `(`, `[`, and `{`.

#### How to test this pull request

See test cases:

```kotlin
fun testCorrectPairedParenthesis() {
    myFixture.configureByText(LatexFileType, """$\left<caret>$""")
    myFixture.type('(')
    myFixture.checkResult("""$\left(<caret>\right)$""")
}

fun testCorrectPairedBraces() {
    myFixture.configureByText(LatexFileType, """$\left<caret>$""")
    myFixture.type('{')
    myFixture.checkResult("""$\left{<caret>\right}$""")
}

fun testCorrectPairedBrackets() {
    myFixture.configureByText(LatexFileType, """$\left<caret>$""")
    myFixture.type('[')
    myFixture.checkResult("""$\left[<caret>\right]$""")
}
```

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary