### PR TITLE
Fix html check when pasting tables from Excel

### DIFF
--- a/src/nl/hannahsten/texifyidea/editor/pasteproviders/LatexPasteProviderUtil.kt
+++ b/src/nl/hannahsten/texifyidea/editor/pasteproviders/LatexPasteProviderUtil.kt
@@ -62,4 +62,4 @@ private val tagDependencies = hashMapOf(
 )
 
 fun htmlTextIsFormattable(htmlIn: String): Boolean =
-    (PandocHtmlToLatexConverter.isPandocInPath && htmlIn.startsWith("<meta")) || openingTags.keys.any { htmlIn.contains("<$it>") } && closingTags.keys.any { htmlIn.contains("<$it>") }
+    (PandocHtmlToLatexConverter.isPandocInPath && htmlIn.startsWith("<meta")) || openingTags.keys.any { htmlIn.contains("<$it") } && closingTags.keys.any { htmlIn.contains("</$it>") }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3676
