### PR TITLE
txt format will use default icon, because CMakeLists.txt should use cmake icon

### DIFF
--- a/src/nl/hannahsten/texifyidea/TexifyIcons.kt
+++ b/src/nl/hannahsten/texifyidea/TexifyIcons.kt
@@ -290,7 +290,6 @@ object TexifyIcons {
             "cls" -> CLASS_FILE
             "dtx" -> DOCUMENTED_LATEX_SOURCE
             "sty" -> STYLE_FILE
-//            "txt" -> TEXT_FILE
             "tikz" -> TIKZ_FILE
             "log" -> TEXT_FILE
             "pdf" -> PDF_FILE

--- a/src/nl/hannahsten/texifyidea/ui/TeXiFyProjectViewNodeDecorator.kt
+++ b/src/nl/hannahsten/texifyidea/ui/TeXiFyProjectViewNodeDecorator.kt
@@ -30,7 +30,7 @@ class TeXiFyProjectViewNodeDecorator : ProjectViewNodeDecorator {
         // Allow Material design plugins to take over the icons
         // For file types registered in plugin.xml this happens automatically
         if (PluginManager.getLoadedPlugins().none { it.name.contains("Material") }) {
-            // Make sure to now override non-LaTeX extensions with the default icon
+            // Make sure to not override non-LaTeX extensions with the default icon
             val icon = TexifyIcons.getIconFromExtension(extension.lowercase(Locale.getDefault()), default = null) ?: return
             presentationData.setIcon(icon)
         }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3674

#### Summary of additions and changes
I comment the case for txt, so I think the the icon of txt will use the defualt configuration of clion (CMakeLists.txt will use cmake icon) to solve this issue https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/3674
But I don't know how to build the plugin, so I haven't test the result. Since the changes are very simple(only 1 line), I hope you can test for me:) thanks a lot!
* 

#### How to test this pull request

```latex

```

- [ ] Updated the documentation, or no update necessary
- [ ] Added tests, or no tests necessary