### PR TITLE
3673 todo

### DIFF
--- a/resources/META-INF/extensions/index.xml
+++ b/resources/META-INF/extensions/index.xml
@@ -18,6 +18,7 @@
         <fileBasedIndex implementation="nl.hannahsten.texifyidea.index.file.LatexExternalPackageInclusionIndex" />
         <indexedRootsProvider implementation="nl.hannahsten.texifyidea.index.file.LatexIndexableSetContributor" />
         <indexPatternSearch implementation="nl.hannahsten.texifyidea.index.LatexTodoSearcher"/>
+        <indexPatternProvider implementation="nl.hannahsten.texifyidea.index.LatexTodoIndexPatternProvider"/>
         <todoIndexer filetype="LaTeX source file" implementationClass="nl.hannahsten.texifyidea.index.LatexTodoIndexer"/>
     </extensions>
 </idea-plugin>

--- a/resources/META-INF/extensions/index.xml
+++ b/resources/META-INF/extensions/index.xml
@@ -17,5 +17,7 @@
         <fileBasedIndex implementation="nl.hannahsten.texifyidea.index.file.LatexExternalEnvironmentIndex" />
         <fileBasedIndex implementation="nl.hannahsten.texifyidea.index.file.LatexExternalPackageInclusionIndex" />
         <indexedRootsProvider implementation="nl.hannahsten.texifyidea.index.file.LatexIndexableSetContributor" />
+        <indexPatternSearch implementation="nl.hannahsten.texifyidea.index.LatexTodoSearcher"/>
+        <todoIndexer filetype="LaTeX source file" implementationClass="nl.hannahsten.texifyidea.index.LatexTodoIndexer"/>
     </extensions>
 </idea-plugin>

--- a/src/nl/hannahsten/texifyidea/index/LatexTodoIndexPatternProvider.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexTodoIndexPatternProvider.kt
@@ -1,0 +1,11 @@
+package nl.hannahsten.texifyidea.index
+
+import com.intellij.psi.search.IndexPattern
+import com.intellij.psi.search.IndexPatternProvider
+import nl.hannahsten.texifyidea.util.magic.CommandMagic
+
+class LatexTodoIndexPatternProvider : IndexPatternProvider {
+    override fun getIndexPatterns(): Array<IndexPattern> {
+        return CommandMagic.todoCommands.map { IndexPattern("${it.replace("\\", "\\\\")}\\b", true) }.toTypedArray()
+    }
+}

--- a/src/nl/hannahsten/texifyidea/index/LatexTodoIndexer.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexTodoIndexer.kt
@@ -14,14 +14,16 @@ import nl.hannahsten.texifyidea.util.magic.CommandMagic
  */
 class LatexTodoIndexer : LexerBasedTodoIndexer() {
     override fun createLexer(consumer: OccurrenceConsumer): Lexer {
-        return object : BaseFilterLexer(LatexLexerAdapter(), consumer) {
-            override fun advance() {
-                val tokenType = delegate.tokenType
-                if (tokenType in LatexTokenSets.COMMENTS || (tokenType == LatexTypes.COMMAND_TOKEN && delegate.tokenText in CommandMagic.todoCommands)) {
-                    advanceTodoItemCountsInToken()
-                }
-                delegate.advance()
-            }
+        return LatexFilterLexer(consumer)
+    }
+}
+
+class LatexFilterLexer(consumer: OccurrenceConsumer) : BaseFilterLexer(LatexLexerAdapter(), consumer) {
+    override fun advance() {
+        val tokenType = delegate.tokenType
+        if (tokenType in LatexTokenSets.COMMENTS || (tokenType == LatexTypes.COMMAND_TOKEN && delegate.tokenText in CommandMagic.todoCommands)) {
+            advanceTodoItemCountsInToken()
         }
+        delegate.advance()
     }
 }

--- a/src/nl/hannahsten/texifyidea/index/LatexTodoIndexer.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexTodoIndexer.kt
@@ -1,0 +1,26 @@
+package nl.hannahsten.texifyidea.index
+
+import com.intellij.lexer.Lexer
+import com.intellij.psi.impl.cache.impl.BaseFilterLexer
+import com.intellij.psi.impl.cache.impl.OccurrenceConsumer
+import com.intellij.psi.impl.cache.impl.todo.LexerBasedTodoIndexer
+import nl.hannahsten.texifyidea.grammar.LatexLexerAdapter
+import nl.hannahsten.texifyidea.psi.LatexTypes
+import nl.hannahsten.texifyidea.util.magic.CommandMagic
+
+/**
+ * Counts the "to do" item, so that it shows up in the Project "to do" window and the count of the number of items is correct.
+ */
+class LatexTodoIndexer : LexerBasedTodoIndexer() {
+    override fun createLexer(consumer: OccurrenceConsumer): Lexer {
+        return object : BaseFilterLexer(LatexLexerAdapter(), consumer) {
+            override fun advance() {
+                val tokenType = delegate.tokenType
+                if (tokenType == LatexTypes.COMMAND_TOKEN && delegate.tokenText in CommandMagic.todoCommands) {
+                    advanceTodoItemCountsInToken()
+                }
+                delegate.advance()
+            }
+        }
+    }
+}

--- a/src/nl/hannahsten/texifyidea/index/LatexTodoIndexer.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexTodoIndexer.kt
@@ -5,6 +5,7 @@ import com.intellij.psi.impl.cache.impl.BaseFilterLexer
 import com.intellij.psi.impl.cache.impl.OccurrenceConsumer
 import com.intellij.psi.impl.cache.impl.todo.LexerBasedTodoIndexer
 import nl.hannahsten.texifyidea.grammar.LatexLexerAdapter
+import nl.hannahsten.texifyidea.grammar.LatexTokenSets
 import nl.hannahsten.texifyidea.psi.LatexTypes
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 
@@ -16,7 +17,7 @@ class LatexTodoIndexer : LexerBasedTodoIndexer() {
         return object : BaseFilterLexer(LatexLexerAdapter(), consumer) {
             override fun advance() {
                 val tokenType = delegate.tokenType
-                if (tokenType == LatexTypes.COMMAND_TOKEN && delegate.tokenText in CommandMagic.todoCommands) {
+                if (tokenType in LatexTokenSets.COMMENTS || (tokenType == LatexTypes.COMMAND_TOKEN && delegate.tokenText in CommandMagic.todoCommands)) {
                     advanceTodoItemCountsInToken()
                 }
                 delegate.advance()

--- a/src/nl/hannahsten/texifyidea/index/LatexTodoSearcher.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexTodoSearcher.kt
@@ -1,0 +1,37 @@
+package nl.hannahsten.texifyidea.index
+
+import com.intellij.openapi.application.QueryExecutorBase
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiFile
+import com.intellij.psi.search.IndexPattern
+import com.intellij.psi.search.IndexPatternOccurrence
+import com.intellij.psi.search.searches.IndexPatternSearch
+import com.intellij.util.Processor
+import nl.hannahsten.texifyidea.file.LatexFile
+import nl.hannahsten.texifyidea.util.files.commandsInFile
+import nl.hannahsten.texifyidea.util.magic.CommandMagic
+
+/**
+ * Provides the "to do" item in the toolwindow and highlighting in the editor.
+ */
+@Suppress("UnstableApiUsage")
+class LatexTodoSearcher : QueryExecutorBase<IndexPatternOccurrence, IndexPatternSearch.SearchParameters>() {
+    override fun processQuery(queryParameters: IndexPatternSearch.SearchParameters, consumer: Processor<in IndexPatternOccurrence>) {
+        val file = queryParameters.file as? LatexFile ?: return
+        val pattern = queryParameters.pattern
+            ?: queryParameters.patternProvider.indexPatterns.firstOrNull { it.patternString.contains("todo", true) }
+            ?: return
+
+        file.commandsInFile().filter { it.name in CommandMagic.todoCommands }
+            .forEach {
+                println("${it.text}: ${it.textRange}")
+                consumer.process(LatexTodoOccurrence(file, it.textRange, pattern))
+            }
+    }
+}
+
+private data class LatexTodoOccurrence(private val file: LatexFile, private val textRange: TextRange, private val pattern: IndexPattern) : IndexPatternOccurrence {
+    override fun getFile(): PsiFile = file
+    override fun getTextRange(): TextRange = textRange
+    override fun getPattern(): IndexPattern = pattern
+}

--- a/src/nl/hannahsten/texifyidea/lang/LatexPackage.kt
+++ b/src/nl/hannahsten/texifyidea/lang/LatexPackage.kt
@@ -86,6 +86,7 @@ open class LatexPackage @JvmOverloads constructor(
         val TCOLORBOX = LatexPackage("tcolorbox")
         val TEXTCOMP = LatexPackage("textcomp")
         val TIKZ = LatexPackage("tikz")
+        val TODONOTES = LatexPackage("todonotes")
         val ULEM = LatexPackage("ulem")
         val VARIOREF = LatexPackage("varioref")
         val WASYSYM = LatexPackage("wasysym")

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexRegularCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexRegularCommand.kt
@@ -25,9 +25,10 @@ object LatexRegularCommand {
     private val LISTINGS: Set<LatexCommand> = LatexListingCommand.entries.toSet()
     private val LOREM_IPSUM: Set<LatexCommand> = LatexLoremIpsumCommand.entries.toSet()
     private val GLOSSARY: Set<LatexCommand> = LatexGlossariesCommand.entries.toSet()
+    private val TODO: Set<LatexCommand> = LatexTodoCommand.entries.toSet()
 
     val ALL: Set<LatexCommand> = GENERIC + TEXTCOMP + EURO + TEXT_SYMBOLS + NEW_DEFINITIONS + MATHTOOLS +
-        XCOLOR + XPARSE + NATBIB + BIBLATEX + SIUNITX + ALGORITHMICX + IFS + LISTINGS + LOREM_IPSUM + GLOSSARY
+        XCOLOR + XPARSE + NATBIB + BIBLATEX + SIUNITX + ALGORITHMICX + IFS + LISTINGS + LOREM_IPSUM + GLOSSARY + TODO
 
     private val lookup = HashMap<String, NonEmptySet<LatexCommand>>()
     private val lookupDisplay = HashMap<String, NonEmptySet<LatexCommand>>()

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexTodoCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexTodoCommand.kt
@@ -1,0 +1,23 @@
+package nl.hannahsten.texifyidea.lang.commands
+
+import nl.hannahsten.texifyidea.lang.LatexPackage
+import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.ALGPSEUDOCODE
+import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.TODONOTES
+
+enum class LatexTodoCommand(
+    override val command: String,
+    override vararg val arguments: Argument = emptyArray(),
+    override val dependency: LatexPackage = LatexPackage.DEFAULT,
+    override val display: String? = null,
+    override val isMathMode: Boolean = false,
+    val collapse: Boolean = false
+) : LatexCommand {
+
+    TODO("todo", "note".asRequired(), dependency = TODONOTES),
+    MISSINGFIGURE("missingfigure", "note".asRequired(), dependency = TODONOTES),
+    LISTOFTODOS("listoftodos", "name".asOptional(), dependency = TODONOTES)
+    ;
+
+    override val identifier: String
+        get() = name
+}

--- a/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
@@ -17,6 +17,7 @@ import nl.hannahsten.texifyidea.lang.commands.LatexNatbibCommand.*
 import nl.hannahsten.texifyidea.lang.commands.LatexNewDefinitionCommand.*
 import nl.hannahsten.texifyidea.lang.commands.LatexOperatorCommand.*
 import nl.hannahsten.texifyidea.lang.commands.LatexRegularCommand
+import nl.hannahsten.texifyidea.lang.commands.LatexTodoCommand
 import nl.hannahsten.texifyidea.lang.commands.LatexUncategorizedStmaryrdSymbols.BIG_SQUARE_CAP
 import nl.hannahsten.texifyidea.lang.commands.LatexXparseCommand.*
 
@@ -498,5 +499,12 @@ object CommandMagic {
      */
     val foldableFootnotes = listOf(
         FOOTNOTE.cmd, FOOTCITE.cmd
+    )
+
+    /**
+     * Commands that should be contributed to the todo toolwindow.
+     */
+    val todoCommands = setOf(
+        LatexTodoCommand.TODO.cmd, LatexTodoCommand.MISSINGFIGURE.cmd
     )
 }

--- a/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
@@ -502,9 +502,7 @@ object CommandMagic {
     )
 
     /**
-     * Commands that should be contributed to the todo toolwindow.
+     * Commands that should be contributed to the to do toolwindow.
      */
-    val todoCommands = setOf(
-        LatexTodoCommand.TODO.cmd, LatexTodoCommand.MISSINGFIGURE.cmd
-    )
+    val todoCommands = setOf(LatexTodoCommand.TODO.cmd, LatexTodoCommand.MISSINGFIGURE.cmd)
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3673 

#### Summary of additions and changes

* Added the `\todo` and `\missingfigure` commands from the `todonotes` package to the todo tool window.

Some remarks on limitations and the implementation:
* The `\todo` commands are counted twice in the total todo count for a file/project/etc because it matches both the new `\todo` and the existing `todo` patterns. We have more control on what appears in the tree, so it only appears once there.
* According to the [dev guide](https://plugins.jetbrains.com/docs/intellij/additional-minor-features.html#additional-places) the EP to register these extra places is [`indexPatternSearch`](https://plugins.jetbrains.com/intellij-platform-explorer/extensions?extensions=com.intellij.indexPatternSearch), but the only way seems to be using quite some internal api's. So no guarantees that this keeps working properly in the future. 
* The commands are not highlighted as todo items and are not customisable via the todo settings, as that is currently not possible (see [IJPL-172245](https://youtrack.jetbrains.com/issue/IJPL-172245)). Once this is fixed, we can probably change our implementation to only include the Searcher?

#### How to test this pull request

```latex
% todo testaqi
\todo{test}

\missingfigure{test}
```

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary