### PR TITLE
Disallow unmatched braces after \@ifnextchar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Fixed
+* Disallow unmatched braces after \@ifnextchar
 * Fix basic case of false positive of duplicate label inspection when user defined \if commands are used
 * Fix a parse error when using \else with a user defined \if-command
 

--- a/src/nl/hannahsten/texifyidea/grammar/LatexLexer.flex
+++ b/src/nl/hannahsten/texifyidea/grammar/LatexLexer.flex
@@ -77,7 +77,8 @@ WHITE_SPACE={SINGLE_WHITE_SPACE}+
 // Commands
 BEGIN_TOKEN="\\begin"
 END_TOKEN="\\end"
-COMMAND_IFNEXTCHAR=\\@ifnextchar.
+// All characters after @ifnextchar may be unbalanced, except braces, see https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/3744#issuecomment-2477263416
+COMMAND_IFNEXTCHAR=\\@ifnextchar[^{]
 COMMAND_TOKEN=\\([a-zA-Z@]+|.|\r)
 COMMAND_TOKEN_LATEX3=\\([a-zA-Z@_:0-9]+|.|\r) // _ and : are only LaTeX3 syntax
 LATEX3_ON=\\(ExplSyntaxOn|ProvidesExplPackage|ProvidesExplClass|ProvidesExplFile)

--- a/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
@@ -59,6 +59,8 @@ class LatexParserTest : BasePlatformTestCase() {
             """
             \newcommand{\xyz}{\@ifnextchar[{\@xyz}{\@xyz[default]}}
             \def\@xyz[#1]#2{do something with #1 and #2}
+            
+            \@namedef{#1}{\@ifnextchar{^}{\@nameuse{#1@}}{\@nameuse{#1@}^{}}}
             """.trimIndent()
         )
         myFixture.checkHighlighting()


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3744
