### PR TITLE
Improve reference resolving when using subfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Fixed
+* Fix 'package not found' error when using texlive-full on Windows, and improve running of system commands, by @tristankretzer
 
 ## [0.9.9-alpha.2] - 2024-11-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@
 
 ### Fixed
 
+## [0.9.9-alpha.2] - 2024-11-12
+
+### Added
+
+* Improve reference resolving when using subfiles
+* Add setting to disable auto-import of bibtex entries from remote libraries
+
+### Fixed
+
+* Fix exception #3557 if using bibtex structure view when bibtex file type is reassignd to plain text
+* Avoid referencing obsolete psifiles, fix exception #3635
+
 ## [0.9.9-alpha.1] - 2024-11-10
 
 ### Added
@@ -409,7 +421,8 @@ Thanks to @jojo2357 and @MisterDeenis for contributing to this release!
 * Fix some intention previews. ([#2796](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2796))
 * Other small bug fixes and improvements. ([#2776](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2776), [#2774](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2774), [#2765](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2765)-[#2773](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2773))
 
-[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.9-alpha.1...HEAD
+[Unreleased]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.9-alpha.2...HEAD
+[0.9.9-alpha.2]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.9-alpha.1...v0.9.9-alpha.2
 [0.9.9-alpha.1]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.8...v0.9.9-alpha.1
 [0.9.8]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.7...v0.9.8
 [0.9.7]: https://github.com/Hannah-Sten/TeXiFy-IDEA/compare/v0.9.6...v0.9.7

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.9.9-alpha.1
+pluginVersion = 0.9.9-alpha.2
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
@@ -173,7 +173,7 @@ class InputFileReference(
         }
 
         // Look for packages/files elsewhere using the kpsewhich command.
-        if (targetFile == null && lookForInstalledPackages) {
+        if (targetFile == null && lookForInstalledPackages && !element.project.isTestProject()) {
             targetFile = element.getFileNameWithExtensions(processedKey)
                 .mapNotNull { LatexPackageLocationCache.getPackageLocation(it, element.project) }
                 .firstNotNullOfOrNull { findFileByPath(it) }

--- a/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
@@ -112,7 +112,10 @@ class InputFileReference(
 
         // Find the sources root of the current file.
         // findRootFile will also call getImportPaths, so that will be executed twice
-        val rootFiles = if (givenRootFile != null) setOf(givenRootFile) else element.containingFile.findRootFiles().mapNotNull { it.virtualFile }
+        val rootFiles = if (givenRootFile != null) setOf(givenRootFile) else element.containingFile.findRootFiles()
+            // If the current file is a root file, then we assume paths have to be relative to this file. In particular, when using subfiles then parts that are relative to one of the other root files should not be valid
+            .let { if (element.containingFile in it) listOf(element.containingFile) else it }
+            .mapNotNull { it.virtualFile }
         val rootDirectories = rootFiles.mapNotNull { it.parent }
 
         // Check environment variables

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspectionTest.kt
@@ -143,6 +143,14 @@ class LatexFileNotFoundInspectionTest : TexifyInspectionTestBase(LatexFileNotFou
         myFixture.checkHighlighting()
     }
 
+    fun testSubfilesInclusions() {
+        myFixture.testHighlighting("subfilestest/subdir/onedown.tex", "subfilestest/subdir/subsubdir/twodown.tex", "subfilestest/main.tex")
+    }
+
+    fun testSubfilesReferenceToMain() {
+        myFixture.testHighlighting("subfilestest/subdir/subsubdir/twodown.tex", "subfilestest/subdir/onedown.tex", "subfilestest/main.tex")
+    }
+
 // java.lang.Throwable: Stub index points to a file without PSI: file = temp:///src/subfiles/dir1, file type = com.intellij.openapi.fileTypes.UnknownFileType@35570dc3
 //    @Test
 //    fun `test subfiles`() {

--- a/test/resources/inspections/latex/filenotfound/commandexpansion/nest/sub.tex
+++ b/test/resources/inspections/latex/filenotfound/commandexpansion/nest/sub.tex
@@ -4,5 +4,5 @@
 
 \begin{document}
     \include{\main/nest/sub2.tex}
-    \include{nest/sub2.tex}
+    \include{<error descr="File 'nest/sub2.tex' not found">nest/sub2.tex</error>}
 \end{document}

--- a/test/resources/inspections/latex/filenotfound/subfilestest/main.tex
+++ b/test/resources/inspections/latex/filenotfound/subfilestest/main.tex
@@ -1,0 +1,9 @@
+\documentclass[11pt]{article}
+
+\usepackage{subfiles}
+
+\begin{document}
+
+\subfile{subdir/onedown.tex}
+
+\end{document}

--- a/test/resources/inspections/latex/filenotfound/subfilestest/main.tex
+++ b/test/resources/inspections/latex/filenotfound/subfilestest/main.tex
@@ -1,5 +1,6 @@
+%! Suppress = FileNotFound
 \documentclass[11pt]{article}
-
+%! Suppress = FileNotFound
 \usepackage{subfiles}
 
 \begin{document}

--- a/test/resources/inspections/latex/filenotfound/subfilestest/subdir/onedown.tex
+++ b/test/resources/inspections/latex/filenotfound/subfilestest/subdir/onedown.tex
@@ -1,0 +1,7 @@
+\documentclass[../main.tex]{subfiles}
+
+\begin{document}
+    Inclusions should be relative to this file, not to the main file.
+    \subfile{subsubdir/twodown.tex}
+    \subfile{<error descr="File 'subdir/subsubdir/twodown.tex' not found">subdir/subsubdir/twodown.tex</error>}
+\end{document}

--- a/test/resources/inspections/latex/filenotfound/subfilestest/subdir/onedown.tex
+++ b/test/resources/inspections/latex/filenotfound/subfilestest/subdir/onedown.tex
@@ -1,4 +1,4 @@
-\documentclass[../main.tex]{subfiles}
+\documentclass[../main.tex]{<error descr="File 'subfiles.cls' not found">subfiles</error>}
 
 \begin{document}
     Inclusions should be relative to this file, not to the main file.

--- a/test/resources/inspections/latex/filenotfound/subfilestest/subdir/subsubdir/twodown.tex
+++ b/test/resources/inspections/latex/filenotfound/subfilestest/subdir/subsubdir/twodown.tex
@@ -1,5 +1,5 @@
 % Path to main file should be relative to this file
-\documentclass[<error descr="File 'main.tex' not found">main.tex</error>]{subfiles}
+\documentclass[<error descr="File 'main.tex' not found">main.tex</error>]{<error descr="File 'subfiles.cls' not found">subfiles</error>}
 
 \begin{document}
     subfile

--- a/test/resources/inspections/latex/filenotfound/subfilestest/subdir/subsubdir/twodown.tex
+++ b/test/resources/inspections/latex/filenotfound/subfilestest/subdir/subsubdir/twodown.tex
@@ -1,0 +1,6 @@
+% Path to main file should be relative to this file
+\documentclass[<error descr="File 'main.tex' not found">main.tex</error>]{subfiles}
+
+\begin{document}
+    subfile
+\end{document}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->

#### Summary of additions and changes

* Resolve only relative to the current file if the current file is a root file, in particular when using subfiles
