### PR TITLE
Fix parse error when using parentheses in a group in a key value command argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add checkboxes to graphic insertion wizard for relative width or height
 
 ### Fixed
+* Fix parse error when using parentheses in a group in a key value command argument
 
 ## [0.9.10-alpha.4] - 2024-12-21
 

--- a/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
+++ b/src/nl/hannahsten/texifyidea/grammar/Latex.bnf
@@ -165,7 +165,7 @@ parameter_group ::= OPEN_BRACE parameter_group_text CLOSE_BRACE { pin=1 }
 // Be sure to capture the whitespace before and after the actual content as groups are meant to capture
 // *everything* inside them.
 // This element is needed instead of parameter_text in order to avoid parse errors for various other tokens that do not appear in parameter_text because they are not usually part of the reference
-parameter_group_text ::= (parameter_text | group | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET)* { hooks = [wsBinders="GREEDY_LEFT_BINDER, GREEDY_RIGHT_BINDER"]  }
+parameter_group_text ::= (parameter_text | group | COMMA | EQUALS | OPEN_BRACKET | CLOSE_BRACKET | OPEN_PAREN | CLOSE_PAREN | OPEN_ANGLE_BRACKET | CLOSE_ANGLE_BRACKET)* { hooks = [wsBinders="GREEDY_LEFT_BINDER, GREEDY_RIGHT_BINDER"]  }
 
 comment ::= COMMENT_TOKEN
 

--- a/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
@@ -24,6 +24,8 @@ class LatexParserTest : BasePlatformTestCase() {
             ${'$'}\test{\cmd{a}[b]}${'$'}
             
             \newcolumntype{P}[1]{>{\raggedright\arraybackslash}p{#1}}
+            
+            \anycommand{test = {Some text with (Round Brackets)}}
             """.trimIndent()
         )
         myFixture.checkHighlighting()


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3575
