### PR TITLE
Add setting to enable spellcheck in all code

### DIFF
--- a/Writerside/topics/Inspections.md
+++ b/Writerside/topics/Inspections.md
@@ -23,6 +23,7 @@ See [Create custom inspections | IntelliJ IDEA Documentation](https://www.jetbr
 ## Spellchecking
 
 IntelliJ has a default spellchecking inspection, see [Spellchecking | IntelliJ IDEA Documentation](https://www.jetbrains.com/help/idea/spellchecking.html#configure-the-typo-inspection).
+To enable spellcheck everywhere in LaTeX code, see [TeXiFy settings](TeXiFy-settings.md#enable-spellcheck-in-all-scopes).
 
 ## Grammar checking
 

--- a/Writerside/topics/TeXiFy-settings.md
+++ b/Writerside/topics/TeXiFy-settings.md
@@ -89,6 +89,24 @@ The index is persistent between restarts.
 However, because a full TeX Live installation contains an enormous amount of packages, it can take a long time to index.
 If this is a problem, you can turn this feature off by deselecting this checkbox.
 
+## Enable spellcheck in all scopes
+_Since 0.10.2_
+
+This setting enables spellcheck in the 'code' inspection scope, which approximately corresponds to non-typeset text.
+
+The spellcheck or 'Proofreading/Typo' inspection is a default inspection not provided by TeXiFy.
+In <ui-path>File | Settings | Editor | Inspections | Proofreading | Typo</ui-path>, scopes can be configured per language.
+Every scope consists of enabling spellcheck in a subset of code, literals or comments.
+For LaTeX, they mean:
+
+* Literals: Regular text, or text in commands for which TeXiFy knows that it contains text, like `\section`.
+* Code: Other text which is not typeset, like labels, or arguments in (custom) commands for which TeXiFy does not know the type.
+
+By default, the 'code' scope is enabled.
+However, in many cases for LaTeX this is not a good default, for example package names or labels often are not valid dictionary words.
+Therefore, this TeXiFy setting disables the 'code' scope by default.
+When this setting is enabled, the 'code' scope can still be disabled.
+
 ## Textidote linter
 
 See [Textidote](Spacing.md#textidote)

--- a/src/nl/hannahsten/texifyidea/settings/TexifyConfigurable.kt
+++ b/src/nl/hannahsten/texifyidea/settings/TexifyConfigurable.kt
@@ -28,6 +28,7 @@ class TexifyConfigurable : SearchableConfigurable {
     private var includeBackslashInSelection: JBCheckBox? = null
     private var showPackagesInStructureView: JBCheckBox? = null
     private var enableExternalIndex: JBCheckBox? = null
+    private var enableSpellcheckEverywhere: JBCheckBox? = null
     private var enableTextidote: JBCheckBox? = null
     private var textidoteOptions: RawCommandLineEditor? = null
     private var latexIndentOptions: RawCommandLineEditor? = null
@@ -48,6 +49,7 @@ class TexifyConfigurable : SearchableConfigurable {
         Pair(::includeBackslashInSelection, settings::includeBackslashInSelection),
         Pair(::showPackagesInStructureView, settings::showPackagesInStructureView),
         Pair(::enableExternalIndex, settings::enableExternalIndex),
+        Pair(::enableSpellcheckEverywhere, settings::enableSpellcheckEverywhere),
         Pair(::enableTextidote, settings::enableTextidote),
     )
 
@@ -70,6 +72,7 @@ class TexifyConfigurable : SearchableConfigurable {
                     includeBackslashInSelection = addCheckbox("Include the backslash in the selection when selecting a LaTeX command")
                     showPackagesInStructureView = addCheckbox("Show LaTeX package files in structure view (warning: structure view will take more time to load)")
                     enableExternalIndex = addCheckbox("Enable indexing of MiKTeX/TeX Live package files (requires restart)")
+                    enableSpellcheckEverywhere = addCheckbox("Enable spellcheck inspection in all scopes")
                     enableTextidote = addCheckbox("Enable the Textidote linter")
                     textidoteOptions = addCommandLineEditor("Textidote", TexifySettingsState().textidoteOptions)
                     latexIndentOptions = addCommandLineEditor("Latexindent", TexifySettingsState().latexIndentOptions)

--- a/src/nl/hannahsten/texifyidea/settings/TexifySettings.kt
+++ b/src/nl/hannahsten/texifyidea/settings/TexifySettings.kt
@@ -55,6 +55,7 @@ class TexifySettings : PersistentStateComponent<TexifySettingsState> {
     var includeBackslashInSelection = false
     var showPackagesInStructureView = false
     var enableExternalIndex = true
+    var enableSpellcheckEverywhere = false
     var enableTextidote = false
     var textidoteOptions = "--check en --output singleline --no-color"
     var latexIndentOptions = ""
@@ -81,6 +82,7 @@ class TexifySettings : PersistentStateComponent<TexifySettingsState> {
             includeBackslashInSelection = includeBackslashInSelection,
             showPackagesInStructureView = showPackagesInStructureView,
             enableExternalIndex = enableExternalIndex,
+            enableSpellcheckEverywhere = enableSpellcheckEverywhere,
             enableTextidote = enableTextidote,
             textidoteOptions = textidoteOptions,
             latexIndentOptions = latexIndentOptions,
@@ -101,6 +103,7 @@ class TexifySettings : PersistentStateComponent<TexifySettingsState> {
         includeBackslashInSelection = state.includeBackslashInSelection
         showPackagesInStructureView = state.showPackagesInStructureView
         enableExternalIndex = state.enableExternalIndex
+        enableSpellcheckEverywhere = state.enableSpellcheckEverywhere
         enableTextidote = state.enableTextidote
         textidoteOptions = state.textidoteOptions
         latexIndentOptions = state.latexIndentOptions

--- a/src/nl/hannahsten/texifyidea/settings/TexifySettingsState.kt
+++ b/src/nl/hannahsten/texifyidea/settings/TexifySettingsState.kt
@@ -14,6 +14,7 @@ data class TexifySettingsState(
     var includeBackslashInSelection: Boolean = false,
     var showPackagesInStructureView: Boolean = false,
     var enableExternalIndex: Boolean = true,
+    var enableSpellcheckEverywhere: Boolean = false,
     var enableTextidote: Boolean = false,
     var textidoteOptions: String = "--check en --output singleline --no-color",
     var latexIndentOptions: String = "",


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #3954

#### Summary of additions and changes

* 'code' is on by default, but I think it should be off for e.g. package names, citations (often containing names)
* Allow overriding the default via a TeXiFy setting