### PR TITLE
Fix a parser issue with bidirectional arrow in TikZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 * Improve error report submitter for long stacktraces
+* Fix a parser issue with bidirectional arrow in TikZ
 
 ## [0.9.9-alpha.4] - 2024-11-13
 

--- a/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
+++ b/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
@@ -126,7 +126,7 @@ picture_param ::= OPEN_PAREN picture_param_content* CLOSE_PAREN { pin=3 }
 // We have to separate optional and required parameter content, because required parameter content
 // can contain mismatched brackets, but optional parameters not (then we wouldn't know what to match)
 optional_param_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | if_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | OPEN_PAREN | CLOSE_PAREN | parameter_text | BACKSLASH | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET | END_IF
-required_param_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | if_block | math_environment | COMMAND_IFNEXTCHAR | group | OPEN_PAREN | CLOSE_PAREN | parameter_text | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET | BACKSLASH | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET | END_IF
+required_param_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | if_block | math_environment | COMMAND_IFNEXTCHAR | group | OPEN_PAREN | CLOSE_PAREN | parameter_text | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET | BACKSLASH | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET | END_IF | ANGLE_PARAM
 // Cannot contain ( or )
 picture_param_content ::= raw_text | magic_comment | comment | environment | pseudocode_block | if_block | math_environment | COMMAND_IFNEXTCHAR | commands | group | parameter_text | BACKSLASH | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET | END_IF
 

--- a/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
@@ -94,6 +94,8 @@ class LatexParserTest : BasePlatformTestCase() {
             \begin{frame}
                 \only<1>{<info descr="null">${'$'}<info textAttributesKey=LATEX_INLINE_MATH>a_1${'$'}</info></info>}
             \end{frame}
+            
+            \tikzset{<->/.style=->}
             """.trimIndent()
         )
         myFixture.checkHighlighting(false, true, false)


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3225
