### PR TITLE
Fix "The filename or extension is too long"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Add WSL support to the bibtex run configuration, using a new setting to choose the LaTeX distribution
 * Default to 0.15.0 behaviour if inputs field is not found in Tectonic.toml
 
+### Changed
+* Only the source root of the module containing the main file is used for -include-directory, instead of source roots of all modules
+
 ### Fixed
 * Fix exceptions #3938, #3939, #3940, #3955
 * Fix a UI freeze which could occur with autocompile on save on project open

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.10.2-alpha.7
+pluginVersion = 0.10.2-alpha.9
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexCommandLineState.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexCommandLineState.kt
@@ -112,7 +112,7 @@ open class LatexCommandLineState(environment: ExecutionEnvironment, private val 
         }
 
         // Windows has a maximum length of a command, possibly 32k characters (#3956), so we log this info in the exception
-        if (SystemInfo.isWindows && command.sumOf { it.length} > 10_000) {
+        if (SystemInfo.isWindows && command.sumOf { it.length } > 10_000) {
             throw ExecutionException("The following command was too long to run: ${command.joinToString(" ")}")
         }
         val commandLine = GeneralCommandLine(command).withWorkDirectory(workingDirectory)

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexCommandLineState.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexCommandLineState.kt
@@ -111,6 +111,10 @@ open class LatexCommandLineState(environment: ExecutionEnvironment, private val 
             }
         }
 
+        // Windows has a maximum length of a command, possibly 32k characters (#3956), so we log this info in the exception
+        if (SystemInfo.isWindows && command.sumOf { it.length} > 10_000) {
+            throw ExecutionException("The following command was too long to run: ${command.joinToString(" ")}")
+        }
         val commandLine = GeneralCommandLine(command).withWorkDirectory(workingDirectory)
             .withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE)
             .withEnvironment(envVariables)


### PR DESCRIPTION
Only select source roots of current module to fix #3956, and improve error message in case the compile command is too long.