### PR TITLE
Add sections to breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+* Add sections to breadcrumbs
 * Change order in structure view to match source file and sectioning level 
 * Add command redefinitions to command definition filter in structure view
 * Add support for automatic language injection on the minted environment

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexBreadcrumbsInfo.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexBreadcrumbsInfo.kt
@@ -22,7 +22,7 @@ open class LatexBreadcrumbsInfo : BreadcrumbsProvider {
 
     override fun getElementInfo(element: PsiElement) = when (element) {
         is LatexEnvironment -> element.name()?.text
-        is LatexCommands -> if (element.name in CommandMagic.sectioningCommands.map { it.cmd }) element.requiredParameter(0) ?: element.name else  element.name
+        is LatexCommands -> if (element.name in CommandMagic.sectioningCommands.map { it.cmd }) element.requiredParameter(0) ?: element.name else element.name
         else -> ""
     } ?: ""
 

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexBreadcrumbsInfo.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexBreadcrumbsInfo.kt
@@ -2,10 +2,14 @@ package nl.hannahsten.texifyidea.structure.latex
 
 import com.intellij.psi.PsiElement
 import com.intellij.ui.breadcrumbs.BreadcrumbsProvider
+import nl.hannahsten.texifyidea.editor.folding.LatexSectionFoldingBuilder
 import nl.hannahsten.texifyidea.grammar.LatexLanguage
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexEnvironment
+import nl.hannahsten.texifyidea.util.files.document
 import nl.hannahsten.texifyidea.util.parser.name
+import nl.hannahsten.texifyidea.util.parser.parents
+import nl.hannahsten.texifyidea.util.parser.requiredParameter
 
 /**
  * @author Hannah Schellekens
@@ -16,7 +20,7 @@ open class LatexBreadcrumbsInfo : BreadcrumbsProvider {
 
     override fun getElementInfo(element: PsiElement) = when (element) {
         is LatexEnvironment -> element.name()?.text
-        is LatexCommands -> element.commandToken.text
+        is LatexCommands -> if (element.name == "\\section") element.requiredParameter(0) else  element.name
         else -> ""
     } ?: ""
 
@@ -24,5 +28,18 @@ open class LatexBreadcrumbsInfo : BreadcrumbsProvider {
         is LatexEnvironment -> true
         is LatexCommands -> true
         else -> false
+    }
+
+    override fun getParent(element: PsiElement): PsiElement? {
+        val document = element.containingFile.document() ?: return super.getParent(element)
+        val parent = LatexSectionFoldingBuilder().buildFoldRegions(element.containingFile, document, quick = true)
+            // Only top-level elements in the section should have the section as parents, other elements should keep their direct parent (e.g. an environment)
+            .filter { it.range.contains(element.textRange) }
+            .filterNot { it.range.contains(element.parent.textRange) }
+            .firstOrNull { it.element.psi != element }
+            ?.element?.psi
+        // Avoid creating a loop
+        if (parent?.parents()?.contains(element) == true) { return super.getParent(element) }
+        return parent ?: super.getParent(element)
     }
 }

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexBreadcrumbsInfo.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexBreadcrumbsInfo.kt
@@ -38,11 +38,12 @@ open class LatexBreadcrumbsInfo : BreadcrumbsProvider {
         val parent = LatexSectionFoldingBuilder().buildFoldRegions(element.containingFile, document, quick = true)
             // Only top-level elements in the section should have the section as parents, other elements should keep their direct parent (e.g. an environment)
             .filter { it.range.contains(element.textRange ?: return@filter false) }
-            .filterNot { it.range.contains(element.parent.textRange ?: return@filterNot true) }
-            .firstOrNull { it.element.psi != element }
+            .filter { !it.range.contains(element.parent.textRange ?: return@filter false) }
+            // Avoid creating a loop
+            .filter { it.element.psi != element }
+            .filter { it.element.psi?.parents()?.contains(element) != true }
+            .minByOrNull { it.range.endOffset - it.range.startOffset }
             ?.element?.psi
-        // Avoid creating a loop
-        if (parent?.parents()?.contains(element) == true) { return super.getParent(element) }
         return parent ?: super.getParent(element)
     }
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3545, partially. I did not manage to get sections to stick properly: if I add elements to acceptElement so that sections will stick, then other things break, like environments sticking too much. So I guess the only way is to add sections to the parser, but for now I just want to test this a bit.
Breadcrumbs seem to work fine though.