### PR TITLE
Fix missing glossary reference inspection when using a glossary definition command in a \newcommand

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexMissingGlossaryReferenceInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexMissingGlossaryReferenceInspection.kt
@@ -30,8 +30,10 @@ class LatexMissingGlossaryReferenceInspection : TexifyInspectionBase() {
         file.childrenOfType<LatexNormalText>().forEach { textElement ->
             val text = textElement.text
             names.forEach { name ->
-                val correctOccurrences = "\\\\gls[^{]+\\{($name)}".toRegex().findAll(text).mapNotNull { it.groups.firstOrNull()?.range }
-                val allOccurrences = name.toRegex().findAll(text).map { it.range }
+                // Ensure the regex is valid, assuming that regular words don't contain e.g. braces
+                val nameLetters = name.replace("[^a-zA-Z]+".toRegex(), "")
+                val correctOccurrences = "\\\\gls[^{]+\\{($nameLetters)}".toRegex().findAll(text).mapNotNull { it.groups.firstOrNull()?.range }
+                val allOccurrences = nameLetters.toRegex().findAll(text).map { it.range }
                 allOccurrences.filter { !correctOccurrences.contains(it) }.forEach { range ->
                     descriptors.add(
                         manager.createProblemDescriptor(

--- a/src/nl/hannahsten/texifyidea/util/files/ReferencedFileSetCache.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/ReferencedFileSetCache.kt
@@ -170,6 +170,7 @@ class ReferencedFileSetCache {
         }
 
         // Make sure to check if file is still valid after retrieving from cache (it may have been deleted)
-        return cache[file.virtualFile.path]?.mapNotNull { it.element }?.filter { it.isValid }?.toSet() ?: setOf(file)
+        val fileset = cache[file.virtualFile.path]?.mapNotNull { it.element }?.filter { it.isValid }?.toSet()
+        return if (fileset.isNullOrEmpty())setOf(file) else fileset
     }
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexMissingGlossaryReferenceInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexMissingGlossaryReferenceInspectionTest.kt
@@ -20,4 +20,9 @@ class LatexMissingGlossaryReferenceInspectionTest : TexifyInspectionTestBase(Lat
             """.trimIndent()
         )
     }
+
+    fun testNewCommand() {
+        myFixture.configureByText(LatexFileType, """\newcommand{\mygls}{\newabbreviation{name}{\ensuremath{#1}}{long}} Some text""")
+        myFixture.checkHighlighting()
+    }
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3877