### PR TITLE
Include \(\) as inline math for grazie text extraction, fixes #3878

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,7 +113,7 @@ dependencies {
         plugin("com.firsttimeinforever.intellij.pdf.viewer.intellij-pdf-viewer:0.17.0")
         plugin("com.jetbrains.hackathon.indices.viewer:1.29")
         // Does not work in tests: https://youtrack.jetbrains.com/issue/GRZ-5023
-//        plugin("com.intellij.grazie.pro:0.3.347")
+//        plugin("com.intellij.grazie.pro:0.3.359")
     }
 
     // Local dependencies

--- a/src/nl/hannahsten/texifyidea/inspections/grazie/LatexTextExtractor.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/grazie/LatexTextExtractor.kt
@@ -85,7 +85,7 @@ class LatexTextExtractor : TextExtractor() {
                 var end = text.textRange.endOffset - 1 - root.startOffset
                 // If LatexNormalText ends, for example because it is followed by a command, we do want to include the space in front of the command, since it is still typeset as a space, which is not true for the space after the command if the command has no arguments,
                 // except when the space is followed by inline math, since we ignore inline math altogether (which is probably not correct) we should also ignore the space
-                if (setOf(' ', '\n').contains(rootText.getOrNull(end + 1)) && rootText.getOrNull(end + 2) != '$') {
+                if (setOf(' ', '\n').contains(rootText.getOrNull(end + 1)) && rootText.getOrNull(end + 2) != '$' && rootText.substring(end + 2, end + 4) != "\\(") {
                     end += 1
                 }
                 listOf(start, end)


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3878 

#### Summary of additions and changes

* The text extraction only recognized `$...$` as inline math, but not `\(...\)`. This PR adds `\(...\)`.

#### How to test this pull request

```latex
\documentclass{article}

\begin{document}
    I have some variables \(v_0, v_1\) used in the text.
    I have some variables $v_0, v_1$ used in the text.
\end{document}
```

- [ ] Updated the documentation, or no update necessary
- [ ] Added tests, or no tests necessary