### PR TITLE
Fix shadowing implicit parameter of enclosing lambda

### DIFF
--- a/src/nl/hannahsten/texifyidea/index/IndexUtilBase.kt
+++ b/src/nl/hannahsten/texifyidea/index/IndexUtilBase.kt
@@ -122,7 +122,7 @@ abstract class IndexUtilBase<T : PsiElement>(
     fun getItems(project: Project, scope: GlobalSearchScope, useCache: Boolean = true): Collection<T> {
         if (useCache) {
             // Cached values may have become invalid over time, so do a double check to be sure (#2976)
-            cache[project]?.get(scope)?.let { return runReadAction { it.mapNotNull { pointer -> pointer.element }.filter { it.isValid } } }
+            cache[project]?.get(scope)?.let { return runReadAction { it.mapNotNull { pointer -> pointer.element }.filter(PsiElement::isValid) } }
         }
         val result = getKeys(project).flatMap { getItemsByName(it, project, scope) }
         runReadAction { cache.getOrPut(project) { mutableMapOf() }[scope] = result.map { it.createSmartPointer() } }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fixes maybe #3886?

#### Summary of additions and changes

* Removed an `it` from an inner lambda, the outer lambda also had implicit parameter `it`.

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary