### PR TITLE
Fix qodana warnings about blocked intention preview

### DIFF
--- a/src/nl/hannahsten/texifyidea/inspections/TexifyInspectionBase.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/TexifyInspectionBase.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.inspections
 
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
 import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.ProblemDescriptor
@@ -154,6 +155,12 @@ abstract class TexifyInspectionBase : LocalInspectionTool() {
             magicComment.addValue(DefaultMagicKeys.SUPPRESS, inspectionId)
             targetElement.element?.addMagicCommentToPsiElement(magicComment)
         }
+
+        /**
+         * There is no use for a preview for suppression "fixes" (there also is no preview when suppressing Java and Kotlin inspections),
+         * disable it manually to avoid [Field blocks intention preview](https://www.jetbrains.com/help/inspectopedia/ActionIsNotPreviewFriendly.html) warnings.
+         */
+        override fun generatePreview(project: Project, previewDescriptor: ProblemDescriptor): IntentionPreviewInfo = IntentionPreviewInfo.EMPTY
 
         override fun isAvailable(project: Project, context: PsiElement): Boolean {
             return context.containingFile.fileType == LatexFileType

--- a/src/nl/hannahsten/texifyidea/inspections/TexifyRegexInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/TexifyRegexInspection.kt
@@ -296,7 +296,7 @@ abstract class TexifyRegexInspection(
     /**
      * Generates the preview of applying the quick fix of the element at the cursor.
      */
-    fun generatePreview(project: Project, descriptor: ProblemDescriptor, replacementRanges: List<IntRange>, replacements: List<String>, groups: List<List<String>>,): IntentionPreviewInfo {
+    fun generatePreview(project: Project, descriptor: ProblemDescriptor, replacementRanges: List<IntRange>, replacements: List<String>, groups: List<List<String>>): IntentionPreviewInfo {
         val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return IntentionPreviewInfo.EMPTY
         // +1 because the caret seems to always be at the start of the text highlighted in the inspection.
         // Take the first replacement as best guess default.

--- a/src/nl/hannahsten/texifyidea/inspections/latex/codematurity/LatexPrimitiveEquationInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codematurity/LatexPrimitiveEquationInspection.kt
@@ -1,12 +1,8 @@
 package nl.hannahsten.texifyidea.inspections.latex.codematurity
 
-import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemHighlightType
-import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.inspections.TexifyRegexInspection
-import nl.hannahsten.texifyidea.util.files.document
 import nl.hannahsten.texifyidea.util.toTextRange
-import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 /**
@@ -16,27 +12,11 @@ open class LatexPrimitiveEquationInspection : TexifyRegexInspection(
     inspectionDisplayName = "Discouraged use of primitive TeX display math",
     inspectionId = "PrimitiveEquation",
     errorMessage = { "Use '\\[..\\]' instead of primitive TeX display math." },
-    pattern = Pattern.compile("(\\\$\\\$)[^\$]*\\\$?[^\$]*(\\\$\\\$)"),
+    pattern = Pattern.compile("\\\$\\\$([^\$]*\\\$?[^\$]*)\\\$\\\$"),
     mathMode = false,
-    replacement = { _, _ -> "" },
-    replacementRange = Util::replaceRange,
+    replacement = { matcher, _ -> "\\[${matcher.group(1)}\\]" },
+    replacementRange = { it.groupRange(0) },
     highlight = ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
-    highlightRange = { Util.replaceRange(it).toTextRange().grown(-1) },
+    highlightRange = { it.groupRange(0).toTextRange() },
     quickFixName = { "Replace with '\\[..\\]'" }
-) {
-
-    object Util {
-        fun replaceRange(it: Matcher) = (it.groupRange(1).first..it.groupRange(2).last)
-    }
-
-    override fun applyFix(descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>): Int {
-        val file = descriptor.psiElement as PsiFile
-        val document = file.document() ?: return 0
-
-        document.replaceString(replacementRange.first, replacementRange.first + 2, "\\[")
-        document.replaceString(replacementRange.last - 2, replacementRange.last, "\\]")
-
-        // $$ were replaced by \[ or \] so the length did not change
-        return 0
-    }
-}
+)

--- a/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexEquationReferenceInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexEquationReferenceInspection.kt
@@ -1,13 +1,11 @@
 package nl.hannahsten.texifyidea.inspections.latex.codestyle
 
 import com.intellij.codeInspection.ProblemDescriptor
-import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.inspections.TexifyRegexInspection
 import nl.hannahsten.texifyidea.lang.LatexPackage
-import nl.hannahsten.texifyidea.util.files.document
+import nl.hannahsten.texifyidea.util.insertUsepackage
 import nl.hannahsten.texifyidea.util.labels.findLatexLabelingElementsInFileSet
 import nl.hannahsten.texifyidea.util.parser.findOuterMathEnvironment
-import nl.hannahsten.texifyidea.util.insertUsepackage
 import java.util.regex.Pattern
 
 open class LatexEquationReferenceInspection : TexifyRegexInspection(
@@ -15,6 +13,8 @@ open class LatexEquationReferenceInspection : TexifyRegexInspection(
     inspectionId = "EquationReference",
     errorMessage = { "Use \\eqref" },
     pattern = Pattern.compile("(\\(\\\\ref\\{)([\\w:]+)(}\\))"),
+    replacement = { matcher, _ -> "\\eqref{${matcher.group(2)}}" },
+    replacementRange = { it.groupRange(0) },
     quickFixName = { "Replace with \\eqref" },
     groupFetcher = { listOf(it.group(2)) },
     cancelIf = { matcher, psiFile ->
@@ -22,16 +22,6 @@ open class LatexEquationReferenceInspection : TexifyRegexInspection(
         psiFile.findLatexLabelingElementsInFileSet().find { it.text == "\\label{${matcher.group(2)}}" }.findOuterMathEnvironment() == null
     }
 ) {
-
-    override fun applyFix(descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>): Int {
-        val file = descriptor.psiElement as PsiFile
-        val document = file.document() ?: return 0
-        val reference = groups[0]
-
-        document.replaceString(replacementRange.first, replacementRange.last, "\\eqref{$reference}")
-        // We add two characters: 'eq' and remove the two braces, thus the document gets 0 characters longer.
-        return 0
-    }
 
     override fun applyFixes(descriptor: ProblemDescriptor, replacementRanges: List<IntRange>, replacements: List<String>, groups: List<List<String>>) {
         super.applyFixes(descriptor, replacementRanges, replacements, groups)

--- a/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMathFunctionTextInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMathFunctionTextInspection.kt
@@ -61,7 +61,8 @@ open class LatexMathFunctionTextInspection : TexifyInspectionBase() {
         override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
             val textCommand = textCommandPointer.element ?: return
             val mathFunction = extractFunction(textCommand) ?: return
-            textCommand.replace(LatexPsiHelper(project).createFromText(mathFunction).firstChild)
+            textCommand.node.removeChild(textCommand.parameterList[0].node)
+            textCommand.node.replaceChild(textCommand.commandToken.node, LatexPsiHelper(project).createFromText(mathFunction).firstChild.node)
         }
 
         override fun generatePreview(project: Project, previewDescriptor: ProblemDescriptor): IntentionPreviewInfo {

--- a/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMathFunctionTextInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexMathFunctionTextInspection.kt
@@ -15,7 +15,6 @@ import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexPsiHelper
 import nl.hannahsten.texifyidea.util.files.commandsInFile
-import nl.hannahsten.texifyidea.util.files.document
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.parser.inMathContext
 import nl.hannahsten.texifyidea.util.parser.requiredParameter

--- a/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexCiteBeforePeriodInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexCiteBeforePeriodInspection.kt
@@ -21,7 +21,7 @@ open class LatexCiteBeforePeriodInspection : TexifyRegexInspection(
     errorMessage = { "\\cite is placed after interpunction" },
     pattern = Pattern.compile("([.,?!;:]~)(\\\\cite)"),
     mathMode = false,
-    replacement = { m, f -> findReplacement(m, f)},
+    replacement = { m, f -> findReplacement(m, f) },
     replacementRange = { it.groupRange(1) },
     highlightRange = { it.groupRange(2).toTextRange() },
     quickFixName = { "Move interpunction to the back of \\cite" },

--- a/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexCollapseCiteInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexCollapseCiteInspection.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.inspections.latex.typesetting
 
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
 import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
@@ -10,6 +11,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.SmartPointerManager
 import com.intellij.psi.SmartPsiElementPointer
 import com.intellij.psi.util.endOffset
+import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
@@ -19,6 +21,7 @@ import nl.hannahsten.texifyidea.psi.LatexNormalText
 import nl.hannahsten.texifyidea.psi.LatexPsiHelper
 import nl.hannahsten.texifyidea.util.caretOffset
 import nl.hannahsten.texifyidea.util.files.commandsInFile
+import nl.hannahsten.texifyidea.util.files.document
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.parser.*
 import java.util.*
@@ -145,44 +148,19 @@ open class LatexCollapseCiteInspection : TexifyInspectionBase() {
      * be collapsed.
      */
     private inner class InspectionFix(val citeBundle: List<SmartPsiElementPointer<LatexCommands>>) : LocalQuickFix {
+        val sortedBundle = lazy {
+            citeBundle.mapNotNull { it.element }.sortedBy { it.textOffset }
+        }
 
         override fun getFamilyName(): String {
             return "Collapse citations"
         }
 
         override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-            val sortedBundle = citeBundle.mapNotNull { it.element }.sortedBy { it.textOffset }
-            // The bundle can contain a gap when the cite commands in it surround a cite command
-            // that is not in the bundle, e.g., a cite command that has an optional parameter.
-            val bundleContainsGap = sortedBundle
-                .zipWithNext { a, b -> a.nextSibling != b }
-                .any()
-
-            // Create the content of the required parameter of the new cite command.
-            val bundle = sortedBundle
-                .flatMap { it.getRequiredParameters() }
-                .joinToString(",")
-
-            // Find the cite command that has to be replaced. When the bundle contains a gap, this is the command
-            // underneath the caret.
-            val targetCite = if (bundleContainsGap) {
-                val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return
-                sortedBundle.firstOrNull { it.endOffset >= editor.caretOffset() }
-                    // When something went wrong with finding a cite at the caret we target the last of the cites
-                    // based on the assumption that cites that have an optional argument are more specific and/or
-                    // important cites and "should" come first.
-                    ?: sortedBundle.lastOrNull() ?: return
-            }
-            // When the bundle does not contain a gap this is the first command, as it doesn't matter
-            // whichever one we pick.
-            else sortedBundle.firstOrNull() ?: return
-
-            // Construct the entire text of the new cite command.
-            val star = if (targetCite.hasStar()) "*" else ""
-            val replacement = "${targetCite.name}$star{$bundle}"
+            val (targetCite, _, replacement) = replacement(project) ?: return
 
             val psiHelper = LatexPsiHelper(project)
-            for (cite in sortedBundle) {
+            for (cite in sortedBundle.value) {
                 // Replace the target cite with the new cite command, using the psi tree.
                 if (cite == targetCite) {
                     cite.replace(psiHelper.createFromText(replacement).firstChild)
@@ -190,6 +168,47 @@ open class LatexCollapseCiteInspection : TexifyInspectionBase() {
                 // Remove any other cite from the psi tree.
                 else cite.parent?.node?.removeChild(cite.node)
             }
+        }
+
+        override fun generatePreview(project: Project, previewDescriptor: ProblemDescriptor): IntentionPreviewInfo {
+            val (_, original, replacement) = replacement(project) ?: return IntentionPreviewInfo.EMPTY
+            return IntentionPreviewInfo.CustomDiff(LatexFileType, original, replacement)
+        }
+
+        private fun replacement(project: Project): Triple<LatexCommands, String, String>? {
+            // The bundle can contain a gap when the cite commands in it surround a cite command
+            // that is not in the bundle, e.g., a cite command that has an optional parameter.
+            val bundleContainsGap = sortedBundle.value
+                .zipWithNext { a, b -> a.nextSibling != b }
+                .any()
+
+            val originalText = sortedBundle.value.firstOrNull()?.let { startCite ->
+                val document = startCite.containingFile.document() ?: return@let ""
+                document.text.substring(startCite.textOffset, sortedBundle.value.lastOrNull()?.textRange?.endOffset ?: document.text.length)
+            } ?: ""
+
+            // Create the content of the required parameter of the new cite command.
+            val bundle = sortedBundle.value
+                .flatMap { it.getRequiredParameters() }
+                .joinToString(",")
+
+            // Find the cite command that has to be replaced. When the bundle contains a gap, this is the command
+            // underneath the caret.
+            val targetCite = if (bundleContainsGap) {
+                val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return null
+                sortedBundle.value.firstOrNull { it.endOffset >= editor.caretOffset() }
+                // When something went wrong with finding a cite at the caret we target the last of the cites
+                // based on the assumption that cites that have an optional argument are more specific and/or
+                // important cites and "should" come first.
+                    ?: sortedBundle.value.lastOrNull() ?: return null
+            }
+            // When the bundle does not contain a gap this is the first command, as it doesn't matter
+            // whichever one we pick.
+            else sortedBundle.value.firstOrNull() ?: return null
+
+            // Construct the entire text of the new cite command.
+            val star = if (targetCite.hasStar()) "*" else ""
+            return Triple(targetCite, originalText, "${targetCite.name}$star{$bundle}")
         }
     }
 }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexCollapseCiteInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexCollapseCiteInspection.kt
@@ -197,9 +197,9 @@ open class LatexCollapseCiteInspection : TexifyInspectionBase() {
             val targetCite = if (bundleContainsGap) {
                 val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return null
                 sortedBundle.value.firstOrNull { it.endOffset >= editor.caretOffset() }
-                // When something went wrong with finding a cite at the caret we target the last of the cites
-                // based on the assumption that cites that have an optional argument are more specific and/or
-                // important cites and "should" come first.
+                    // When something went wrong with finding a cite at the caret we target the last of the cites
+                    // based on the assumption that cites that have an optional argument are more specific and/or
+                    // important cites and "should" come first.
                     ?: sortedBundle.value.lastOrNull() ?: return null
             }
             // When the bundle does not contain a gap this is the first command, as it doesn't matter

--- a/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexEnDashInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexEnDashInspection.kt
@@ -16,7 +16,7 @@ open class LatexEnDashInspection : TexifyRegexInspection(
     quickFixName = { "Convert to en dash" },
     cancelIf = { matcher, _ -> PatternMagic.correctEnDash.matcher(matcher.group(1)).matches() },
     replacementRange = { it.groupRange(1) },
-    replacement = { matcher, _ -> "${matcher.group(2)}--${matcher.group(3)}"},
+    replacement = { matcher, _ -> "${matcher.group(2)}--${matcher.group(3)}" },
     highlightRange = { it.groupRange(1).toTextRange() },
     groupFetcher = { listOf(it.group(2), it.group(3)) }
 )

--- a/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexEnDashInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexEnDashInspection.kt
@@ -1,10 +1,6 @@
 package nl.hannahsten.texifyidea.inspections.latex.typesetting
 
-import com.intellij.codeInspection.ProblemDescriptor
-import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.inspections.TexifyRegexInspection
-import nl.hannahsten.texifyidea.util.files.document
-import nl.hannahsten.texifyidea.util.length
 import nl.hannahsten.texifyidea.util.magic.PatternMagic
 import nl.hannahsten.texifyidea.util.toTextRange
 import java.util.regex.Pattern
@@ -20,19 +16,7 @@ open class LatexEnDashInspection : TexifyRegexInspection(
     quickFixName = { "Convert to en dash" },
     cancelIf = { matcher, _ -> PatternMagic.correctEnDash.matcher(matcher.group(1)).matches() },
     replacementRange = { it.groupRange(1) },
+    replacement = { matcher, _ -> "${matcher.group(2)}--${matcher.group(3)}"},
     highlightRange = { it.groupRange(1).toTextRange() },
     groupFetcher = { listOf(it.group(2), it.group(3)) }
-) {
-
-    override fun applyFix(descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>): Int {
-        val file = descriptor.psiElement as PsiFile
-        val document = file.document() ?: return 0
-        val start = groups[0]
-        val end = groups[1]
-
-        val dashReplacement = "$start--$end"
-        document.replaceString(replacementRange.first, replacementRange.last, dashReplacement)
-
-        return dashReplacement.length - replacementRange.length
-    }
-}
+)

--- a/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexEncloseWithLeftRightInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexEncloseWithLeftRightInspection.kt
@@ -219,7 +219,7 @@ open class LatexEncloseWithLeftRightInspection : TexifyLineOptionsInspection("Cu
         }
 
         /**
-         * See documentation [https://www.jetbrains.com/help/inspectopedia/ActionIsNotPreviewFriendly.html](ActionIsNotPreviewFriendly), overriding this method implements fix 2:
+         * See documentation [ActionIsNotPreviewFriendly](https://www.jetbrains.com/help/inspectopedia/ActionIsNotPreviewFriendly.html), overriding this method implements fix 2:
          * > You may override getFileModifierForPreview() method and create a copy of the quick-fix rebinding it to the non-physical file copy which is supplied as a parameter. Use PsiTreeUtil.findSameElementInCopy() to find the corresponding PSI elements inside the supplied non-physical copy.
          */
         override fun getFileModifierForPreview(target: PsiFile): FileModifier? {

--- a/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexEncloseWithLeftRightInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexEncloseWithLeftRightInspection.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.inspections.latex.typesetting
 
+import com.intellij.codeInsight.intention.FileModifier
 import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
@@ -8,6 +9,7 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.*
+import com.intellij.psi.util.PsiTreeUtil
 import nl.hannahsten.texifyidea.inspections.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyLineOptionsInspection
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
@@ -206,20 +208,43 @@ open class LatexEncloseWithLeftRightInspection : TexifyLineOptionsInspection("Cu
 
         override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
             if (!applied) {
-                val psiHelper = LatexPsiHelper(project)
-                val openReplacement = psiHelper.createFromText("\\left$open").firstChild
-                val closeReplacement = psiHelper.createFromText("\\right${Util.brackets[open]}").firstChild
-
                 // Get the elements from the psi pointers before replacing elements, because the pointers are not accurate
                 // anymore after changing the psi structure.
                 val openElement = openElement.element ?: return
                 val closeElement = closeElement.element ?: return
-
-                openElement.replace(openReplacement)
-                closeElement.replace(closeReplacement)
+                replacePsi(project, openElement, closeElement, open)
 
                 applied = true
             }
+        }
+
+        /**
+         * See documentation [https://www.jetbrains.com/help/inspectopedia/ActionIsNotPreviewFriendly.html](ActionIsNotPreviewFriendly), overriding this method implements fix 2:
+         * > You may override getFileModifierForPreview() method and create a copy of the quick-fix rebinding it to the non-physical file copy which is supplied as a parameter. Use PsiTreeUtil.findSameElementInCopy() to find the corresponding PSI elements inside the supplied non-physical copy.
+         */
+        override fun getFileModifierForPreview(target: PsiFile): FileModifier? {
+            val openPsiElement = PsiTreeUtil.findSameElementInCopy(openElement.element, target) ?: return null
+            val closePsiElement = PsiTreeUtil.findSameElementInCopy(closeElement.element, target) ?: return null
+
+            return object : LocalQuickFix {
+                override fun getFamilyName() = this@InsertLeftRightFix.familyName
+
+                override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+                    // Warnings about potential memory leaks because of PsiElements (which can be fixed with SmartElementPointers)
+                    // can be ignored here because this quick fix is operating on a copy of the psi file to generate a preview.
+                    @Suppress("StatefulEp")
+                    replacePsi(project, openPsiElement, closePsiElement, open)
+                }
+            }
+        }
+
+        private fun replacePsi(project: Project, openPsiElement: PsiElement, closePsiElement: PsiElement, open: String) {
+            val psiHelper = LatexPsiHelper(project)
+            val openReplacement = psiHelper.createFromText("\\left$open").firstChild
+            val closeReplacement = psiHelper.createFromText("\\right${Util.brackets[open]}").firstChild
+
+            openPsiElement.replace(openReplacement)
+            closePsiElement.replace(closeReplacement)
         }
     }
 }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/spacing/LatexSpaceAfterAbbreviationInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/spacing/LatexSpaceAfterAbbreviationInspection.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.inspections.latex.typesetting.spacing
 
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
 import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
@@ -9,6 +10,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
+import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
 import nl.hannahsten.texifyidea.psi.LatexNormalText
@@ -107,6 +109,13 @@ open class LatexSpaceAfterAbbreviationInspection : TexifyInspectionBase() {
             val start = normalText.textOffset + whitespaceRange.last - 1
             val end = normalText.textOffset + whitespaceRange.last
             document.replaceString(start, end, "\\ ")
+        }
+
+        override fun generatePreview(project: Project, descriptor: ProblemDescriptor): IntentionPreviewInfo {
+            val text = (descriptor.psiElement as? LatexNormalText)?.text ?: return IntentionPreviewInfo.EMPTY
+            return (whitespaceRange.last - 1).let {
+                IntentionPreviewInfo.CustomDiff(LatexFileType, text, "${text.substring(0..<it)}\\${text.substring(it)}")
+            }
         }
     }
 }

--- a/test/nl/hannahsten/texifyidea/inspections/TexifyRegexInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/TexifyRegexInspectionTest.kt
@@ -40,7 +40,8 @@ class TexifyRegexInspectionTest {
                 replacements,
                 replacementRanges,
                 groups,
-                this::applyFixes
+                this::applyFixes,
+                this::generatePreview
             )
         }
 


### PR DESCRIPTION
#### Summary of additions and changes

* Fixed [Field blocks intention preview](https://www.jetbrains.com/help/inspectopedia/ActionIsNotPreviewFriendly.html) warnings reported by Qodana for single inspections.

#### How to test this pull request

Check that the quick fixes have the correct preview.

```latex
\documentclass{article}
\usepackage{amsmath}
\begin{document}
    test e.g. terq
    \[
        aaa (qe'\frac{4}{3} \text{cos}) x = 3
    \]
    bla \cite{test}~\cite{two}
\end{document}
```

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary