### PR TITLE
Attempt to show notification of library sync error (fixes #3848)

### DIFF
--- a/src/nl/hannahsten/texifyidea/remotelibraries/RemoteBibLibrary.kt
+++ b/src/nl/hannahsten/texifyidea/remotelibraries/RemoteBibLibrary.kt
@@ -18,7 +18,7 @@ abstract class RemoteBibLibrary(open val identifier: String, open val displayNam
     companion object {
 
         fun showNotification(project: Project, libraryName: String, statusMessage: String) {
-            val title = "Could not connect to $libraryName"
+            val title = "Something went wrong when retrieving library from $libraryName"
             Notification("LaTeX", title, statusMessage, NotificationType.ERROR).notify(project)
         }
     }
@@ -33,7 +33,11 @@ abstract class RemoteBibLibrary(open val identifier: String, open val displayNam
 
         // Reading the dummy bib file needs to happen in a place where we have read access.
         runReadAction {
-            BibtexEntryListConverter().fromString(body)
+            try {
+                BibtexEntryListConverter().fromString(body)
+            } catch (e: Exception) {
+                raise(RemoteLibraryRequestFailure(displayName, body))
+            }
         }
     }
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3848 

#### Summary of additions and changes

Attempts to not fail without notification when getting an unexpected response from a remote library.

#### How to test this pull request
I'm not sure how to trigger an error, but have verified that logging into Mendeley and syncing the library still works.

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary