### PR TITLE
Add WSL support to the bibtex run configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+* Add WSL support to the bibtex run configuration, using a new setting to choose the LaTeX distribution
 * Default to 0.15.0 behaviour if inputs field is not found in Tectonic.toml
 
 ### Fixed

--- a/src/nl/hannahsten/texifyidea/run/bibtex/BibtexCommandLineState.kt
+++ b/src/nl/hannahsten/texifyidea/run/bibtex/BibtexCommandLineState.kt
@@ -8,7 +8,7 @@ import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.util.execution.ParametersListUtil
-import nl.hannahsten.texifyidea.run.compiler.LatexCompiler.Companion.toWslPath
+import nl.hannahsten.texifyidea.run.compiler.LatexCompiler.Companion.toWslPathIfNeeded
 import nl.hannahsten.texifyidea.run.latex.LatexDistributionType
 
 /**
@@ -34,7 +34,7 @@ open class BibtexCommandLineState(
                     .forEach { wslCommand += " $it" }
             }
 
-            wslCommand += " ${runConfig.bibWorkingDir?.path?.toWslPath(runConfig.getLatexDistributionType())}"
+            wslCommand += " ${runConfig.bibWorkingDir?.path?.toWslPathIfNeeded(runConfig.getLatexDistributionType())}"
 
             mutableListOf("bash", "-ic", wslCommand)
         }

--- a/src/nl/hannahsten/texifyidea/run/bibtex/BibtexCommandLineState.kt
+++ b/src/nl/hannahsten/texifyidea/run/bibtex/BibtexCommandLineState.kt
@@ -7,6 +7,9 @@ import com.intellij.execution.process.KillableProcessHandler
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.util.execution.ParametersListUtil
+import nl.hannahsten.texifyidea.run.compiler.LatexCompiler.Companion.toWslPath
+import nl.hannahsten.texifyidea.run.latex.LatexDistributionType
 
 /**
  * @author Sten Wessel
@@ -19,7 +22,25 @@ open class BibtexCommandLineState(
     @Throws(ExecutionException::class)
     override fun startProcess(): ProcessHandler {
         val compiler = runConfig.compiler ?: throw ExecutionException("No valid compiler specified.")
-        val command: List<String> = compiler.getCommand(runConfig, environment.project) ?: throw ExecutionException("Compile command could not be created.")
+        val compilerCommand = compiler.getCommand(runConfig, environment.project)?.toMutableList() ?: throw ExecutionException("Compile command could not be created.")
+
+        // See LatexCompiler#getCommand
+        val command = if (runConfig.getLatexDistributionType() == LatexDistributionType.WSL_TEXLIVE) {
+            var wslCommand = GeneralCommandLine(compilerCommand).commandLineString
+
+            // Custom compiler arguments specified by the user
+            runConfig.compilerArguments?.let { arguments ->
+                ParametersListUtil.parse(arguments)
+                    .forEach { wslCommand += " $it" }
+            }
+
+            wslCommand += " ${runConfig.bibWorkingDir?.path?.toWslPath(runConfig.getLatexDistributionType())}"
+
+            mutableListOf("bash", "-ic", wslCommand)
+        }
+        else {
+            compilerCommand
+        }
 
         // The working directory is as specified by the user in the working directory.
         // The fallback (if null or empty) directory is the directory of the main file.

--- a/src/nl/hannahsten/texifyidea/run/bibtex/BibtexSettingsEditor.kt
+++ b/src/nl/hannahsten/texifyidea/run/bibtex/BibtexSettingsEditor.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.ui.RawCommandLineEditor
 import com.intellij.ui.SeparatorComponent
 import nl.hannahsten.texifyidea.run.compiler.BibliographyCompiler
+import nl.hannahsten.texifyidea.run.latex.LatexDistributionType
 import java.awt.event.ItemEvent
 import javax.swing.JCheckBox
 import javax.swing.JComponent
@@ -33,6 +34,8 @@ class BibtexSettingsEditor(private val project: Project) : SettingsEditor<Bibtex
      * Is automatically set based on the LaTeX run config when created. */
     private lateinit var bibWorkingDir: LabeledComponent<TextFieldWithBrowseButton>
 
+    private lateinit var latexDistribution: LabeledComponent<ComboBox<LatexDistributionType>>
+
     override fun createEditor(): JComponent {
         createUIComponents()
         return panel
@@ -46,6 +49,7 @@ class BibtexSettingsEditor(private val project: Project) : SettingsEditor<Bibtex
         enableCompilerPath.isSelected = runConfig.compilerPath != null
         mainFile.component.text = runConfig.mainFile?.path ?: ""
         bibWorkingDir.component.text = runConfig.bibWorkingDir?.path ?: ""
+        latexDistribution.component.selectedItem = runConfig.latexDistribution
     }
 
     override fun applyEditorTo(runConfig: BibtexRunConfiguration) {
@@ -55,6 +59,7 @@ class BibtexSettingsEditor(private val project: Project) : SettingsEditor<Bibtex
         runConfig.environmentVariables = environmentVariables.envData
         runConfig.mainFile = if (mainFile.component.text.isNotBlank()) LocalFileSystem.getInstance().findFileByPath(mainFile.component.text) else null
         runConfig.bibWorkingDir = if (bibWorkingDir.component.text.isNotBlank()) LocalFileSystem.getInstance().findFileByPath(bibWorkingDir.component.text) else null
+        runConfig.latexDistribution = latexDistribution.component.selectedItem as LatexDistributionType? ?: LatexDistributionType.PROJECT_SDK
     }
 
     private fun createUIComponents() {
@@ -132,6 +137,11 @@ class BibtexSettingsEditor(private val project: Project) : SettingsEditor<Bibtex
             )
             bibWorkingDir = LabeledComponent.create(workingDirField, "Working directory for bibtex")
             add(bibWorkingDir)
+
+            // LaTeX distribution, use project SDK as backwards compatible default
+            @Suppress("DialogTitleCapitalization")
+            latexDistribution = LabeledComponent.create(ComboBox(LatexDistributionType.entries.filter { it.isAvailable(project) }.toTypedArray() + arrayOf(LatexDistributionType.PROJECT_SDK)), "LaTeX Distribution")
+            panel.add(latexDistribution)
         }
     }
 }

--- a/src/nl/hannahsten/texifyidea/run/bibtex/BibtexSettingsEditor.kt
+++ b/src/nl/hannahsten/texifyidea/run/bibtex/BibtexSettingsEditor.kt
@@ -141,7 +141,7 @@ class BibtexSettingsEditor(private val project: Project) : SettingsEditor<Bibtex
             // LaTeX distribution, use project SDK as backwards compatible default
             @Suppress("DialogTitleCapitalization")
             latexDistribution = LabeledComponent.create(ComboBox(LatexDistributionType.entries.filter { it.isAvailable(project) }.toTypedArray() + arrayOf(LatexDistributionType.PROJECT_SDK)), "LaTeX Distribution")
-            panel.add(latexDistribution)
+            add(latexDistribution)
         }
     }
 }

--- a/src/nl/hannahsten/texifyidea/run/compiler/BiberCompiler.kt
+++ b/src/nl/hannahsten/texifyidea/run/compiler/BiberCompiler.kt
@@ -4,7 +4,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.util.execution.ParametersListUtil
 import nl.hannahsten.texifyidea.run.bibtex.BibtexRunConfiguration
 import nl.hannahsten.texifyidea.run.compiler.LatexCompiler.Companion.toWslPathIfNeeded
-import nl.hannahsten.texifyidea.run.latex.LatexDistributionType
 
 /**
  * @author Thomas Schouten

--- a/src/nl/hannahsten/texifyidea/run/compiler/BiberCompiler.kt
+++ b/src/nl/hannahsten/texifyidea/run/compiler/BiberCompiler.kt
@@ -3,6 +3,8 @@ package nl.hannahsten.texifyidea.run.compiler
 import com.intellij.openapi.project.Project
 import com.intellij.util.execution.ParametersListUtil
 import nl.hannahsten.texifyidea.run.bibtex.BibtexRunConfiguration
+import nl.hannahsten.texifyidea.run.compiler.LatexCompiler.Companion.toWslPathIfNeeded
+import nl.hannahsten.texifyidea.run.latex.LatexDistributionType
 
 /**
  * @author Thomas Schouten
@@ -18,7 +20,8 @@ internal object BiberCompiler : Compiler<BibtexRunConfiguration> {
         // Biber can find auxiliary files, but the flag is different from bibtex.
         // The following flag assumes the command is executed in the directory where the .bcf control file is.
         // The extra directory added is the directory from which the path to the .bib resource file is searched as specified in the .bcf file.
-        add("--input-directory=${runConfig.mainFile?.parent?.path ?: ""}")
+        val mainPath = runConfig.mainFile?.parent?.path?.toWslPathIfNeeded(runConfig.getLatexDistributionType()) ?: ""
+        add("--input-directory=$mainPath")
 
         runConfig.compilerArguments?.let { addAll(ParametersListUtil.parse(it)) }
 

--- a/src/nl/hannahsten/texifyidea/run/compiler/BibtexCompiler.kt
+++ b/src/nl/hannahsten/texifyidea/run/compiler/BibtexCompiler.kt
@@ -30,7 +30,7 @@ internal object BibtexCompiler : Compiler<BibtexRunConfiguration> {
             // We (mis)use project SDK as default setting for backwards compatibility
             if ((runConfig.getLatexDistributionType() == LatexDistributionType.PROJECT_SDK && LatexSdkUtil.isMiktexAvailable) || runConfig.getLatexDistributionType().isMiktex(project)) {
                 val mainPath = runConfig.mainFile?.parent?.path?.toWslPathIfNeeded(runConfig.getLatexDistributionType()) ?: ""
-                add("-include-directory=${mainPath}")
+                add("-include-directory=$mainPath")
                 addAll(moduleRoots.map { "-include-directory=${it.path.toWslPathIfNeeded(runConfig.getLatexDistributionType())}" })
             }
 

--- a/src/nl/hannahsten/texifyidea/run/compiler/BibtexCompiler.kt
+++ b/src/nl/hannahsten/texifyidea/run/compiler/BibtexCompiler.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.util.execution.ParametersListUtil
 import nl.hannahsten.texifyidea.run.bibtex.BibtexRunConfiguration
+import nl.hannahsten.texifyidea.run.compiler.LatexCompiler.Companion.toWslPathIfNeeded
 import nl.hannahsten.texifyidea.run.latex.LatexDistributionType
 import nl.hannahsten.texifyidea.settings.sdk.LatexSdkUtil
 
@@ -28,8 +29,9 @@ internal object BibtexCompiler : Compiler<BibtexRunConfiguration> {
             // Include files from auxiliary directory on Windows
             // We (mis)use project SDK as default setting for backwards compatibility
             if ((runConfig.getLatexDistributionType() == LatexDistributionType.PROJECT_SDK && LatexSdkUtil.isMiktexAvailable) || runConfig.getLatexDistributionType().isMiktex(project)) {
-                add("-include-directory=${runConfig.mainFile?.parent?.path ?: ""}")
-                addAll(moduleRoots.map { "-include-directory=${it.path}" })
+                val mainPath = runConfig.mainFile?.parent?.path?.toWslPathIfNeeded(runConfig.getLatexDistributionType()) ?: ""
+                add("-include-directory=${mainPath}")
+                addAll(moduleRoots.map { "-include-directory=${it.path.toWslPathIfNeeded(runConfig.getLatexDistributionType())}" })
             }
 
             add(runConfig.mainFile?.nameWithoutExtension ?: return null)

--- a/src/nl/hannahsten/texifyidea/run/compiler/BibtexCompiler.kt
+++ b/src/nl/hannahsten/texifyidea/run/compiler/BibtexCompiler.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.util.execution.ParametersListUtil
 import nl.hannahsten.texifyidea.run.bibtex.BibtexRunConfiguration
+import nl.hannahsten.texifyidea.run.latex.LatexDistributionType
 import nl.hannahsten.texifyidea.settings.sdk.LatexSdkUtil
 
 /**
@@ -25,7 +26,8 @@ internal object BibtexCompiler : Compiler<BibtexRunConfiguration> {
             runConfig.compilerArguments?.let { addAll(ParametersListUtil.parse(it)) }
 
             // Include files from auxiliary directory on Windows
-            if (LatexSdkUtil.isMiktexAvailable) {
+            // We (mis)use project SDK as default setting for backwards compatibility
+            if ((runConfig.getLatexDistributionType() == LatexDistributionType.PROJECT_SDK && LatexSdkUtil.isMiktexAvailable) || runConfig.getLatexDistributionType().isMiktex(project)) {
                 add("-include-directory=${runConfig.mainFile?.parent?.path ?: ""}")
                 addAll(moduleRoots.map { "-include-directory=${it.path}" })
             }

--- a/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
+++ b/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
@@ -277,15 +277,6 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
     ;
 
     /**
-     * Convert Windows paths to WSL paths.
-     */
-    private fun String.toPath(runConfig: LatexRunConfiguration): String =
-        if (runConfig.getLatexDistributionType() == LatexDistributionType.WSL_TEXLIVE) {
-            runCommand("wsl", "wslpath", "-a", this) ?: this
-        }
-        else this
-
-    /**
      * Get the execution command for the latex compiler.
      *
      * @param runConfig
@@ -315,7 +306,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
             "/out"
         }
         else {
-            runConfig.outputPath.getAndCreatePath()?.path?.toPath(runConfig)
+            runConfig.outputPath.getAndCreatePath()?.path?.toWslPath(runConfig.getLatexDistributionType())
         }
 
         val auxilPath = if (runConfig.getLatexDistributionType() == LatexDistributionType.DOCKER_MIKTEX) {
@@ -325,7 +316,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
             null
         }
         else {
-            runConfig.auxilPath.getAndCreatePath()?.path?.toPath(runConfig)
+            runConfig.auxilPath.getAndCreatePath()?.path?.toWslPath(runConfig.getLatexDistributionType())
         }
 
         val command = createCommand(
@@ -345,7 +336,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
                     .forEach { wslCommand += " $it" }
             }
 
-            wslCommand += " ${mainFile.path.toPath(runConfig)}"
+            wslCommand += " ${mainFile.path.toWslPath(runConfig.getLatexDistributionType())}"
 
             return mutableListOf("bash", "-ic", wslCommand)
         }
@@ -481,6 +472,15 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
                 it.executableName.equals(exe, true)
             } ?: PDFLATEX
         }
+
+        /**
+         * Convert Windows paths to WSL paths.
+         */
+        fun String.toWslPath(distributionType: LatexDistributionType): String =
+            if (distributionType == LatexDistributionType.WSL_TEXLIVE) {
+                runCommand("wsl", "wslpath", "-a", this) ?: this
+            }
+            else this
     }
 
     /**

--- a/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
+++ b/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
@@ -306,7 +306,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
             "/out"
         }
         else {
-            runConfig.outputPath.getAndCreatePath()?.path?.toWslPath(runConfig.getLatexDistributionType())
+            runConfig.outputPath.getAndCreatePath()?.path?.toWslPathIfNeeded(runConfig.getLatexDistributionType())
         }
 
         val auxilPath = if (runConfig.getLatexDistributionType() == LatexDistributionType.DOCKER_MIKTEX) {
@@ -316,7 +316,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
             null
         }
         else {
-            runConfig.auxilPath.getAndCreatePath()?.path?.toWslPath(runConfig.getLatexDistributionType())
+            runConfig.auxilPath.getAndCreatePath()?.path?.toWslPathIfNeeded(runConfig.getLatexDistributionType())
         }
 
         val command = createCommand(
@@ -336,7 +336,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
                     .forEach { wslCommand += " $it" }
             }
 
-            wslCommand += " ${mainFile.path.toWslPath(runConfig.getLatexDistributionType())}"
+            wslCommand += " ${mainFile.path.toWslPathIfNeeded(runConfig.getLatexDistributionType())}"
 
             return mutableListOf("bash", "-ic", wslCommand)
         }
@@ -476,7 +476,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
         /**
          * Convert Windows paths to WSL paths.
          */
-        fun String.toWslPath(distributionType: LatexDistributionType): String =
+        fun String.toWslPathIfNeeded(distributionType: LatexDistributionType): String =
             if (distributionType == LatexDistributionType.WSL_TEXLIVE) {
                 runCommand("wsl", "wslpath", "-a", this) ?: this
             }

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
@@ -420,6 +420,7 @@ class LatexRunConfiguration(
         if (compilerArguments != null) bibtexRunConfiguration.compilerArguments = compilerArguments
         bibtexRunConfiguration.mainFile = mainFile
         bibtexRunConfiguration.setSuggestedName()
+        bibtexRunConfiguration.setDefaultDistribution(latexDistribution)
 
         // On non-MiKTeX systems, add bibinputs for bibtex to work
         if (!latexDistribution.isMiktex(project)) {


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3891

When updating from an older version, project sdk will be selected. When a bibtex run config is created by the latex run config, the distribution from the latex run config is used.