### PR TITLE
Fix parse erron when using inline math in cases* environment in inline math

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Fixed
 * Fix parse error when using parentheses in a group in a key value command argument
+* Fix parse erron when using inline math in cases* environment in inline math
+* 
 
 ## [0.9.10-alpha.4] - 2024-12-21
 

--- a/src/nl/hannahsten/texifyidea/grammar/LatexLexer.flex
+++ b/src/nl/hannahsten/texifyidea/grammar/LatexLexer.flex
@@ -135,7 +135,7 @@ START_IFS=\\if | \\ifcat | \\ifx | \\ifcase | \\ifnum | \\ifodd | \\ifhmode | \\
 ELSE=\\else
 END_IFS=\\fi
 
-%states INLINE_MATH INLINE_MATH_LATEX DISPLAY_MATH TEXT_INSIDE_INLINE_MATH NESTED_INLINE_MATH PARTIAL_DEFINITION
+%states INLINE_MATH INLINE_MATH_LATEX DISPLAY_MATH TEXT_INSIDE_INLINE_MATH NESTED_INLINE_MATH PARTIAL_DEFINITION ENVIRONMENT_INSIDE_INLINE_MATH
 %states NEW_ENVIRONMENT_DEFINITION_NAME NEW_ENVIRONMENT_DEFINITION NEW_ENVIRONMENT_SKIP_BRACE NEW_ENVIRONMENT_DEFINITION_END NEW_DOCUMENT_ENV_DEFINITION_NAME NEW_DOCUMENT_ENV_DEFINITION_ARGS_SPEC NEW_COMMAND_DEFINITION_PARAM1 NEW_COMMAND_DEFINITION_PARAM2
 
 // latex3 has some special syntax
@@ -462,12 +462,21 @@ END_IFS=\\fi
     // When already in inline math, when encountering a \text command we need to switch out of the math state
     // because if we encounter another $, then it will be an inline_math_start, not an inline_math_end
     \\text              { yypushState(TEXT_INSIDE_INLINE_MATH); return COMMAND_TOKEN; }
+    // Similarly, environments like cases* from mathtools have text as their second column, which can have inline math
+    // We cannot use a single token for inline math start and end because the parser will try to parse the one that should be an 'end' as a 'start'
+    // Therefore, to make sure that we cannot have a START \begin{cases*} END ... START \end{cases*} END, we use a separate state
+    {BEGIN_TOKEN}       { yypushState(ENVIRONMENT_INSIDE_INLINE_MATH); return BEGIN_TOKEN; }
 }
 
 // When in a \text in inline math, either start nested inline math or close the \text
 <TEXT_INSIDE_INLINE_MATH> {
     "$"                 { yypushState(NESTED_INLINE_MATH); return INLINE_MATH_START; }
     {CLOSE_BRACE}       { yypopState(); return CLOSE_BRACE; }
+}
+
+<ENVIRONMENT_INSIDE_INLINE_MATH> {
+    "$"                 { yypushState(NESTED_INLINE_MATH); return INLINE_MATH_START; }
+    {END_TOKEN}         { yypopState(); return END_TOKEN; }
 }
 
 <INLINE_MATH_LATEX> {

--- a/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
+++ b/test/nl/hannahsten/texifyidea/psi/LatexParserTest.kt
@@ -50,6 +50,11 @@ class LatexParserTest : BasePlatformTestCase() {
             LatexFileType,
             """
             $ math \text{ text $\xi$ text } math$
+            
+            $\begin{cases*}
+                 1 & if $ p \equiv 1 \pmod 4$ \\
+                 -1 & if $ p \equiv 3 \pmod 4$
+            \end{cases*}$ a
             """.trimIndent()
         )
         myFixture.checkHighlighting()


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3687

Only supports one level of nesting.