### PR TITLE
Fix crash if using bibtex structure view when bibtex file type is reassignd to plain text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Fixed
+* Fix exception #3557 if using bibtex structure view when bibtex file type is reassignd to plain text
 
 ## [0.9.8]
 

--- a/src/nl/hannahsten/texifyidea/structure/bibtex/BibtexStructureViewElement.kt
+++ b/src/nl/hannahsten/texifyidea/structure/bibtex/BibtexStructureViewElement.kt
@@ -33,8 +33,9 @@ open class BibtexStructureViewElement(val element: PsiElement) : StructureViewTr
     }
 
     override fun getPresentation(): ItemPresentation {
-        assert(element is BibtexFile) { "Expected BibtexFile, got ${element.javaClass}" }
-        return BibtexFilePresentation(element as BibtexFile)
+        // File is usually a BibtexFile, but can be PsiPlainTextFile sometimes
+        assert(element is PsiFile) { "Expected PsiFile, got ${element.javaClass}" }
+        return BibtexFilePresentation(element as PsiFile)
     }
 
     override fun getChildren(): Array<TreeElement> {


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3557
