### PR TITLE
Add support for the \includestandalone command, providing autocomplet…

### DIFF
--- a/src/nl/hannahsten/texifyidea/lang/LatexPackage.kt
+++ b/src/nl/hannahsten/texifyidea/lang/LatexPackage.kt
@@ -84,6 +84,7 @@ open class LatexPackage @JvmOverloads constructor(
         val SPLITIDX = LatexPackage("splitidx")
         val SPLITINDEX = LatexPackage("splitindex")
         val STMARYRD = LatexPackage("stmaryrd")
+        val STANDALONE = LatexPackage("standalone")
         val SUBFILES = LatexPackage("subfiles")
         val SVG = LatexPackage("svg")
         val TABULARRAY = LatexPackage("tabularray")

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexGenericRegularCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexGenericRegularCommand.kt
@@ -151,6 +151,7 @@ enum class LatexGenericRegularCommand(
     INPUTFROM("inputfrom", RequiredFolderArgument("absolute path"), RequiredFileArgument("filename", false, false, "tex"), dependency = LatexPackage.IMPORT),
     INPUTMINTED("inputminted", "language".asRequired(Argument.Type.MINTED_FUNTIME_LAND), RequiredFileArgument("sourcefile", true, false, ""), dependency = LatexPackage.MINTED),
     INCLUDEGRAPHICS("includegraphics", "key-val-list".asOptional(), RequiredPicturePathArgument("imagefile", isAbsolutePathSupported = true, commaSeparatesArguments = false, FileMagic.graphicFileExtensions, supportsAnyExtension = false), dependency = GRAPHICX),
+    INCLUDESTANDALONE("includestandalone", "mode".asOptional(), RequiredFileArgument("filename", false, false, "tex", *FileMagic.graphicFileExtensions.toTypedArray()), dependency = LatexPackage.STANDALONE),
     INCLUDEONLY("includeonly", RequiredFileArgument("sourcefile", false, true, "tex")),
     INCLUDESVG("includesvg", "options".asOptional(), RequiredPicturePathArgument("svg file", isAbsolutePathSupported = true, commaSeparatesArguments = false, extension = listOf("svg"), supportsAnyExtension = false), dependency = SVG),
     INDEXNAME("indexname", "name".asRequired()),

--- a/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
@@ -369,7 +369,8 @@ object CommandMagic {
      */
     val illegalExtensions = mapOf(
         INPUT.cmd to listOf(".tex"),
-        INCLUDE.cmd to listOf(".tex"),
+        INCLUDE.cmd to listOf(".tex") + FileMagic.graphicFileExtensions.map { ".$it" },
+        INCLUDESTANDALONE.cmd to listOf(".tex"),
         SUBFILEINCLUDE.cmd to listOf(".tex"),
         BIBLIOGRAPHY.cmd to listOf(".bib"),
         INCLUDEGRAPHICS.cmd to FileMagic.graphicFileExtensions.map { ".$it" }, // https://tex.stackexchange.com/a/1075/98850

--- a/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
+++ b/src/nl/hannahsten/texifyidea/util/magic/CommandMagic.kt
@@ -369,8 +369,8 @@ object CommandMagic {
      */
     val illegalExtensions = mapOf(
         INPUT.cmd to listOf(".tex"),
-        INCLUDE.cmd to listOf(".tex") + FileMagic.graphicFileExtensions.map { ".$it" },
-        INCLUDESTANDALONE.cmd to listOf(".tex"),
+        INCLUDE.cmd to listOf(".tex"),
+        INCLUDESTANDALONE.cmd to listOf(".tex") + FileMagic.graphicFileExtensions.map { ".$it" },
         SUBFILEINCLUDE.cmd to listOf(".tex"),
         BIBLIOGRAPHY.cmd to listOf(".bib"),
         INCLUDEGRAPHICS.cmd to FileMagic.graphicFileExtensions.map { ".$it" }, // https://tex.stackexchange.com/a/1075/98850


### PR DESCRIPTION
…ion and file referencing, fixes #3844

<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3844 

#### Summary of additions and changes

* Add support for the `\includestandalone` command, providing autocompletion and file referencing

#### How to test this pull request

main.tex
```latex
\documentclass{article}
\usepackage{standalone}

\begin{document}
    test
    \includestandalone[mode=buildmissing]{image}
\end{document}
```

image.tex
```latex
\documentclass[10pt,border=3mm]{standalone}
\usepackage{tikz}

\begin{document}
    \begin{tikzpicture}
        \draw (0,0) -- (0,5);
    \end{tikzpicture}
\end{document}
```

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary