### PR TITLE
Let user defined folding regions override section folding regions by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 ### Added
 * Add environment variables option to the external tool run configuration
+* Let user defined folding regions override section folding regions by default
 
 ### Fixed
+* Fix missing glossary reference inspection when using a glossary definition command in a \newcommand
+* Improve log parsing of 'undefined control sequence' error
 * Fix a parsing issue when a verbatim command is followed by a space
 * Make language injection id check case insensitive
 * Fix exceptions #3843, #3853, #3852, #3846 and #3866

--- a/Writerside/topics/Editing-a-LaTeX-file.md
+++ b/Writerside/topics/Editing-a-LaTeX-file.md
@@ -229,6 +229,7 @@ The syntax `% !TeX parser = off` is also supported.
 ### Custom folding regions
 
 You can use either `%! region My description` and `%! endregion` or NetBeans-style `%! <editor-fold desc="My Description">` and `%! <editor-fold>` magic comments to specify custom folding regions.
+They cannot interleave with structural elements like environments or math, but as long as they are balanced they will override the default section folding regions.
 For more information, see [https://blog.jetbrains.com/idea/2012/03/custom-code-folding-regions-in-intellij-idea-111/](https://blog.jetbrains.com/idea/2012/03/custom-code-folding-regions-in-intellij-idea-111/) and [https://www.jetbrains.com/help/idea/code-folding-settings.html](https://www.jetbrains.com/help/idea/code-folding-settings.html)
 
 ### Fake sections

--- a/Writerside/topics/General.md
+++ b/Writerside/topics/General.md
@@ -14,6 +14,7 @@ You can for example fold sections, subsections, greek letters, etc.
 Note you can easily fold or collapse until a certain level using the menu or shortcuts.
 
 Which elements are folded by default can be configured in <ui-path>File | Settings | Editor | General | Code Folding | LaTeX</ui-path>.
+You can also use magic comments, to define custom folding regions, or modify the default sectioning folding regions, see [Magic Comments](Editing-a-LaTeX-file.md#custom-folding-regions).
 
 ![folding](folding.png)
 

--- a/src/nl/hannahsten/texifyidea/editor/folding/LatexSectionFoldingBuilder.kt
+++ b/src/nl/hannahsten/texifyidea/editor/folding/LatexSectionFoldingBuilder.kt
@@ -37,9 +37,8 @@ open class LatexSectionFoldingBuilder : FoldingBuilderEx() {
             .sortedBy { it.textOffset }
         val comments = root.childrenOfType<LatexMagicComment>().filter { it.key() == DefaultMagicKeys.FAKE }
         // If the user has a custom folding region interleaving with sections, e.g. spanning multiple sections but ending inside a section, we give the user priority over the default section folding (so that the user does not need to put fake sections everywhere)
-        val customRegions = root.childrenOfType<LatexMagicComment>().filter { it.key() == CustomMagicKey("region") || it.key() == CustomMagicKey("endregion") }
+        val customRegions = root.childrenOfType<LatexMagicComment>().filter { it.isStartRegion() || it.isEndRegion() }
         val sectionElements: List<PsiElement> = (commands + comments).sortedBy { it.textOffset }
-        val sectionAndRegionElements: List<PsiElement> = (sectionElements + customRegions).sortedBy { it.textOffset }
 
         if (sectionElements.isEmpty()) {
             return descriptors.toTypedArray()
@@ -57,58 +56,53 @@ open class LatexSectionFoldingBuilder : FoldingBuilderEx() {
         }
 
         for (currentFoldingCommand in sectionElements) {
-            var foundHigherCommand = false
             val currentCommandRank = sectionCommandNames.indexOf(currentFoldingCommand.name() ?: continue)
-
-            // Count nested regions
-            var customRegionCounter = 0
 
             // Find the 'deepest' section under currentFoldingCommand,
             // so when we find something that is equal or lower in rank
             // (a section is ranked lower than a subsection) then we
             // get the block of text between it and the currentFoldingCommand
-            for (nextFoldingCommand in sectionAndRegionElements.filter { it.startOffset > currentFoldingCommand.startOffset }) {
-                // Keep track of custom folding regions within a section that we should skip (we are looking for an endregion that starts before this section, and are assuming that these are balanced)
-                // todo now do the same for custom regions that are starting in this section but not ending here
-                if (nextFoldingCommand is LatexMagicComment) {
-                    if (nextFoldingCommand.key() == CustomMagicKey("region")) {
-                        customRegionCounter++
-                        continue
+            val nextElements = sectionElements.filter { it.startOffset > currentFoldingCommand.startOffset }
+            // If we found a command which is ranked lower, save the block of text inbetween
+            // Note that a section is ranked lower than a subsection
+            val sectionEnd = nextElements.firstOrNull { sectionCommandNames.indexOf(it.name()) <= currentCommandRank }
+
+            // Keep track of custom folding regions within a section that we should skip
+            // We are looking for an endregion that starts before this section, or a start region that ends after this section,
+            // so effectively we are looking for the first unmatched (within this section) region command
+            val firstUnmatchedRegion = customRegions
+                .filter { it.startOffset > currentFoldingCommand.startOffset }
+                .filter { if (sectionEnd == null) true else it.startOffset < sectionEnd.startOffset }
+                .fold(listOf<LatexMagicComment>()) { unmatchedIndices, comment ->
+                    if (comment.isStartRegion()) {
+                        unmatchedIndices + comment
                     }
-                    else if (nextFoldingCommand.key() == CustomMagicKey("endregion")) {
-                        customRegionCounter--
+                    // If the last one is an end, it is already not matched - don't remove it
+                    else if (unmatchedIndices.lastOrNull()?.isStartRegion() == true) {
+                        unmatchedIndices.dropLast(1)
                     }
-                    if (customRegionCounter >= 0) continue
+                    else {
+                        unmatchedIndices
+                    }
                 }
+                .firstOrNull()
 
-                // Find the rank of the next command to compare with the current rank
-                val nextCommandRank = sectionCommandNames.indexOf(nextFoldingCommand.name())
+            if (sectionEnd != null) {
+                // Get the location of the next folding command
+                val end = (firstUnmatchedRegion ?: sectionEnd).parentOfType(LatexNoMathContent::class)?.previousSiblingIgnoreWhitespace()
+                    ?: break
 
-                // If we found a command which is ranked lower, save the block of text inbetween
-                // Note that a section is ranked lower than a subsection
-                if (nextCommandRank <= currentCommandRank) {
-                    // Get the location of the next folding command
-                    val end = nextFoldingCommand.parentOfType(LatexNoMathContent::class)?.previousSiblingIgnoreWhitespace()
-                        ?: break
+                // Get the text range between the current and the next folding command
+                if (end.textOffset + end.textLength - currentFoldingCommand.textOffset > 0) {
+                    val foldingRange = TextRange(currentFoldingCommand.textOffset, end.textOffset + end.textLength)
 
-                    // Get the text range between the current and the next folding command
-                    if (end.textOffset + end.textLength - currentFoldingCommand.textOffset > 0) {
-                        val foldingRange = TextRange(currentFoldingCommand.textOffset, end.textOffset + end.textLength)
-
-                        // Add it as a folding block
-                        descriptors.add(FoldingDescriptor(currentFoldingCommand, foldingRange))
-                    }
-
-                    foundHigherCommand = true
-                    break
+                    // Add it as a folding block
+                    descriptors.add(FoldingDescriptor(currentFoldingCommand, foldingRange))
                 }
             }
-
-            /*
-             * If this item is the topmost level of the section structure or the last section marker,
-             * use the end of all text as the end of the range.
-             */
-            if (!foundHigherCommand) {
+            // If this item is the topmost level of the section structure or the last section marker,
+            // use the end of all text as the end of the range.
+            else {
                 val foldingContent = sectionElements.last().parentOfType(LatexNoMathContent::class) ?: continue
                 var nextContent: LatexNoMathContent? = foldingContent
                 var previousContent: LatexNoMathContent = foldingContent
@@ -116,10 +110,11 @@ open class LatexSectionFoldingBuilder : FoldingBuilderEx() {
                     previousContent = nextContent
                     nextContent = nextContent.nextSiblingIgnoreWhitespace() as? LatexNoMathContent
                 }
-                if (previousContent.textOffset + previousContent.textLength - currentFoldingCommand.textOffset > 0) {
+                val sectionEnd = firstUnmatchedRegion ?: previousContent
+                if (sectionEnd.textOffset + sectionEnd.textLength - currentFoldingCommand.textOffset > 0) {
                     val foldingRange = TextRange(
                         currentFoldingCommand.textOffset,
-                        previousContent.textOffset + previousContent.textLength
+                        sectionEnd.textOffset + sectionEnd.textLength
                     )
                     descriptors.add(FoldingDescriptor(currentFoldingCommand, foldingRange))
                 }
@@ -127,4 +122,7 @@ open class LatexSectionFoldingBuilder : FoldingBuilderEx() {
         }
         return descriptors.toTypedArray()
     }
+
+    private fun LatexMagicComment.isStartRegion(): Boolean = key() == CustomMagicKey("region")
+    private fun LatexMagicComment.isEndRegion(): Boolean = key() == CustomMagicKey("endregion")
 }

--- a/src/nl/hannahsten/texifyidea/editor/folding/LatexSectionFoldingBuilder.kt
+++ b/src/nl/hannahsten/texifyidea/editor/folding/LatexSectionFoldingBuilder.kt
@@ -82,7 +82,7 @@ open class LatexSectionFoldingBuilder : FoldingBuilderEx() {
                         unmatchedIndices.dropLast(1)
                     }
                     else {
-                        unmatchedIndices
+                        unmatchedIndices + comment
                     }
                 }
                 .firstOrNull()
@@ -110,11 +110,11 @@ open class LatexSectionFoldingBuilder : FoldingBuilderEx() {
                     previousContent = nextContent
                     nextContent = nextContent.nextSiblingIgnoreWhitespace() as? LatexNoMathContent
                 }
-                val sectionEnd = firstUnmatchedRegion ?: previousContent
-                if (sectionEnd.textOffset + sectionEnd.textLength - currentFoldingCommand.textOffset > 0) {
+                val endOffset = if (firstUnmatchedRegion != null) firstUnmatchedRegion.startOffset - 1 else previousContent.textOffset + previousContent.textLength
+                if (endOffset - currentFoldingCommand.textOffset > 0) {
                     val foldingRange = TextRange(
                         currentFoldingCommand.textOffset,
-                        sectionEnd.textOffset + sectionEnd.textLength
+                        endOffset
                     )
                     descriptors.add(FoldingDescriptor(currentFoldingCommand, foldingRange))
                 }

--- a/test/resources/editor/folding/sections.tex
+++ b/test/resources/editor/folding/sections.tex
@@ -6,4 +6,17 @@ Text.
 Text.</fold></fold>
 <fold text='\section{Three}...'>\section{Three}
 Text.</fold>
+<fold text='sections'>%! region sections
+<fold text='\section{introduction}...'>\section{introduction}
+\blindtext</fold>
+<fold text='\section{salient point}...'>\section{salient point}
+<fold text='section-content'>%! region section-content
+\blindtext
+%! endregion</fold></fold>
+%! endregion</fold>
+
+<fold text='references'>%! region references
+\newpage
+\printbibliography
+%! endregion</fold>
 </fold>\end{document}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3857

#### Summary of additions and changes

* Section folding region ends on the first region or endregion that has no match within the current section

#### How to test this pull request

```latex
\titleformat*{\section}{\itshape}
\begin{document}
\section{One}
Text.
\subsection{Two}
Text.
\section{Three}
Text.
%! region sections
\section{introduction}
\blindtext
\section{salient point}
%! region section-content
\blindtext
%! endregion
%! endregion

%! region references
\newpage
\printbibliography
%! endregion
\end{document}
```

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary