### PR TITLE
Update siunix command completion

### DIFF
--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexSiunitxCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexSiunitxCommand.kt
@@ -35,7 +35,6 @@ enum class LatexSiunitxCommand(
     SI("si", "options".asOptional(), "unit".asRequired(), dependency = SIUNITX),
     SI_NUM("SI", "options".asOptional(), "number".asRequired(), "pre-unit".asOptional(), "unit".asRequired(), dependency = SIUNITX),
     SILIST("SIlist", "options".asOptional(), "numbers".asRequired(), "unit".asRequired(), dependency = SIUNITX),
-    SIRANGE("numrange", "options".asOptional(), "number1".asRequired(), "number2".asRequired(), "unit".asRequired(), dependency = SIUNITX),
     ;
 
     override val identifier: String

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexSiunitxCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexSiunitxCommand.kt
@@ -29,12 +29,6 @@ enum class LatexSiunitxCommand(
     COMPLEXQTY("complexqty", "options".asOptional(), "number".asRequired(), "unit".asRequired(), dependency = SIUNITX),
     SISETUP("sisetup", "options".asRequired(), dependency = SIUNITX),
     TABLENUM("tablenum", "options".asOptional(), "number".asRequired(), dependency = SIUNITX),
-
-    // As of version 3, the following commands are not recommended anymore
-    // See chapter 5 "Upgrading from version 2" in the siunitx documentation for more information
-    SI("si", "options".asOptional(), "unit".asRequired(), dependency = SIUNITX),
-    SI_NUM("SI", "options".asOptional(), "number".asRequired(), "pre-unit".asOptional(), "unit".asRequired(), dependency = SIUNITX),
-    SILIST("SIlist", "options".asOptional(), "numbers".asRequired(), "unit".asRequired(), dependency = SIUNITX),
     ;
 
     override val identifier: String

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexSiunitxCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexSiunitxCommand.kt
@@ -17,14 +17,25 @@ enum class LatexSiunitxCommand(
 
     ANG("ang", "options".asOptional(), "angle".asRequired(), dependency = SIUNITX),
     NUM("num", "options".asOptional(), "number".asRequired(), dependency = SIUNITX),
-    SI("si", "options".asOptional(), "unit".asRequired(), dependency = SIUNITX),
-    SI_NUM("SI", "options".asOptional(), "number".asRequired(), "pre-unit".asOptional(), "unit".asRequired(), dependency = SIUNITX),
+    UNIT("unit", "options".asOptional(), "unit".asRequired(), dependency = SIUNITX),
+    QTY("qty", "options".asOptional(), "number".asRequired(), "unit".asRequired(), dependency = SIUNITX),
     NUMLIST("numlist", "options".asOptional(), "numbers".asRequired(), dependency = SIUNITX),
+    NUMPRODUCT("numproduct", "options".asOptional(), "numbers".asRequired(), dependency = SIUNITX),
     NUMRANGE("numrange", "options".asOptional(), "number1".asRequired(), "number2".asRequired(), dependency = SIUNITX),
-    SILIST("SIlist", "options".asOptional(), "numbers".asRequired(), "unit".asRequired(), dependency = SIUNITX),
-    SIRANGE("numrange", "options".asOptional(), "number1".asRequired(), "number2".asRequired(), "unit".asRequired(), dependency = SIUNITX),
+    QTYLIST("qtylist", "options".asOptional(), "numbers".asRequired(), "unit".asRequired(), dependency = SIUNITX),
+    QTYPRODUCT("qtyproduct", "options".asOptional(), "numbers".asRequired(), "unit".asRequired(), dependency = SIUNITX),
+    QTYRANGE("qtyrange", "options".asOptional(), "number1".asRequired(), "number2".asRequired(), "unit".asRequired(), dependency = SIUNITX),
+    COMPLEXNUM("complexnum", "options".asOptional(), "number".asRequired(), dependency = SIUNITX),
+    COMPLEXQTY("complexqty", "options".asOptional(), "number".asRequired(), "unit".asRequired(), dependency = SIUNITX),
     SISETUP("sisetup", "options".asRequired(), dependency = SIUNITX),
     TABLENUM("tablenum", "options".asOptional(), "number".asRequired(), dependency = SIUNITX),
+
+    // As of version 3, the following commands are not recommended anymore
+    // See chapter 5 "Upgrading from version 2" in the siunitx documentation for more information
+    SI("si", "options".asOptional(), "unit".asRequired(), dependency = SIUNITX),
+    SI_NUM("SI", "options".asOptional(), "number".asRequired(), "pre-unit".asOptional(), "unit".asRequired(), dependency = SIUNITX),
+    SILIST("SIlist", "options".asOptional(), "numbers".asRequired(), "unit".asRequired(), dependency = SIUNITX),
+    SIRANGE("numrange", "options".asOptional(), "number1".asRequired(), "number2".asRequired(), "unit".asRequired(), dependency = SIUNITX),
     ;
 
     override val identifier: String


### PR DESCRIPTION
#### Summary of additions and changes

In version 3, the siunitx commands changed. This commit adds those commands to LatexSiunitxCommand.kt and removes an old command (numrange), which would conflict with one new command. 
Also, some of the previously implemented commands aren't recommended anymore by the package. I'm not sure, if there is already a way to mark a command completion as deprecated, so I just added a comment.