### PR TITLE
Improve log parsing of 'undefined control sequence'

### DIFF
--- a/src/nl/hannahsten/texifyidea/run/latex/logtab/LatexLogMessageExtractor.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/logtab/LatexLogMessageExtractor.kt
@@ -54,7 +54,7 @@ object LatexLogMessageExtractor {
 
         // Look for errors that need special treatment.
         specialErrorHandlersList.forEach { handler ->
-            if (handler.regex.any { it.containsMatchIn(text) }) {
+            if (handler.regex.any { it.containsMatchIn(textToMatch) }) {
                 return handler.findMessage(text, newText, currentFile)
             }
         }

--- a/src/nl/hannahsten/texifyidea/run/latex/logtab/LatexLogMessageExtractor.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/logtab/LatexLogMessageExtractor.kt
@@ -54,6 +54,7 @@ object LatexLogMessageExtractor {
 
         // Look for errors that need special treatment.
         specialErrorHandlersList.forEach { handler ->
+            // In cases of a broken up line, it could be we will only match on the lines joined together
             if (handler.regex.any { it.containsMatchIn(textToMatch) }) {
                 return handler.findMessage(text, newText, currentFile)
             }

--- a/src/nl/hannahsten/texifyidea/run/latex/logtab/LatexOutputListener.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/logtab/LatexOutputListener.kt
@@ -41,6 +41,8 @@ class LatexOutputListener(
                 !PACKAGE_WARNING_CONTINUATION.toRegex().containsMatchIn(secondLine) &&
                 // Assume the undefined control sequence always continues on the next line
                 !firstLine.trim().endsWith("Undefined control sequence.") &&
+                // And if 'Undefined control sequence' was broken up over line length, we can still check if the second line starts with the line number
+                !"^l\\.(\\d+)".toRegex().containsMatchIn(secondLine) &&
                 // Case of the first line pointing out something interesting on the second line
                 !(firstLine.endsWith(":") && secondLine.startsWith("    "))
         }

--- a/src/nl/hannahsten/texifyidea/run/latex/logtab/messagehandlers/errors/LatexUndefinedControlSequenceHandler.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/logtab/messagehandlers/errors/LatexUndefinedControlSequenceHandler.kt
@@ -10,8 +10,8 @@ object LatexUndefinedControlSequenceHandler : LatexMessageHandler(
     LatexLogMessageType.ERROR,
     // The last part (with line number and command) is optional because it may appear on the next line
     // Any line content may appear before the command which is undefined (which is the last thing on the line)
-    """^$FILE_LINE_REGEX (?<message>Undefined control sequence.)(\s*l.\d+[\s\S]*(?<command>\\\w+)$)?""".toRegex(),
-    """^$LATEX_ERROR_REGEX (?<message>Undefined control sequence\.)\s*l\.(?<line>\d+)\s*.*(?<command>\\\w+)${'$'}""".toRegex()
+    """^$FILE_LINE_REGEX (?<message>Undefined control sequence\.)(\s*l.\d+[\s\S]*(?<command>\\\w+)$)?""".toRegex(),
+    """^$LATEX_ERROR_REGEX (?<message>Undefined control sequence\.)(\s*l\.(?<line>\d+)\s*.*(?<command>\\\w+)$)?""".toRegex()
 ) {
 
     override fun findMessage(text: String, newText: String, currentFile: String?): LatexLogMessage? {

--- a/test/nl/hannahsten/texifyidea/run/logtab/LatexOutputListenerTest.kt
+++ b/test/nl/hannahsten/texifyidea/run/logtab/LatexOutputListenerTest.kt
@@ -532,7 +532,7 @@ class LatexOutputListenerTest : BasePlatformTestCase() {
 
         val expectedMessages = setOf(
             // Possible improvement: detecting line 4
-            LatexLogMessage("unexpected symbol near '3'.", "./main.tex", -1, ERROR)
+            LatexLogMessage("unexpected symbol near '3' \\directlua{3 = x}", "./main.tex", -1, ERROR)
         )
 
         testLog(log, expectedMessages)
@@ -556,7 +556,7 @@ class LatexOutputListenerTest : BasePlatformTestCase() {
             """.trimIndent()
 
         val expectedMessages = setOf(
-            LatexLogMessage("Undefined control sequence. \\IsTrue", "config/constants.tex", 70, ERROR)
+            LatexLogMessage("Undefined control sequence. \\PrintVersion \\IsTrue", "config/constants.tex", 70, ERROR)
         )
 
         testLog(log, expectedMessages)
@@ -798,7 +798,7 @@ ive/2020/texmf-dist/fonts/type1/public/amsfonts/cm/cmr10.pfb></home/thomas/texl
 
         val expectedMessages = setOf(
             LatexLogMessage("Undefined control sequence. \\bloop", "./nested/lipsum-one.tex", 9, ERROR),
-            LatexLogMessage("Undefined control sequence. \\cupt", "./hw5.tex", 79, ERROR)
+            LatexLogMessage("Undefined control sequence. \\cupt T$).", "./hw5.tex", 79, ERROR)
         )
 
         testLog(log, expectedMessages)
@@ -872,6 +872,8 @@ Document Class: article 2024/06/29 v1.4n Standard LaTeX document class
 [1{/usr/local/texlive/2024/texmf-var/fonts/map/pdftex/updmap/pdftex.map}]
 ./0_main.tex:23: Undefined control sequence.
 l.23     \asd
+...
+...
             """.trimIndent()
 
         val expectedMessages = setOf(
@@ -884,25 +886,17 @@ l.23     \asd
     fun `test long file name`() {
         val log =
             """
-This is pdfTeX, Version 3.141592653-2.6-1.40.26 (TeX Live 2024) (preloaded format=pdflatex)
- restricted \write18 enabled.
-entering extended mode
 (/home/thomas/GitRepos/random-tex-empty/src/main.tex
-LaTeX2e <2024-06-01> patch level 2
-L3 programming layer <2024-09-10>
-(/home/thomas/texlive/2024/texmf-dist/tex/latex/base/article.cls
-Document Class: article 2024/06/29 v1.4n Standard LaTeX document class
-(/home/thomas/texlive/2024/texmf-dist/tex/latex/base/size10.clo))
-(/home/thomas/texlive/2024/texmf-dist/tex/latex/l3backend/l3backend-pdftex.def)
- (/home/thomas/GitRepos/random-tex-empty/out/main.aux)
 [1{/home/thomas/texlive/2024/texmf-var/fonts/map/pdftex/updmap/pdftex.map}]
 /home/thomas/GitRepos/random-tex-empty/src/main.tex:22: Undefined control seque
 nce.
 l.22 	\asd
+...
+...
             """.trimIndent()
 
         val expectedMessages = setOf(
-            LatexLogMessage("Undefined control sequence. \\asd", "main.tex", 22, ERROR),
+            LatexLogMessage("Undefined control sequence \\asd", "/home/thomas/GitRepos/random-tex-empty/src/main.tex", 22, ERROR),
         )
 
         testLog(log, expectedMessages)

--- a/test/nl/hannahsten/texifyidea/run/logtab/LatexOutputListenerTest.kt
+++ b/test/nl/hannahsten/texifyidea/run/logtab/LatexOutputListenerTest.kt
@@ -556,7 +556,7 @@ class LatexOutputListenerTest : BasePlatformTestCase() {
             """.trimIndent()
 
         val expectedMessages = setOf(
-            LatexLogMessage("Undefined control sequence. \\PrintVersion", "config/constants.tex", 70, ERROR)
+            LatexLogMessage("Undefined control sequence. \\IsTrue", "config/constants.tex", 70, ERROR)
         )
 
         testLog(log, expectedMessages)
@@ -853,6 +853,56 @@ Latexmk: Summary of warnings from last run of *latex:
         val expectedMessages = setOf(
             LatexLogMessage("makeindex: file not writable for security reasons: /home/thomas/GitRepos/random-math/out/random-math.ind", null, -1, ERROR),
             LatexLogMessage("Can't create output index file /home/thomas/GitRepos/random-math/out/random-math.ind.", null, -1, ERROR),
+        )
+
+        testLog(log, expectedMessages)
+    }
+
+    fun `test updmap`() {
+        val log =
+            """
+(./0_main.tex
+LaTeX2e <2024-11-01> patch level 1
+L3 programming layer <2024-12-25>
+(/usr/local/texlive/2024/texmf-dist/tex/latex/base/article.cls
+Document Class: article 2024/06/29 v1.4n Standard LaTeX document class
+(/usr/local/texlive/2024/texmf-dist/tex/latex/base/size10.clo))
+(/usr/local/texlive/2024/texmf-dist/tex/latex/l3backend/l3backend-pdftex.def)
+(/Users/neal/Desktop/mwe/out/0_main.aux)
+[1{/usr/local/texlive/2024/texmf-var/fonts/map/pdftex/updmap/pdftex.map}]
+./0_main.tex:23: Undefined control sequence.
+l.23     \asd
+            """.trimIndent()
+
+        val expectedMessages = setOf(
+            LatexLogMessage("Undefined control sequence. \\asd", "./0_main.tex", 23, ERROR),
+        )
+
+        testLog(log, expectedMessages)
+    }
+
+    fun `test long file name`() {
+        val log =
+            """
+This is pdfTeX, Version 3.141592653-2.6-1.40.26 (TeX Live 2024) (preloaded format=pdflatex)
+ restricted \write18 enabled.
+entering extended mode
+(/home/thomas/GitRepos/random-tex-empty/src/main.tex
+LaTeX2e <2024-06-01> patch level 2
+L3 programming layer <2024-09-10>
+(/home/thomas/texlive/2024/texmf-dist/tex/latex/base/article.cls
+Document Class: article 2024/06/29 v1.4n Standard LaTeX document class
+(/home/thomas/texlive/2024/texmf-dist/tex/latex/base/size10.clo))
+(/home/thomas/texlive/2024/texmf-dist/tex/latex/l3backend/l3backend-pdftex.def)
+ (/home/thomas/GitRepos/random-tex-empty/out/main.aux)
+[1{/home/thomas/texlive/2024/texmf-var/fonts/map/pdftex/updmap/pdftex.map}]
+/home/thomas/GitRepos/random-tex-empty/src/main.tex:22: Undefined control seque
+nce.
+l.22 	\asd
+            """.trimIndent()
+
+        val expectedMessages = setOf(
+            LatexLogMessage("Undefined control sequence. \\asd", "main.tex", 22, ERROR),
         )
 
         testLog(log, expectedMessages)


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3847