### PR TITLE
Fix validation when renaming a bibtex identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add setting to enable spellcheck in 'code' scope
 
 ### Fixed
+* Fix validation when renaming a bibtex identifier
 * Fix a possible UI freeze when computing obsolete pdf viewer settings
 * Do not run grammar checks in graphicspath argument
 * Fix the command line becoming too long when there are hundreds of source roots in the module

--- a/resources/META-INF/extensions/references-refactoring.xml
+++ b/resources/META-INF/extensions/references-refactoring.xml
@@ -6,5 +6,6 @@
 
         <lang.findUsagesProvider language="Bibtex" implementationClass="nl.hannahsten.texifyidea.reference.BibtexUsagesProvider"/>
         <lang.refactoringSupport language="Bibtex" implementationClass="nl.hannahsten.texifyidea.refactoring.BibtexRefactoringSupportProvider" />
+        <lang.namesValidator language="Bibtex" implementationClass="nl.hannahsten.texifyidea.refactoring.BibtexNamesValidator" />
     </extensions>
 </idea-plugin>

--- a/src/nl/hannahsten/texifyidea/refactoring/BibtexNamesValidator.kt
+++ b/src/nl/hannahsten/texifyidea/refactoring/BibtexNamesValidator.kt
@@ -1,0 +1,19 @@
+package nl.hannahsten.texifyidea.refactoring
+
+import com.intellij.lang.refactoring.NamesValidator
+import com.intellij.openapi.project.Project
+
+/**
+ * See [LatexNamesValidator]
+ */
+class BibtexNamesValidator : NamesValidator {
+
+    override fun isKeyword(name: String, project: Project?): Boolean {
+        return false
+    }
+
+    override fun isIdentifier(name: String, project: Project?): Boolean {
+        // Characters for bibtex identifiers, see lexer
+        return name.matches("^[^,{}()\"#%'=~\\\\ \\n]+$".toRegex())
+    }
+}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #4003