### PR TITLE
Improve Grazie implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Fixed
+* Fix various issues with the Grazie implementation, in particular default rules for Grazie Pro
 
 ## [0.9.10-alpha.2] - 2024-12-05
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,6 +113,7 @@ dependencies {
         bundledPlugin("tanvd.grazi")
         plugin("com.firsttimeinforever.intellij.pdf.viewer.intellij-pdf-viewer:0.17.0")
         plugin("com.jetbrains.hackathon.indices.viewer:1.28")
+        plugin("com.intellij.grazie.pro:0.3.347")
     }
 
     // Local dependencies

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,7 +114,7 @@ dependencies {
         plugin("com.firsttimeinforever.intellij.pdf.viewer.intellij-pdf-viewer:0.17.0")
         plugin("com.jetbrains.hackathon.indices.viewer:1.28")
         // Does not work in tests: https://youtrack.jetbrains.com/issue/GRZ-5023
-        plugin("com.intellij.grazie.pro:0.3.347")
+//        plugin("com.intellij.grazie.pro:0.3.347")
     }
 
     // Local dependencies

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,7 +114,7 @@ dependencies {
         plugin("com.firsttimeinforever.intellij.pdf.viewer.intellij-pdf-viewer:0.17.0")
         plugin("com.jetbrains.hackathon.indices.viewer:1.28")
         // Does not work in tests: https://youtrack.jetbrains.com/issue/GRZ-5023
-//        plugin("com.intellij.grazie.pro:0.3.347")
+        plugin("com.intellij.grazie.pro:0.3.347")
     }
 
     // Local dependencies

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,7 +113,8 @@ dependencies {
         bundledPlugin("tanvd.grazi")
         plugin("com.firsttimeinforever.intellij.pdf.viewer.intellij-pdf-viewer:0.17.0")
         plugin("com.jetbrains.hackathon.indices.viewer:1.28")
-        plugin("com.intellij.grazie.pro:0.3.347")
+        // Does not work in tests: https://youtrack.jetbrains.com/issue/GRZ-5023
+//        plugin("com.intellij.grazie.pro:0.3.347")
     }
 
     // Local dependencies

--- a/src/nl/hannahsten/texifyidea/inspections/grazie/LatexTextExtractor.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/grazie/LatexTextExtractor.kt
@@ -25,6 +25,10 @@ class LatexTextExtractor : TextExtractor() {
             return null
         }
 
+        return buildTextContent(root)
+    }
+
+    fun buildTextContent(root: LatexContent): TextContent? {
         // Since Grazie works by first checking leaf elements, and if it gets null tries one level higher, we cannot return anything (e.g. literal for a command, comment for comments) other than LatexContent because then LatexContent itself will not be used as a root.
         // However, we do need it as a root because we need to filter out certain things like inline math ourselves, so that we can make sure all the whitespace around ignored items is correct.
         val domain = TextContent.TextDomain.PLAIN_TEXT

--- a/src/nl/hannahsten/texifyidea/inspections/grazie/LatexTextExtractor.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/grazie/LatexTextExtractor.kt
@@ -11,10 +11,7 @@ import nl.hannahsten.texifyidea.lang.commands.LatexCommand
 import nl.hannahsten.texifyidea.psi.*
 import nl.hannahsten.texifyidea.util.merge
 import nl.hannahsten.texifyidea.util.overlaps
-import nl.hannahsten.texifyidea.util.parser.childrenOfType
-import nl.hannahsten.texifyidea.util.parser.endOffset
-import nl.hannahsten.texifyidea.util.parser.firstParentOfType
-import nl.hannahsten.texifyidea.util.parser.parents
+import nl.hannahsten.texifyidea.util.parser.*
 import nl.hannahsten.texifyidea.util.toTextRange
 
 /**
@@ -53,7 +50,7 @@ class LatexTextExtractor : TextExtractor() {
         // Only keep normaltext, assuming other things (like inline math) need to be ignored.
         val ranges = (root.childrenOfType(LatexNormalText::class) + root.childrenOfType<LatexParameterText>() + root.childrenOfType<PsiWhiteSpace>())
             .asSequence()
-            .filter { it.isNotInMathEnvironment() && it.isNotInSquareBrackets() }
+            .filter { !it.inMathContext() && it.isNotInSquareBrackets() }
             // Ranges that we need to keep
             // Note that textRangeInParent will not be correct because that's the text range in the direct parent, not in the root
             .flatMap { text ->
@@ -117,8 +114,6 @@ class LatexTextExtractor : TextExtractor() {
 
         return ranges.sortedBy { it.first }
     }
-
-    private fun PsiElement.isNotInMathEnvironment() = parents().none { it is LatexMathEnvironment }
 
     private fun PsiElement.isNotInSquareBrackets() = parents().find { it is LatexGroup || it is LatexOptionalParam }
         ?.let { it is LatexGroup } ?: true

--- a/src/nl/hannahsten/texifyidea/inspections/grazie/LatexTextExtractor.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/grazie/LatexTextExtractor.kt
@@ -57,7 +57,13 @@ class LatexTextExtractor : TextExtractor() {
             // Note that textRangeInParent will not be correct because that's the text range in the direct parent, not in the root
             .flatMap { text ->
                 // Skip arguments of non-text commands, but keep arguments of unknown commands, in particular if they are in the middle of a sentence
-                if (text is LatexParameterText && LatexCommand.lookup(text.firstParentOfType(LatexCommands::class)?.name)?.firstOrNull()?.arguments?.any { it.type != Argument.Type.TEXT } == true || text.firstParentOfType<LatexBeginCommand>() != null || text.firstParentOfType<LatexEndCommand>() != null) {
+                // Even commends which have no text as argument, for example certain reference commands like auteref, may need to be kept in to get correct punctuation
+                if (text is LatexParameterText && LatexCommand.lookup(text.firstParentOfType(LatexCommands::class)?.name)?.firstOrNull()?.arguments?.any { it.type != Argument.Type.TEXT && it.type != Argument.Type.LABEL } == true) {
+                    return@flatMap emptyList()
+                }
+
+                // Environment names are never part of a sentence
+                if (text.firstParentOfType<LatexBeginCommand>() != null || text.firstParentOfType<LatexEndCommand>() != null) {
                     // Ignore this
                     return@flatMap emptyList()
                 }

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexGenericRegularCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexGenericRegularCommand.kt
@@ -154,7 +154,7 @@ enum class LatexGenericRegularCommand(
     INDEXSPACE("indexspace"),
     INDEX("intex", "entry".asRequired()),
     IT("it"),
-    ITEM("item", "label".asOptional()),
+    ITEM("item", "label".asOptional(Argument.Type.TEXT)),
     ITSHAPE("itshape"),
     LABEL("label", "key".asRequired()),
     LARGE("large"),

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexGlossariesCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexGlossariesCommand.kt
@@ -4,8 +4,8 @@ import com.intellij.psi.PsiElement
 import nl.hannahsten.texifyidea.lang.LatexPackage
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexParameterText
-import nl.hannahsten.texifyidea.util.parser.firstChildOfType
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
+import nl.hannahsten.texifyidea.util.parser.firstChildOfType
 import nl.hannahsten.texifyidea.util.parser.requiredParameters
 
 enum class LatexGlossariesCommand(
@@ -46,10 +46,10 @@ enum class LatexGlossariesCommand(
         "long".asRequired(),
         dependency = LatexPackage.GLOSSARIES
     ),
-    GLS("gls", "label".asRequired(), dependency = LatexPackage.GLOSSARIES),
-    GLSUPPER("Gls", "label".asRequired(), dependency = LatexPackage.GLOSSARIES),
-    GLSPLURAL("glspl", "label".asRequired(), dependency = LatexPackage.GLOSSARIES),
-    GLSPLURALUPPER("Glspl", "label".asRequired(), dependency = LatexPackage.GLOSSARIES),
+    GLS("gls", "label".asRequired(Argument.Type.TEXT), dependency = LatexPackage.GLOSSARIES),
+    GLSUPPER("Gls", "label".asRequired(Argument.Type.TEXT), dependency = LatexPackage.GLOSSARIES),
+    GLSPLURAL("glspl", "label".asRequired(Argument.Type.TEXT), dependency = LatexPackage.GLOSSARIES),
+    GLSPLURALUPPER("Glspl", "label".asRequired(Argument.Type.TEXT), dependency = LatexPackage.GLOSSARIES),
 
     LOADGLSENTRIES(
         "loadglsentries",

--- a/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
@@ -37,30 +37,34 @@ class GrazieInspectionTest : BasePlatformTestCase() {
     }
 
     fun testCommentInText() {
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             \begin{document}
                 All <GRAMMAR_ERROR descr="The verb 'is' is singular. Did you mean: this is or those are?">those is</GRAMMAR_ERROR> problems in the middle of a sentence.
                 % <GRAMMAR_ERROR descr="The verb 'is' is singular. Did you mean: this is or Those are?">Those is</GRAMMAR_ERROR> a problem in a comment
                 <GRAMMAR_ERROR descr="The verb 'is' is singular. Did you mean: this is or Those are?">Those is</GRAMMAR_ERROR> a problem at the beginning of a sentence.
             \end{document}
-        """.trimIndent())
+            """.trimIndent()
+        )
         myFixture.checkHighlighting(true, false, false, true)
     }
 
     fun testSentenceAtEnvironmentStart() {
-        myFixture.configureByText(LatexFileType, """
+        myFixture.configureByText(
+            LatexFileType,
+            """
             \begin{document}
                 <GRAMMAR_ERROR descr="Use An instead of 'A' if the following word starts with a vowel sound, e.g. 'an article', 'an hour'.">A</GRAMMAR_ERROR> apple a day keeps the doctor away.
                 Some other sentence.
             \end{document}
-        """.trimIndent())
+            """.trimIndent()
+        )
         myFixture.checkHighlighting(true, false, false, true)
     }
 
     fun testInlineMath() {
-        myFixture.configureByText(
-            LatexFileType, """Does Grazie detect ${'$'}m$ as a sentence?"""
-        )
+        myFixture.configureByText(LatexFileType, """Does Grazie detect ${'$'}m$ as a sentence?""")
         myFixture.checkHighlighting()
     }
 
@@ -76,9 +80,7 @@ class GrazieInspectionTest : BasePlatformTestCase() {
     }
 
     fun testMatchingParens() {
-        myFixture.configureByText(
-            LatexFileType, """A sentence (in this case). More sentence."""
-        )
+        myFixture.configureByText(LatexFileType, """A sentence (in this case). More sentence.""")
         myFixture.checkHighlighting()
     }
 
@@ -171,13 +173,11 @@ class GrazieInspectionTest : BasePlatformTestCase() {
      * To find a rule id, search for the name in https://community.languagetool.org/rule/list and use the id together with the prefex from LangTool.globalIdPrefix
      */
 
-
     fun testCommaInSentence() {
         GrazieConfig.update { it.copy(userEnabledRules = setOf("LanguageTool.EN.COMMA_PARENTHESIS_WHITESPACE")) }
         myFixture.configureByText(LatexFileType, """\label{fig} Similar to the structure presented in \autoref{fig}, it is.""")
         myFixture.checkHighlighting()
     }
-
 
     fun testCommandsInSentence() {
         GrazieConfig.update { it.copy(userEnabledRules = setOf("LanguageTool.EN.CONSECUTIVE_SPACES")) }
@@ -200,15 +200,18 @@ class GrazieInspectionTest : BasePlatformTestCase() {
     }
 
     fun testNewlinesShouldBeKept() {
-        val text =  """
+        val text = """
             \section{First}
             \section{Second}
         """.trimIndent()
         myFixture.configureByText(LatexFileType, text)
         val submittedText = getSubmittedText(myFixture.file)
-        assertEquals("""
+        assertEquals(
+            """
             First
             Second
-        """.trimIndent(), submittedText)
+            """.trimIndent(),
+            submittedText
+        )
     }
 }

--- a/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
@@ -31,17 +31,29 @@ class GrazieInspectionTest : BasePlatformTestCase() {
         }
     }
 
-    fun testCheckGrammarInConstructs() {
+    fun testSingleSentence() {
         myFixture.configureByText(LatexFileType, """Is these an error with a sentence ${'$'}\xi${'$'} end or not.""")
         myFixture.checkHighlighting()
-        val testName = getTestName(false)
-        myFixture.configureByFile("$testName.tex")
+    }
+
+    fun testCommentInText() {
+        myFixture.configureByText(LatexFileType, """
+            \begin{document}
+                All <GRAMMAR_ERROR descr="The verb 'is' is singular. Did you mean: this is or those are?">those is</GRAMMAR_ERROR> problems in the middle of a sentence.
+                % <GRAMMAR_ERROR descr="The verb 'is' is singular. Did you mean: this is or Those are?">Those is</GRAMMAR_ERROR> a problem in a comment
+                <GRAMMAR_ERROR descr="The verb 'is' is singular. Did you mean: this is or Those are?">Those is</GRAMMAR_ERROR> a problem at the beginning of a sentence.
+            \end{document}
+        """.trimIndent())
         myFixture.checkHighlighting(true, false, false, true)
     }
 
-    fun testMultilineCheckGrammar() {
-        val testName = getTestName(false)
-        myFixture.configureByFile("$testName.tex")
+    fun testSentenceAtEnvironmentStart() {
+        myFixture.configureByText(LatexFileType, """
+            \begin{document}
+                <GRAMMAR_ERROR descr="Use An instead of 'A' if the following word starts with a vowel sound, e.g. 'an article', 'an hour'.">A</GRAMMAR_ERROR> apple a day keeps the doctor away.
+                Some other sentence.
+            \end{document}
+        """.trimIndent())
         myFixture.checkHighlighting(true, false, false, true)
     }
 

--- a/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/grazie/GrazieInspectionTest.kt
@@ -142,18 +142,19 @@ class GrazieInspectionTest : BasePlatformTestCase() {
 
     /*
      * These rules are not enabled by default in Grazie Lite, but do show up by default in Grazie Pro.
+     * To find a rule id, search for the name in https://community.languagetool.org/rule/list and use the id together with the prefex from LangTool.globalIdPrefix
      */
 
 
     fun testCommaInSentence() {
-        GrazieConfig.update { it.copy(userEnabledRules = setOf("COMMA_PARENTHESIS_WHITESPACE")) }
+        GrazieConfig.update { it.copy(userEnabledRules = setOf("LanguageTool.EN.COMMA_PARENTHESIS_WHITESPACE")) }
         myFixture.configureByText(LatexFileType, """\label{fig} Similar to the structure presented in \autoref{fig}, it is.""")
         myFixture.checkHighlighting()
     }
 
 
     fun testCommandsInSentence() {
-        GrazieConfig.update { it.copy(userEnabledRules = setOf("CONSECUTIVE_SPACES")) }
+        GrazieConfig.update { it.copy(userEnabledRules = setOf("LanguageTool.EN.CONSECUTIVE_SPACES")) }
         myFixture.configureByText(LatexFileType, """The principles of a generic \ac{PID} controller.""")
         myFixture.checkHighlighting()
     }
@@ -188,4 +189,6 @@ class GrazieInspectionTest : BasePlatformTestCase() {
         val submittedText = getSubmittedText(text, ranges)
         assertEquals("A PID controller.", submittedText)
     }
+
+    // todo that one german test
 }

--- a/test/resources/inspections/grazie/CheckGrammarInConstructs.tex
+++ b/test/resources/inspections/grazie/CheckGrammarInConstructs.tex
@@ -1,5 +1,0 @@
-\begin{document}
-    All <GRAMMAR_ERROR descr="The verb 'is' is singular. Did you mean: this is or those are?">those is</GRAMMAR_ERROR> problems in the middle of a sentence.
-    % <GRAMMAR_ERROR descr="The verb 'is' is singular. Did you mean: this is or Those are?">Those is</GRAMMAR_ERROR> a problem in a comment
-    <GRAMMAR_ERROR descr="The verb 'is' is singular. Did you mean: this is or Those are?">Those is</GRAMMAR_ERROR> a problem at the beginning of a sentence.
-\end{document}

--- a/test/resources/inspections/grazie/MultilineCheckGrammar.tex
+++ b/test/resources/inspections/grazie/MultilineCheckGrammar.tex
@@ -1,4 +1,0 @@
-\begin{document}
-    <GRAMMAR_ERROR descr="Use An instead of 'A' if the following word starts with a vowel sound, e.g. 'an article', 'an hour'.">A</GRAMMAR_ERROR> apple a day keeps the doctor away.
-    Some other sentence.
-\end{document}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->


#### Summary of additions and changes

* Fix #3508: argument type of \gls commands
* Fix #3141: parameter text should be kept as it is usually part of a sentence
* Fix #3621: similar to previous one
* Fix #3494: Newlines may be crucial information to know that things are not part of the same sentence, so keep them
* Fix #3700: fix math environment check
* Disable Grazie in tabular as it contains no full sentences usually
