### PR TITLE
Fix default Docker image name when running Dockerized TeX Live without a project SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Fixed
+* Fix default Docker image name when running Dockerized TeX Live without a project SDK
 
 ## [0.9.8]
 

--- a/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
+++ b/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
@@ -373,7 +373,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
 
     @Suppress("SameParameterValue")
     private fun createDockerCommand(runConfig: LatexRunConfiguration, dockerAuxilDir: String?, dockerOutputDir: String?, mainFile: VirtualFile, command: MutableList<String>) {
-        val isMiktex = runConfig.getLatexDistributionType() == LatexDistributionType.MIKTEX
+        val isMiktex = runConfig.getLatexDistributionType() == LatexDistributionType.DOCKER_MIKTEX
 
         if (isMiktex) {
             // See https://hub.docker.com/r/miktex/miktex
@@ -420,7 +420,9 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
             }
         }
 
-        parameterList.add((sdk?.sdkAdditionalData as? DockerSdkAdditionalData)?.imageName ?: "miktex:latest")
+        val sdkImage = (sdk?.sdkAdditionalData as? DockerSdkAdditionalData)?.imageName
+        val default = if (isMiktex) "miktex/miktex:latest" else "texlive/texlive:latest"
+        parameterList.add(sdkImage ?: default)
 
         command.addAll(0, parameterList)
     }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3605
