### PR TITLE
Add \ohm to autocomplete, fixes #3916

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspection.kt
@@ -216,9 +216,9 @@ class LatexUnicodeInspection : TexifyInspectionBase() {
                     document?.psiFile(project)?.insertUsepackage(pkg)
                 }
 
-                // TODO check fix-all
                 val command = replacement.firstChildOfType(LatexContent::class) ?: return@runWriteCommandAction
-                element.parent?.node?.replaceChild(element.parent.firstChild.node, command.node)
+                val unicodeElement = descriptor.psiElement.findElementAt(descriptor.textRangeInElement.startOffset) ?: return@runWriteCommandAction
+                unicodeElement.parent?.node?.replaceChild(unicodeElement.node, command.node)
             }
         }
 

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspection.kt
@@ -14,7 +14,6 @@ import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.psi.util.parentOfType
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
@@ -22,10 +21,8 @@ import nl.hannahsten.texifyidea.lang.Diacritic
 import nl.hannahsten.texifyidea.lang.commands.LatexCommand
 import nl.hannahsten.texifyidea.lang.commands.LatexMathCommand
 import nl.hannahsten.texifyidea.lang.commands.LatexRegularCommand
-import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexContent
 import nl.hannahsten.texifyidea.psi.LatexMathEnvironment
-import nl.hannahsten.texifyidea.psi.LatexNoMathContent
 import nl.hannahsten.texifyidea.psi.LatexNormalText
 import nl.hannahsten.texifyidea.psi.LatexPsiHelper
 import nl.hannahsten.texifyidea.run.compiler.LatexCompiler
@@ -34,8 +31,6 @@ import nl.hannahsten.texifyidea.settings.sdk.TexliveSdk
 import nl.hannahsten.texifyidea.util.files.psiFile
 import nl.hannahsten.texifyidea.util.includedPackages
 import nl.hannahsten.texifyidea.util.insertUsepackage
-import nl.hannahsten.texifyidea.util.magic.CommandMagic
-import nl.hannahsten.texifyidea.util.magic.EnvironmentMagic
 import nl.hannahsten.texifyidea.util.magic.PackageMagic
 import nl.hannahsten.texifyidea.util.magic.PatternMagic
 import nl.hannahsten.texifyidea.util.parser.findDependencies

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexSiunitxCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexSiunitxCommand.kt
@@ -20,6 +20,7 @@ enum class LatexSiunitxCommand(
     UNIT("unit", "options".asOptional(), "unit".asRequired(), dependency = SIUNITX),
     QTY("qty", "options".asOptional(), "number".asRequired(), "unit".asRequired(), dependency = SIUNITX),
     MICRO("micro", display = "µ", dependency = SIUNITX),
+    OHM("ohm", display = "Ω", dependency = SIUNITX),
     NUMLIST("numlist", "options".asOptional(), "numbers".asRequired(), dependency = SIUNITX),
     NUMPRODUCT("numproduct", "options".asOptional(), "numbers".asRequired(), dependency = SIUNITX),
     NUMRANGE("numrange", "options".asOptional(), "number1".asRequired(), "number2".asRequired(), dependency = SIUNITX),

--- a/src/nl/hannahsten/texifyidea/util/parser/LatexPsiUtil.kt
+++ b/src/nl/hannahsten/texifyidea/util/parser/LatexPsiUtil.kt
@@ -4,7 +4,6 @@ import com.intellij.codeInsight.PsiEquivalenceUtil
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiRecursiveElementVisitor
-import com.jetbrains.rhizomedb.lookup
 import nl.hannahsten.texifyidea.file.LatexFile
 import nl.hannahsten.texifyidea.lang.Environment
 import nl.hannahsten.texifyidea.lang.LatexPackage

--- a/src/nl/hannahsten/texifyidea/util/parser/LatexPsiUtil.kt
+++ b/src/nl/hannahsten/texifyidea/util/parser/LatexPsiUtil.kt
@@ -165,9 +165,9 @@ fun PsiElement.findOccurrences(searchRoot: PsiElement): List<LatexExtractablePSI
 }
 
 fun PsiElement.findDependencies(): Set<LatexPackage> {
-    val commandsDependencies = this.childrenOfType<LatexCommands>(true)
+    val commandsDependencies = this.childrenOfType<LatexCommands>()
         .mapNotNull { LatexCommand.lookup(it)?.firstOrNull()?.dependency }
-    val environmentDependencies = this.childrenOfType<LatexEnvironment>(true)
+    val environmentDependencies = this.childrenOfType<LatexEnvironment>()
         .mapNotNull { Environment.lookup(it.getEnvironmentName())?.dependency }
 
     return (commandsDependencies + environmentDependencies).filter { it.isDefault.not() }.toSet()

--- a/src/nl/hannahsten/texifyidea/util/parser/LatexPsiUtil.kt
+++ b/src/nl/hannahsten/texifyidea/util/parser/LatexPsiUtil.kt
@@ -4,8 +4,11 @@ import com.intellij.codeInsight.PsiEquivalenceUtil
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiRecursiveElementVisitor
+import com.jetbrains.rhizomedb.lookup
 import nl.hannahsten.texifyidea.file.LatexFile
 import nl.hannahsten.texifyidea.lang.Environment
+import nl.hannahsten.texifyidea.lang.LatexPackage
+import nl.hannahsten.texifyidea.lang.commands.LatexCommand
 import nl.hannahsten.texifyidea.psi.*
 import nl.hannahsten.texifyidea.util.files.commandsInFileSet
 
@@ -160,4 +163,13 @@ fun PsiElement.findOccurrences(searchRoot: PsiElement): List<LatexExtractablePSI
     }
     searchRoot.acceptChildren(visitor)
     return visitor.foundOccurrences.map { it.asExtractable() }
+}
+
+fun PsiElement.findDependencies(): Set<LatexPackage> {
+    val commandsDependencies = this.childrenOfType<LatexCommands>(true)
+        .mapNotNull { LatexCommand.lookup(it)?.firstOrNull()?.dependency }
+    val environmentDependencies = this.childrenOfType<LatexEnvironment>(true)
+        .mapNotNull { Environment.lookup(it.getEnvironmentName())?.dependency }
+
+    return (commandsDependencies + environmentDependencies).filter { it.isDefault.not() }.toSet()
 }

--- a/src/nl/hannahsten/texifyidea/util/parser/Psi.kt
+++ b/src/nl/hannahsten/texifyidea/util/parser/Psi.kt
@@ -30,18 +30,13 @@ fun PsiElement.lineNumber(): Int? = containingFile.document()?.getLineNumber(tex
 /**
  * @see [PsiTreeUtil.getChildrenOfType]
  */
-fun <T : PsiElement> PsiElement.childrenOfType(clazz: KClass<T>, recursive: Boolean = false): Collection<T> {
+fun <T : PsiElement> PsiElement.childrenOfType(clazz: KClass<T>): Collection<T> {
     return runReadAction {
         if (!this.isValid || project.isDisposed) {
             emptyList()
         }
         else {
-            val directChildren = PsiTreeUtil.findChildrenOfType(this, clazz.java)
-            if (recursive) {
-                directChildren + children.flatMap { it.childrenOfType(clazz, true) }
-            } else {
-                directChildren
-            }
+            PsiTreeUtil.findChildrenOfType(this, clazz.java)
         }
     }
 }
@@ -49,7 +44,7 @@ fun <T : PsiElement> PsiElement.childrenOfType(clazz: KClass<T>, recursive: Bool
 /**
  * @see [PsiTreeUtil.getChildrenOfType]
  */
-inline fun <reified T : PsiElement> PsiElement.childrenOfType(recursive: Boolean = false): Collection<T> = childrenOfType(T::class, recursive)
+inline fun <reified T : PsiElement> PsiElement.childrenOfType(): Collection<T> = childrenOfType(T::class)
 
 /**
  * Finds the first element that matches a given predicate.

--- a/src/nl/hannahsten/texifyidea/util/parser/Psi.kt
+++ b/src/nl/hannahsten/texifyidea/util/parser/Psi.kt
@@ -30,13 +30,18 @@ fun PsiElement.lineNumber(): Int? = containingFile.document()?.getLineNumber(tex
 /**
  * @see [PsiTreeUtil.getChildrenOfType]
  */
-fun <T : PsiElement> PsiElement.childrenOfType(clazz: KClass<T>): Collection<T> {
+fun <T : PsiElement> PsiElement.childrenOfType(clazz: KClass<T>, recursive: Boolean = false): Collection<T> {
     return runReadAction {
         if (!this.isValid || project.isDisposed) {
             emptyList()
         }
         else {
-            PsiTreeUtil.findChildrenOfType(this, clazz.java)
+            val directChildren = PsiTreeUtil.findChildrenOfType(this, clazz.java)
+            if (recursive) {
+                directChildren + children.flatMap { it.childrenOfType(clazz, true) }
+            } else {
+                directChildren
+            }
         }
     }
 }
@@ -44,7 +49,7 @@ fun <T : PsiElement> PsiElement.childrenOfType(clazz: KClass<T>): Collection<T> 
 /**
  * @see [PsiTreeUtil.getChildrenOfType]
  */
-inline fun <reified T : PsiElement> PsiElement.childrenOfType(): Collection<T> = childrenOfType(T::class)
+inline fun <reified T : PsiElement> PsiElement.childrenOfType(recursive: Boolean = false): Collection<T> = childrenOfType(T::class, recursive)
 
 /**
  * Finds the first element that matches a given predicate.

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspectionTest.kt
@@ -102,6 +102,13 @@ class LatexUnicodeInspectionQuickFix : LatexUnicodeInspectionTest() {
         testNamedQuickFix("$ μ$", "$ \\mu$", "Escape Unicode character", 1)
     }
 
+    fun `test capital Omega`() {
+        setUnicodeSupport(false)
+
+        testNamedQuickFix("$ Ω$", "$ \\Omega$", "Escape Unicode character", 1)
+        testNamedQuickFix("$ Ω$", "$ \\ohm$", "Escape Unicode character", 1)
+    }
+
     @Suppress("NonAsciiCharacters")
     fun `test escape unicode quick fix î`() {
         setUnicodeSupport(false)

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspectionTest.kt
@@ -158,6 +158,12 @@ class LatexUnicodeInspectionQuickFix : LatexUnicodeInspectionTest() {
         testNamedQuickFix("å", "\\aa", "Escape Unicode character", 2)
     }
 
+    fun `test escape unicode quick fix word`() {
+        setUnicodeSupport(false)
+
+        testNamedQuickFix("Umeå", "Ume\\aa", "Escape Unicode character", 2)
+    }
+
     fun `test escape unicode quick fix known math command`() {
         setUnicodeSupport(false)
 

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspectionTest.kt
@@ -98,15 +98,51 @@ class LatexUnicodeInspectionQuickFix : LatexUnicodeInspectionTest() {
     fun `test mu`() {
         setUnicodeSupport(false)
 
-        testNamedQuickFix("$ µ$", "$ \\micro$", "Escape Unicode character", 1)
         testNamedQuickFix("$ μ$", "$ \\mu$", "Escape Unicode character", 1)
+        testNamedQuickFix(
+            """
+            \documentclass{article}
+            
+            \begin{document}
+                $ µ$
+            \end{document}
+            """.trimIndent(),
+            """
+            \documentclass{article}
+            \usepackage{siunitx}
+            
+            \begin{document}
+                $ \micro$
+            \end{document}
+            """.trimIndent(),
+            "Escape Unicode character",
+            1
+        )
     }
 
     fun `test capital Omega`() {
         setUnicodeSupport(false)
 
         testNamedQuickFix("$ Ω$", "$ \\Omega$", "Escape Unicode character", 1)
-        testNamedQuickFix("$ Ω$", "$ \\ohm$", "Escape Unicode character", 1)
+        testNamedQuickFix(
+            """
+            \documentclass{article}
+            
+            \begin{document}
+                $ Ω$
+            \end{document}
+            """.trimIndent(),
+            """
+            \documentclass{article}
+            \usepackage{siunitx}
+            
+            \begin{document}
+                $ \ohm$
+            \end{document}
+            """.trimIndent(),
+            "Escape Unicode character",
+            1
+        )
     }
 
     @Suppress("NonAsciiCharacters")


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3916 

#### Summary of additions and changes

* The unicode symbol for Ohm (Ω) has been added to the autocompletion, this also fixes the unicode inspection quick fix for this symbol.
* Fix that the replacement of one of `µΩ` (without space) would delete the other as well.

Note that this doesn't fix (but at least it doesn't make it worse) the problem with multiple descriptors in one psi element, e.g., `µ Ω`, and the "apply all fixes in file". The fix all can't replace the omega because the text range in the descriptor is out-of-date after replacing mu. This is something we should probably fix generally for the texify inspection base (like we have done for the regex inspection base).

#### How to test this pull request

```latex
\documentclass{article}
\begin{document}
    We see that $Ω Ω\neq\emptyset$
\end{document}
```

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary