### PR TITLE
Search for external bib files in background

### DIFF
--- a/src/nl/hannahsten/texifyidea/index/file/LatexIndexableSetContributor.kt
+++ b/src/nl/hannahsten/texifyidea/index/file/LatexIndexableSetContributor.kt
@@ -17,6 +17,7 @@ import nl.hannahsten.texifyidea.util.getTexinputsPaths
 import nl.hannahsten.texifyidea.util.isTestProject
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.parser.requiredParameter
+import nl.hannahsten.texifyidea.util.runInBackground
 import org.codehaus.plexus.archiver.ArchiverException
 import org.codehaus.plexus.archiver.tar.TarBZip2UnArchiver
 import org.codehaus.plexus.archiver.tar.TarXZUnArchiver
@@ -73,31 +74,21 @@ class LatexIndexableSetContributor : IndexableSetContributor() {
         roots.addAll(getTexinputsPaths(project, rootFiles = listOf(), expandPaths = false).mapNotNull { LocalFileSystem.getInstance().findFileByPath(it) })
 
         // Using the index while building it may be problematic, cache the result and hope it doesn't create too much trouble
-        if (Cache.externalDirectFileInclusions == null) {
-            if (!DumbService.isDumb(project)) {
-                try {
-                    // For now, just do this for bibliography and direct input commands, as there this is most common
-                    val externalFiles = LatexIncludesIndex.Util.getCommandsByNames(CommandMagic.includeOnlyExtensions.entries.filter { it.value.contains("bib") || it.value.contains("tex") }.map { it.key }.toSet(), project, GlobalSearchScope.projectScope(project))
-                        // We can't add single files, so take the parent
-                        .mapNotNull {
-                            val path = it.requiredParameter(0) ?: return@mapNotNull null
-                            if (File(path).isAbsolute) {
-                                LocalFileSystem.getInstance().findFileByPath(path)?.parent
-                            }
-                            else {
-                                it.containingFile.parent?.virtualFile?.findFileByRelativePath(path)?.parent
-                            }
+        if (Cache.externalDirectFileInclusions == null && !DumbService.isDumb(project)) {
+            runInBackground(project, "Searching for external bib files...") {
+                // For now, just do this for bibliography and direct input commands, as there this is most common
+                val externalFiles = LatexIncludesIndex.Util.getCommandsByNames(CommandMagic.includeOnlyExtensions.entries.filter { it.value.contains("bib") || it.value.contains("tex") }.map { it.key }.toSet(), project, GlobalSearchScope.projectScope(project))
+                    // We can't add single files, so take the parent
+                    .mapNotNull {
+                        val path = it.requiredParameter(0) ?: return@mapNotNull null
+                        if (File(path).isAbsolute) {
+                            LocalFileSystem.getInstance().findFileByPath(path)?.parent
                         }
-                    Cache.externalDirectFileInclusions = externalFiles.toSet()
-                } catch (e: Throwable) {
-                    // This is very rare, but it can happen, in which case we will ignore and try again later
-                    if (e.message?.contains("Indexing process should not rely on non-indexed file data") == true) {
-                        Log.warn("Ignored index not ready: " + e.message)
+                        else {
+                            it.containingFile.parent?.virtualFile?.findFileByRelativePath(path)?.parent
+                        }
                     }
-                    else {
-                        throw e
-                    }
-                }
+                Cache.externalDirectFileInclusions = externalFiles.toSet()
             }
         }
         roots.addAll(Cache.externalDirectFileInclusions?.filter { it.exists() } ?: emptyList())


### PR DESCRIPTION
Attempt to avoid the "Indexing process should not rely on non-indexed file data" error, which is a java.lang.Throwable we cannot catch in Kotlin