### PR TITLE
Avoid NPE in LatexPackageNotInstalledInspection

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/packages/LatexPackageNotInstalledInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/packages/LatexPackageNotInstalledInspection.kt
@@ -64,7 +64,7 @@ class LatexPackageNotInstalledInspection : TexifyInspectionBase() {
                 .map { it.groupValues.last() }.toMutableList()
         }
 
-        val installedPackages = TexLivePackages.packageList!!
+        val installedPackages = TexLivePackages.packageList ?: return descriptors
         val customPackages = LatexDefinitionIndex.Util.getCommandsByName(
             LatexGenericRegularCommand.PROVIDESPACKAGE.cmd, file.project,
             file.project


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3935