### PR TITLE
Use theme foreground and background colors for equation preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+* Use theme foreground and background colors for equation preview
 * Support references in \subfix command
 * Provide autocompletion for all relevant directories when using subfiles
 

--- a/src/nl/hannahsten/texifyidea/action/preview/InkscapePreviewer.kt
+++ b/src/nl/hannahsten/texifyidea/action/preview/InkscapePreviewer.kt
@@ -6,9 +6,11 @@ import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.io.FileUtil
+import com.intellij.ui.JBColor
 import nl.hannahsten.texifyidea.settings.sdk.LatexSdkUtil
 import nl.hannahsten.texifyidea.util.SystemEnvironment
 import nl.hannahsten.texifyidea.util.runCommandWithExitCode
+import nl.hannahsten.texifyidea.util.toHex
 import java.io.File
 import java.io.IOException
 import java.io.PrintWriter
@@ -134,7 +136,7 @@ $previewCode
                     "$tempBasename.pdf",
                     "--export-area-drawing",
                     "--export-dpi", "1000",
-                    "--export-background", "#FFFFFF",
+                    "--export-background", JBColor.background().toHex(),
                     "--export-background-opacity", "1.0",
                     "--export-filename", "$tempBasename.png"
                 ),
@@ -161,7 +163,7 @@ $previewCode
                     "$tempBasename.svg",
                     "--export-area-drawing",
                     "--export-dpi", "1000",
-                    "--export-background", "#FFFFFF",
+                    "--export-background", JBColor.background().toHex(),
                     "--export-png", "$tempBasename.png"
                 ),
                 tempDirectory,

--- a/src/nl/hannahsten/texifyidea/action/preview/JlatexmathPreviewer.kt
+++ b/src/nl/hannahsten/texifyidea/action/preview/JlatexmathPreviewer.kt
@@ -1,7 +1,6 @@
 package nl.hannahsten.texifyidea.action.preview
 
 import com.intellij.openapi.project.Project
-import com.intellij.ui.Gray
 import com.intellij.ui.JBColor
 import com.intellij.util.ui.JBUI
 import org.apache.batik.dom.GenericDOMImplementation
@@ -10,7 +9,6 @@ import org.apache.batik.svggen.SVGGraphics2D
 import org.apache.batik.transcoder.TranscoderException
 import org.apache.batik.transcoder.TranscoderInput
 import org.apache.batik.transcoder.TranscoderOutput
-import org.apache.batik.transcoder.image.ImageTranscoder
 import org.apache.batik.transcoder.image.PNGTranscoder
 import org.scilab.forge.jlatexmath.DefaultTeXFont
 import org.scilab.forge.jlatexmath.ParseException
@@ -70,7 +68,6 @@ class JlatexmathPreviewer : Previewer {
         val transcoderInput = TranscoderInput(FileInputStream("$tempBaseName.svg"))
         val os = FileOutputStream("$tempBaseName.png")
         val transcoderOutput = TranscoderOutput(os)
-        transcoder.addTranscodingHint(ImageTranscoder.KEY_BACKGROUND_COLOR, JBColor.WHITE)
         transcoder.addTranscodingHint(PNGTranscoder.KEY_WIDTH, scaledWidth)
         transcoder.addTranscodingHint(PNGTranscoder.KEY_HEIGHT, scaledHeight)
 
@@ -98,10 +95,10 @@ class JlatexmathPreviewer : Previewer {
         val icon = formula.createTeXIcon(TeXConstants.STYLE_DISPLAY, 20f)
         icon.insets = JBUI.insets(5)
         g2.svgCanvasSize = Dimension(icon.iconWidth, icon.iconHeight)
-        g2.color = JBColor.WHITE
+        g2.color = JBColor.background()
         g2.fillRect(0, 0, icon.iconWidth, icon.iconHeight)
         val jl = JLabel()
-        jl.foreground = Gray._0
+        jl.foreground = JBColor.foreground()
         icon.paintIcon(jl, g2, 0, 0)
         val useCSS = true
         val svgs = FileOutputStream("$tempBaseName.svg")

--- a/src/nl/hannahsten/texifyidea/action/preview/PreviewFormUpdater.kt
+++ b/src/nl/hannahsten/texifyidea/action/preview/PreviewFormUpdater.kt
@@ -1,6 +1,7 @@
 package nl.hannahsten.texifyidea.action.preview
 
 import com.intellij.openapi.project.Project
+import com.intellij.ui.JBColor
 
 /**
  * @author Sergei Izmailov
@@ -53,8 +54,14 @@ class PreviewFormUpdater(private val previewForm: PreviewForm) {
     fun compilePreview(previewCode: String, project: Project, canUseJlatexmath: Boolean) {
         previewForm.setEquation(previewCode)
 
+        val foreground = JBColor.foreground()
+        val colorPreamble = """
+        \usepackage{xcolor}
+        \color[RGB]{${foreground.red},${foreground.green},${foreground.blue}}
+        """.trimIndent()
+
         // Combine default and user defined preamble. Cannot be used if we decide to run latexmath.
-        val preamble = preamble + userPreamble
+        val preamble = preamble + colorPreamble + userPreamble
 
         // jlatexmath cannot handle a custom preamble
         val previewer = if (userPreamble.isBlank() && canUseJlatexmath) {

--- a/src/nl/hannahsten/texifyidea/util/UserInterface.kt
+++ b/src/nl/hannahsten/texifyidea/util/UserInterface.kt
@@ -4,6 +4,7 @@ import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.panels.HorizontalLayout
 import com.intellij.util.ui.JBUI
 import java.awt.BorderLayout
+import java.awt.Color
 import java.awt.Dimension
 import java.awt.event.KeyAdapter
 import java.awt.event.KeyEvent
@@ -128,3 +129,5 @@ fun JPanel.addLabeledComponent(
 fun hbox(spacing: Int = 8, vararg components: JComponent) = JPanel(HorizontalLayout(spacing)).apply {
     components.forEach { add(it) }
 }
+
+fun Color.toHex() = String.format("#%02x%02x%02x", red, green, blue)


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3435


#### How to test this pull request

Updated both previewers, the inkscape preview can be triggered by adding
```latex
%! begin preamble = math
\usepackage{amsmath}
%! end preamble = math
```
