### PR TITLE
Remove unnecessary checks in structure presentation

### DIFF
--- a/src/nl/hannahsten/texifyidea/structure/latex/BibitemPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/BibitemPresentation.kt
@@ -14,10 +14,6 @@ class BibitemPresentation(labelCommand: LatexCommands) : ItemPresentation {
     private val locationString: String
 
     init {
-        if (labelCommand.commandToken.text != "\\bibitem") {
-            throw IllegalArgumentException("command is no \\bibitem-command")
-        }
-
         // Get label name.
         this.bibitemName = labelCommand.getRequiredParameters().firstOrNull() ?: ""
 

--- a/src/nl/hannahsten/texifyidea/structure/latex/BibitemPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/BibitemPresentation.kt
@@ -10,12 +10,11 @@ import nl.hannahsten.texifyidea.psi.LatexCommands
  */
 class BibitemPresentation(labelCommand: LatexCommands) : ItemPresentation {
 
-    private val bibitemName: String
+    // Get label name.
+    private val bibitemName = labelCommand.getRequiredParameters().firstOrNull() ?: ""
     private val locationString: String
 
     init {
-        // Get label name.
-        this.bibitemName = labelCommand.getRequiredParameters().firstOrNull() ?: ""
 
         // Location string.
         val manager = FileDocumentManager.getInstance()

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexChapterPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexChapterPresentation.kt
@@ -1,10 +1,8 @@
 package nl.hannahsten.texifyidea.structure.latex
 
 import nl.hannahsten.texifyidea.TexifyIcons
-import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.structure.EditableHintPresentation
-import nl.hannahsten.texifyidea.util.magic.cmd
 
 /**
  * @author Hannah Schellekens
@@ -15,10 +13,6 @@ class LatexChapterPresentation(chapterCommand: LatexCommands) : EditableHintPres
     private var hint = ""
 
     init {
-        if (chapterCommand.name != LatexGenericRegularCommand.CHAPTER.cmd) {
-            throw IllegalArgumentException("command is no \\chapter-command")
-        }
-
         this.chapterName = chapterCommand.getRequiredParameters().getOrElse(0) { "No chapter name" }
     }
 

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexChapterPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexChapterPresentation.kt
@@ -9,12 +9,8 @@ import nl.hannahsten.texifyidea.structure.EditableHintPresentation
  */
 class LatexChapterPresentation(chapterCommand: LatexCommands) : EditableHintPresentation {
 
-    private val chapterName: String
+    private val chapterName = chapterCommand.getRequiredParameters().getOrElse(0) { "No chapter name" }
     private var hint = ""
-
-    init {
-        this.chapterName = chapterCommand.getRequiredParameters().getOrElse(0) { "No chapter name" }
-    }
 
     override fun getPresentableText() = chapterName
 

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexIncludePresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexIncludePresentation.kt
@@ -10,11 +10,7 @@ import nl.hannahsten.texifyidea.util.parser.getIncludedFiles
  */
 class LatexIncludePresentation(labelCommand: LatexCommands) : ItemPresentation {
 
-    private val fileName: String
-
-    init {
-        this.fileName = labelCommand.getIncludedFiles(true).joinToString { it.name }
-    }
+    private val fileName = labelCommand.getIncludedFiles(true).joinToString { it.name }
 
     override fun getPresentableText() = fileName
 

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexIncludePresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexIncludePresentation.kt
@@ -4,7 +4,6 @@ import com.intellij.navigation.ItemPresentation
 import nl.hannahsten.texifyidea.TexifyIcons
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.util.parser.getIncludedFiles
-import nl.hannahsten.texifyidea.util.updateAndGetIncludeCommands
 
 /**
  * @author Hannah Schellekens
@@ -14,10 +13,6 @@ class LatexIncludePresentation(labelCommand: LatexCommands) : ItemPresentation {
     private val fileName: String
 
     init {
-        if (labelCommand.name !in updateAndGetIncludeCommands(labelCommand.project)) {
-            throw IllegalArgumentException("Command $labelCommand is no include command")
-        }
-
         this.fileName = labelCommand.getIncludedFiles(true).joinToString { it.name }
     }
 

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexLabelPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexLabelPresentation.kt
@@ -5,7 +5,6 @@ import com.intellij.openapi.fileEditor.FileDocumentManager
 import nl.hannahsten.texifyidea.TexifyIcons
 import nl.hannahsten.texifyidea.lang.alias.CommandManager
 import nl.hannahsten.texifyidea.psi.LatexCommands
-import nl.hannahsten.texifyidea.util.labels.getLabelDefinitionCommandsNoUpdate
 import nl.hannahsten.texifyidea.util.parser.requiredParameter
 
 /**
@@ -17,12 +16,6 @@ class LatexLabelPresentation(labelCommand: LatexCommands) : ItemPresentation {
     private val presentableText: String
 
     init {
-        val labelingCommands = getLabelDefinitionCommandsNoUpdate()
-        if (!labelingCommands.contains(labelCommand.commandToken.text)) {
-            val token = labelCommand.commandToken.text
-            throw IllegalArgumentException("command '$token' is no \\label-command")
-        }
-
         val position =
             CommandManager.labelAliasesInfo.getOrDefault(labelCommand.commandToken.text, null)?.positions?.firstOrNull()
                 ?: 0

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexParagraphPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexParagraphPresentation.kt
@@ -13,10 +13,6 @@ class LatexParagraphPresentation(paragraphCommand: LatexCommands) : EditableHint
     private var hint = ""
 
     init {
-        if (paragraphCommand.commandToken.text != "\\paragraph") {
-            throw IllegalArgumentException("command is no \\paragraph-command")
-        }
-
         if (paragraphCommand.getRequiredParameters().isEmpty()) {
             this.paragraphName = ""
         }

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexPartPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexPartPresentation.kt
@@ -13,10 +13,6 @@ class LatexPartPresentation(partCommand: LatexCommands) : EditableHintPresentati
     private var hint = ""
 
     init {
-        if (partCommand.commandToken.text != "\\part") {
-            throw IllegalArgumentException("command is no \\part-command")
-        }
-
         this.partName = partCommand.getRequiredParameters().firstOrNull() ?: "Unnamed part"
     }
 

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexPartPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexPartPresentation.kt
@@ -9,12 +9,8 @@ import nl.hannahsten.texifyidea.structure.EditableHintPresentation
  */
 class LatexPartPresentation(partCommand: LatexCommands) : EditableHintPresentation {
 
-    private val partName: String
+    private val partName = partCommand.getRequiredParameters().firstOrNull() ?: "Unnamed part"
     private var hint = ""
-
-    init {
-        this.partName = partCommand.getRequiredParameters().firstOrNull() ?: "Unnamed part"
-    }
 
     override fun getPresentableText() = partName
 

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexSectionPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexSectionPresentation.kt
@@ -9,12 +9,8 @@ import nl.hannahsten.texifyidea.structure.EditableHintPresentation
  */
 class LatexSectionPresentation(sectionCommand: LatexCommands) : EditableHintPresentation {
 
-    private val sectionName: String
+    private val sectionName = sectionCommand.getRequiredParameters().firstOrNull() ?: "Unnamed section"
     private var hint = ""
-
-    init {
-        this.sectionName = sectionCommand.getRequiredParameters().firstOrNull() ?: "Unnamed section"
-    }
 
     override fun getPresentableText() = sectionName
 

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexSectionPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexSectionPresentation.kt
@@ -13,10 +13,6 @@ class LatexSectionPresentation(sectionCommand: LatexCommands) : EditableHintPres
     private var hint = ""
 
     init {
-        if (sectionCommand.commandToken.text != "\\section") {
-            throw IllegalArgumentException("command is no \\section-command")
-        }
-
         this.sectionName = sectionCommand.getRequiredParameters().firstOrNull() ?: "Unnamed section"
     }
 

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexStructureViewCommandElement.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexStructureViewCommandElement.kt
@@ -4,10 +4,11 @@ import com.intellij.ide.structureView.StructureViewTreeElement
 import com.intellij.ide.util.treeView.smartTree.SortableTreeElement
 import com.intellij.ide.util.treeView.smartTree.TreeElement
 import com.intellij.navigation.NavigationItem
+import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.structure.EditableHintPresentation
+import nl.hannahsten.texifyidea.util.magic.cmd
 import nl.hannahsten.texifyidea.util.parser.nextCommand
-import java.util.*
 
 /**
  * @author Hannah Schellekens
@@ -18,7 +19,7 @@ class LatexStructureViewCommandElement private constructor(private val element: 
 
         @JvmStatic
         fun newCommand(commands: LatexCommands): LatexStructureViewCommandElement? {
-            if ("\\let" == commands.commandToken.text || "\\def" == commands.commandToken.text) {
+            if (LatexGenericRegularCommand.LET.cmd == commands.name || LatexGenericRegularCommand.DEF.cmd == commands.commandToken.text) {
                 val sibling = commands.nextCommand() ?: return null
 
                 return LatexStructureViewCommandElement(sibling)

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexSubParagraphPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexSubParagraphPresentation.kt
@@ -9,12 +9,8 @@ import nl.hannahsten.texifyidea.structure.EditableHintPresentation
  */
 class LatexSubParagraphPresentation(subParagraphCommand: LatexCommands) : EditableHintPresentation {
 
-    private val subParagraphName: String
+    private val subParagraphName = subParagraphCommand.getRequiredParameters().firstOrNull() ?: "Unknown subparagraph"
     private var hint = ""
-
-    init {
-        this.subParagraphName = subParagraphCommand.getRequiredParameters().firstOrNull() ?: "Unknown subparagraph"
-    }
 
     override fun getPresentableText() = subParagraphName
 

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexSubParagraphPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexSubParagraphPresentation.kt
@@ -13,10 +13,6 @@ class LatexSubParagraphPresentation(subParagraphCommand: LatexCommands) : Editab
     private var hint = ""
 
     init {
-        if (subParagraphCommand.name != "\\subparagraph") {
-            throw IllegalArgumentException("command is no \\subparagraph-command")
-        }
-
         this.subParagraphName = subParagraphCommand.getRequiredParameters().firstOrNull() ?: "Unknown subparagraph"
     }
 

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexSubSectionPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexSubSectionPresentation.kt
@@ -9,12 +9,8 @@ import nl.hannahsten.texifyidea.structure.EditableHintPresentation
  */
 class LatexSubSectionPresentation(sectionCommand: LatexCommands) : EditableHintPresentation {
 
-    private val subSectionName: String
+    private val subSectionName = sectionCommand.getRequiredParameters().firstOrNull() ?: "Unnamed subsection"
     private var hint = ""
-
-    init {
-        this.subSectionName = sectionCommand.getRequiredParameters().firstOrNull() ?: "Unnamed subsection"
-    }
 
     override fun getPresentableText() = subSectionName
 

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexSubSectionPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexSubSectionPresentation.kt
@@ -13,10 +13,6 @@ class LatexSubSectionPresentation(sectionCommand: LatexCommands) : EditableHintP
     private var hint = ""
 
     init {
-        if (sectionCommand.commandToken.text != "\\subsection") {
-            throw IllegalArgumentException("command is no \\subsection-command")
-        }
-
         this.subSectionName = sectionCommand.getRequiredParameters().firstOrNull() ?: "Unnamed subsection"
     }
 

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexSubSubSectionPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexSubSubSectionPresentation.kt
@@ -13,10 +13,6 @@ class LatexSubSubSectionPresentation(sectionCommand: LatexCommands) : EditableHi
     private var hint = ""
 
     init {
-        if (sectionCommand.commandToken.text != "\\subsubsection") {
-            throw IllegalArgumentException("command is no \\subsubsection-command")
-        }
-
         this.subSubSectionName = sectionCommand.getRequiredParameters().firstOrNull() ?: "Unnamed subsubsection"
     }
 

--- a/src/nl/hannahsten/texifyidea/structure/latex/LatexSubSubSectionPresentation.kt
+++ b/src/nl/hannahsten/texifyidea/structure/latex/LatexSubSubSectionPresentation.kt
@@ -9,12 +9,8 @@ import nl.hannahsten.texifyidea.structure.EditableHintPresentation
  */
 class LatexSubSubSectionPresentation(sectionCommand: LatexCommands) : EditableHintPresentation {
 
-    private val subSubSectionName: String
+    private val subSubSectionName = sectionCommand.getRequiredParameters().firstOrNull() ?: "Unnamed subsubsection"
     private var hint = ""
-
-    init {
-        this.subSubSectionName = sectionCommand.getRequiredParameters().firstOrNull() ?: "Unnamed subsubsection"
-    }
 
     override fun getPresentableText() = subSubSectionName
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3814, caused by mismatch between commandToken.text and .name, which is expected
