### PR TITLE
Don't crash inspection when index out of date, fixes #3853

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexIncorrectSectionNestingInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexIncorrectSectionNestingInspection.kt
@@ -41,7 +41,8 @@ open class LatexIncorrectSectionNestingInspection : TexifyInspectionBase() {
             .sortedBy { it.textOffset }
             .zipWithNext()
             .filter { (first, second) ->
-                first.commandName() in (commandToForbiddenPredecessors[second.commandName()] ?: error("Unexpected command ${second.commandName()} after ${first.commandName()}"))
+                first.isValid && second.isValid &&
+                    commandToForbiddenPredecessors[second.commandName()]?.contains(first.commandName()) == true
             }
             .map {
                 manager.createProblemDescriptor(


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3853 

#### Summary of additions and changes

* Don't crash when command is not one of the expected commands.

#### How to test this pull request
Unable to reproduce, but it seems likely that the index got out of date.

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary