### PR TITLE
Add checkboxes to graphic insertion wizard for relative width or height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+* Add checkboxes to graphic insertion wizard for relative width or height
 
 ### Fixed
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3550


#### Summary of additions and changes

* Hardcoded \linewidth and \textheight, also added option for keepaspectratio
