### PR TITLE
Default to 0.15.0 behaviour if inputs field is not found in Tectonic.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+* Default to 0.15.0 behaviour if inputs field is not found in Tectonic.toml
 
 ### Fixed
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "12.1.2"
 
     // Vulnerability scanning
-    id("org.owasp.dependencycheck") version "12.0.2"
+    id("org.owasp.dependencycheck") version "12.1.0"
 
     id("org.jetbrains.changelog") version "2.2.1"
 
@@ -143,13 +143,13 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.2")
 
     // Http requests
-    implementation("io.ktor:ktor-client-core:3.0.3")
-    implementation("io.ktor:ktor-client-cio:3.0.3")
-    implementation("io.ktor:ktor-client-auth:3.0.3")
-    implementation("io.ktor:ktor-client-content-negotiation:3.0.3")
-    implementation("io.ktor:ktor-server-core:3.0.3")
-    implementation("io.ktor:ktor-server-jetty-jakarta:3.0.3")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:3.0.3")
+    implementation("io.ktor:ktor-client-core:3.1.0")
+    implementation("io.ktor:ktor-client-cio:3.1.0")
+    implementation("io.ktor:ktor-client-auth:3.1.0")
+    implementation("io.ktor:ktor-client-content-negotiation:3.1.0")
+    implementation("io.ktor:ktor-server-core:3.1.0")
+    implementation("io.ktor:ktor-server-jetty-jakarta:3.1.0")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:3.1.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
 
     // Comparing versions
@@ -172,11 +172,11 @@ dependencies {
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.11.4")
 
     // Use junit 5 for test cases
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.4")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.12.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.11.4")
 
     // Enable use of the JUnitPlatform Runner within the IDE
-    testImplementation("org.junit.platform:junit-platform-runner:1.11.4")
+    testImplementation("org.junit.platform:junit-platform-runner:1.12.0")
 
     testImplementation("io.mockk:mockk:1.13.16")
 

--- a/src/nl/hannahsten/texifyidea/settings/sdk/TectonicSdk.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/TectonicSdk.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import nl.hannahsten.texifyidea.run.latex.LatexDistributionType
 import nl.hannahsten.texifyidea.util.runCommand
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion
 import java.io.File
 
 /**
@@ -17,6 +18,13 @@ class TectonicSdk : LatexSdk("Tectonic SDK") {
     object Cache {
         // Map readable file name (e.g. article.sty) to actual file path on disk
         var fileLocationCache: Map<String, String>? = null
+
+        val version by lazy {
+            val versionString = TectonicSdk().getVersionString("/usr/bin")
+            // For some reason, the current output I have is tectonic 0.15.0Tectonic 0.15.0
+            val versionMatch = Regex("""(\d+\.\d+\.\d+)""").find(versionString ?: "")?.groupValues?.get(1) ?: "0.0.0"
+            DefaultArtifactVersion(versionMatch)
+        }
     }
 
     /**

--- a/src/nl/hannahsten/texifyidea/util/files/FileSet.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/FileSet.kt
@@ -69,7 +69,8 @@ suspend fun findTectonicTomlInclusions(project: Project): List<Set<PsiFile>> {
         val output = (data.getOrDefault("output", null) as? List<*> ?: return@mapNotNull null).firstOrNull() as? Map<*, *>
         // The Inputs field was added after 0.15.0, at the moment of writing unreleased so we cannot check the version
         val inputs = if (output?.keys?.contains("inputs") == true) {
-            output.getOrDefault("inputs", listOf("_preamble.tex", "index.tex", "_postamble.tex")) as? List<*> ?: return@mapNotNull null
+            val inputListMaybe = output.getOrDefault("inputs", listOf("_preamble.tex", "index.tex", "_postamble.tex"))
+            if (inputListMaybe is String) listOf(inputListMaybe) else inputListMaybe as? List<*> ?: return@mapNotNull null
         }
         else {
             // See https://tectonic-typesetting.github.io/book/latest/ref/tectonic-toml.html#contents

--- a/src/nl/hannahsten/texifyidea/util/files/FileSet.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/FileSet.kt
@@ -66,8 +66,18 @@ suspend fun findTectonicTomlInclusions(project: Project): List<Set<PsiFile>> {
     val tomlFiles = smartReadAction(project) { findTectonicTomlFiles(project) }
     val filesets = tomlFiles.mapNotNull { tomlFile ->
         val data = TomlMapper().readValue(File(tomlFile.path), Map::class.java)
-        val outputList = data.getOrDefault("output", null) as? List<*> ?: return@mapNotNull null
-        val inputs = (outputList.firstOrNull() as? Map<*, *>)?.getOrDefault("inputs", null) as? List<*> ?: return@mapNotNull null
+        val output = (data.getOrDefault("output", null) as? List<*> ?: return@mapNotNull null).firstOrNull() as? Map<*, *>
+        // The Inputs field was added after 0.15.0, at the moment of writing unreleased so we cannot check the version
+        val inputs = if (output?.keys?.contains("inputs") == true) {
+            output.getOrDefault("inputs", listOf("_preamble.tex", "index.tex", "_postamble.tex")) as? List<*> ?: return@mapNotNull null
+        }
+        else {
+            // See https://tectonic-typesetting.github.io/book/latest/ref/tectonic-toml.html#contents
+            val preamble = output?.getOrDefault("preamble", "_preamble.tex") as? String ?: return@mapNotNull null
+            val index = output.getOrDefault("index", "index.tex") as? String ?: return@mapNotNull null
+            val postamble = output.getOrDefault("postamble", "_postamble.tex") as? String ?: return@mapNotNull null
+            listOf(preamble, index, postamble)
+        }
         // Inputs can be either a map "inline" -> String or file name
         // Actually it can also be just a single file name, but then we don't need all this gymnastics
         inputs.filterIsInstance<String>().mapNotNull {


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3879


Assumes that if inputs is present, the unreleased version is used