### PR TITLE
Fix timeout in CommandRunner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Default to 0.15.0 behaviour if inputs field is not found in Tectonic.toml
 
 ### Fixed
+* Fix a possible UI freeze if pdflatex doesn't exit while TeXiFy is checking for files to index
 * Fix StackOverflowError when color definitions reference each other
 * Fix #3906 invalid element exception
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3909

The timeout was not working properly, as demonstrated by this MWE:

```kotlin
import kotlinx.coroutines.*
import java.util.concurrent.TimeUnit
import kotlin.time.Duration

fun main() {
    runBlocking {
        val process = ProcessBuilder("sleep", "60").start()
        val output = async { process.inputReader().use { it.readText() } }
        val timeout = 1000L
        val resultCode = withTimeoutOrNull(timeout) {
            process.waitFor(timeout, TimeUnit.MILLISECONDS)
        } ?: run {
            process.destroy()
            println("Process destroyed after timeout")
        }
        val resultOutput = output.await()
        println("Process exited with $resultCode and output $resultOutput")
    }
}
```

Fixed version:

```kotlin
import kotlinx.coroutines.*
import java.util.concurrent.TimeUnit
import kotlin.time.Duration

fun main() {
    runBlocking {
        val process = ProcessBuilder("sleep", "60").start()
        val output = async { process.inputReader().use { it.readText() } }
        val timeout = 1000L
        withTimeoutOrNull(timeout) {
            val resultCode = process.waitFor(timeout, TimeUnit.MILLISECONDS)
            val resultOutput = output.await()
            println("Process exited with $resultCode and output $resultOutput")
        } ?: run {
            process.destroy()
            println("Process destroyed after timeout")
        }
    }
}
```