### PR TITLE
Check if file is still valid after retrieving from cache 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Fixed
+* Fix exception #3771 when a file referenced from cache is deleted
 * Fix basic case of false positive of duplicate label inspection when user defined \if commands are used
 * Fix a parse error when using \else with a user defined \if-command
 

--- a/src/nl/hannahsten/texifyidea/util/files/ReferencedFileSetCache.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/ReferencedFileSetCache.kt
@@ -122,7 +122,8 @@ class ReferencedFileSetCache {
                     }
                 }
             }
-            cache[file.virtualFile]?.mapNotNull { it.element }?.toSet() ?: setOf(file)
+            // Make sure to check if file is still valid after retrieving from cache (it may have been deleted)
+            cache[file.virtualFile]?.mapNotNull { it.element }?.filter { it.isValid }?.toSet() ?: setOf(file)
         }
         else {
             setOf(file)


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3771
