### PR TITLE
Fix a false negative of the non-matching environment name inspection for empty parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Default to 0.15.0 behaviour if inputs field is not found in Tectonic.toml
 
 ### Fixed
+* Fix a false negative of the non-matching environment name inspection for empty parameters
 * Fix a possible UI freeze if pdflatex doesn't exit while TeXiFy is checking for files to index
 * Fix StackOverflowError when color definitions reference each other
 * Fix #3906 invalid element exception

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexNonMatchingEnvironmentInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexNonMatchingEnvironmentInspection.kt
@@ -34,8 +34,8 @@ open class LatexNonMatchingEnvironmentInspection : TexifyInspectionBase() {
         val begins = file.childrenOfType(LatexBeginCommand::class)
         for (begin in begins) {
             val end = begin.endCommand() ?: continue
-            val beginEnvironment = begin.environmentName() ?: continue
-            val endEnvironment = end.environmentName() ?: continue
+            val beginEnvironment = begin.environmentName() ?: ""
+            val endEnvironment = end.environmentName() ?: ""
             if (beginEnvironment == endEnvironment) {
                 continue
             }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexNonMatchingEnvironmentInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexNonMatchingEnvironmentInspectionTest.kt
@@ -17,6 +17,9 @@ class LatexNonMatchingEnvironmentInspectionTest : TexifyInspectionTestBase(Latex
         <error descr="DefaultEnvironment name does not match with the name in \end.">\begin{center}</error>
             bla
         <error descr="DefaultEnvironment name does not match with the name in \begin.">\end{left}</error>
+        <error descr="DefaultEnvironment name does not match with the name in \end.">\begin{center}</error>
+            bla
+        <error descr="DefaultEnvironment name does not match with the name in \begin.">\end{}</error>
         """.trimIndent()
     )
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3918
