### PR TITLE
Fix parse error when using commands with arguments in parameter of \href or \url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add checkboxes to graphic insertion wizard for relative width or height
 
 ### Fixed
+* Fix parse error when using commands with arguments in parameter of \href or \url
 * Fix parse error when using parentheses in a group in a key value command argument
 
 ## [0.9.10-alpha.4] - 2024-12-21

--- a/src/nl/hannahsten/texifyidea/grammar/LatexLexer.flex
+++ b/src/nl/hannahsten/texifyidea/grammar/LatexLexer.flex
@@ -214,8 +214,10 @@ END_IFS=\\fi
 }
 
 <URL_VERBATIM> {
-    { OPEN_BRACE }      { verbatimUrlBracesCount++; return OPEN_BRACE; }
-    { CLOSE_BRACE }     { verbatimUrlBracesCount--; if (verbatimUrlBracesCount == 0) { yypopState(); } return CLOSE_BRACE; }
+    {OPEN_BRACE}        { verbatimUrlBracesCount++; return OPEN_BRACE; }
+    {CLOSE_BRACE}       { verbatimUrlBracesCount--; if (verbatimUrlBracesCount == 0) { yypopState(); } return CLOSE_BRACE; }
+    // There can be whitespace between command and argument
+    {WHITE_SPACE}       { return com.intellij.psi.TokenType.WHITE_SPACE; }
     {ANY_CHAR}          { return RAW_TEXT_TOKEN; }
     // Because the state is exclusive, we have to handle bad characters here as well (in case of an open \verb|... for example)
     [^]                 { return com.intellij.psi.TokenType.BAD_CHARACTER; }

--- a/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
@@ -26,6 +26,8 @@ class LatexParserTest : BasePlatformTestCase() {
             \newcolumntype{P}[1]{>{\raggedright\arraybackslash}p{#1}}
             
             \anycommand{test = {Some text with (Round Brackets)}}
+            
+            \href{\thefield{#%}}{#1}
             """.trimIndent()
         )
         myFixture.checkHighlighting()


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3613
