### PR TITLE
Improve performance of file set cache refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+
 * Always create output directory if it does not exist
 * Remove action to delete all generated files
 * Add support for reference resolving and autocompletion for the acronym package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-
+* Improve performance of file set cache refresh
 * Always create output directory if it does not exist
 * Remove action to delete all generated files
 * Add support for reference resolving and autocompletion for the acronym package

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.10.3-alpha.7
+pluginVersion = 0.10.3-alpha.8
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.10.3-alpha.6
+pluginVersion = 0.10.3-alpha.7
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
+++ b/src/nl/hannahsten/texifyidea/reference/InputFileReference.kt
@@ -95,7 +95,7 @@ class InputFileReference(
      *              (10 seconds divided by 500 commands/resolves) so this is not a problem when doing only one resolve
      *              (if requested by the user).
      */
-    fun resolve(lookForInstalledPackages: Boolean, givenRootFile: VirtualFile? = null, isBuildingFileset: Boolean = false): PsiFile? {
+    fun resolve(lookForInstalledPackages: Boolean, givenRootFile: VirtualFile? = null, isBuildingFileset: Boolean = false, checkImportPath: Boolean = true, checkAddToLuatexPath: Boolean = true): PsiFile? {
         // IMPORTANT In this method, do not use any functionality which makes use of the file set,
         // because this function is used to find the file set so that would cause an infinite loop
 
@@ -196,7 +196,7 @@ class InputFileReference(
                 .firstNotNullOfOrNull { findFileByPath(it) }
         }
 
-        if (targetFile == null) targetFile = searchFileByImportPaths(element)?.virtualFile
+        if (targetFile == null && checkImportPath) targetFile = searchFileByImportPaths(element)?.virtualFile
 
         // \externaldocument uses the .aux file in the output directory, we are only interested in the source file, but it can be anywhere (because no relative path will be given, as in the output directory everything will be on the same level).
         // This does not count for building the file set, because the external document is not actually in the fileset, only the label definitions are
@@ -205,7 +205,7 @@ class InputFileReference(
         }
 
         // addtoluatexpath package
-        if (targetFile == null) {
+        if (targetFile == null && checkAddToLuatexPath) {
             for (path in addToLuatexPathSearchDirectories(element.project)) {
                 targetFile = path.findFile(processedKey, extensions, supportsAnyExtension)
                 if (targetFile != null) break

--- a/src/nl/hannahsten/texifyidea/settings/sdk/LatexProjectSdkSetupValidator.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/LatexProjectSdkSetupValidator.kt
@@ -22,7 +22,14 @@ import nl.hannahsten.texifyidea.util.runCommand
 class LatexProjectSdkSetupValidator : ProjectSdkSetupValidator {
 
     object Cache {
-        val isPdflatexInPath by lazy { runCommand("pdflatex", "--version", timeout = 10)?.contains("pdfTeX") == true }
+        val isPdflatexInPath by lazy {
+            for (retry in 0..5) {
+                runCommand("pdflatex", "--version", timeout = 10)?.let {
+                    return@lazy it.contains("pdfTeX")
+                }
+            }
+            false
+        }
     }
 
     override fun isApplicableFor(project: Project, file: VirtualFile): Boolean {

--- a/src/nl/hannahsten/texifyidea/settings/sdk/LatexProjectSdkSetupValidator.kt
+++ b/src/nl/hannahsten/texifyidea/settings/sdk/LatexProjectSdkSetupValidator.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.PsiManager
 import com.intellij.ui.EditorNotificationPanel
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.grammar.LatexLanguage
+import nl.hannahsten.texifyidea.util.runCommand
 
 /**
  * https://jetbrains.org/intellij/sdk/docs/reference_guide/project_model/sdk.html#assisting-in-setting-up-an-sdk
@@ -19,6 +20,10 @@ import nl.hannahsten.texifyidea.grammar.LatexLanguage
  * @author Thomas
  */
 class LatexProjectSdkSetupValidator : ProjectSdkSetupValidator {
+
+    object Cache {
+        val isPdflatexInPath by lazy { runCommand("pdflatex", "--version", timeout = 10)?.contains("pdfTeX") == true }
+    }
 
     override fun isApplicableFor(project: Project, file: VirtualFile): Boolean {
         // Check if setting up a LaTeX SDK would make sense
@@ -28,7 +33,7 @@ class LatexProjectSdkSetupValidator : ProjectSdkSetupValidator {
     override fun getErrorMessage(project: Project, file: VirtualFile): String? {
         // Based on https://github.com/rikvdkleij/intellij-haskell/blob/895a214b174b69f661d4f7d4230633058fca8f1e/src/main/scala/intellij/haskell/notification/HaskellProjectSdkSetupValidator.scala#L24
         // Nothing to do if we don't need an SDK
-        if (LatexSdkUtil.isPdflatexInPath) return null
+        if (Cache.isPdflatexInPath) return null
         val module = ModuleUtilCore.findModuleForFile(file, project) ?: return null
         if (ModuleRootManager.getInstance(module).sdk?.sdkType is LatexSdk || ProjectRootManager.getInstance(project).projectSdk?.sdkType is LatexSdk) return null
         return "No LaTeX installation could be found. Please add it to PATH or set up a LaTeX SDK (and reopen this file)."

--- a/src/nl/hannahsten/texifyidea/util/files/FileSet.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/FileSet.kt
@@ -54,7 +54,7 @@ internal suspend fun Project.findReferencedFileSetWithoutCache(reporter: Progres
     return roots
         .associateWith { root ->
             // Map root to all directly referenced files.
-            reporter?.sizedStep((1000 / roots.size).toInt()) {
+            reporter?.sizedStep((1000 / roots.size)) {
                 root.referencedFiles(root.virtualFile, isImportPackageUsed, usesLuatexPaths) + root
             } ?: (root.referencedFiles(root.virtualFile, isImportPackageUsed, usesLuatexPaths) + root)
         }
@@ -115,7 +115,7 @@ fun VirtualFile.findTectonicTomlFile(): VirtualFile? {
             break
         }
 
-        parent?.findFile("Tectonic.toml")?.let { return it }
+        parent.findFile("Tectonic.toml")?.let { return it }
     }
     return null
 }
@@ -173,7 +173,7 @@ fun addToLuatexPathSearchDirectories(project: Project): List<VirtualFile> {
             basePath.allChildDirectories()
         }
         else if (it.endsWith("/*")) {
-            basePath.children.filter { it.isDirectory }
+            basePath.children.filter { child -> child.isDirectory }
         }
         else {
             listOf(basePath)

--- a/src/nl/hannahsten/texifyidea/util/files/ImportPackage.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/ImportPackage.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.util.files
 
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
@@ -21,19 +22,7 @@ import kotlin.math.min
  */
 fun searchFileByImportPaths(command: LatexCommands): PsiFile? {
     // Check if import commands are used (do this now, to only search for import paths when needed)
-    val allRelativeImportCommands = LatexIncludesIndex.Util.getCommandsByNames(
-        CommandMagic.relativeImportCommands,
-        command.project,
-        GlobalSearchScope.projectScope(command.project)
-    )
-    val allAbsoluteImportCommands = LatexIncludesIndex.Util.getCommandsByNames(
-        CommandMagic.absoluteImportCommands,
-        command.project,
-        GlobalSearchScope.projectScope(command.project)
-    )
-    if (allAbsoluteImportCommands.isEmpty() && allRelativeImportCommands.isEmpty()) {
-        return null
-    }
+    if (isImportPackageUsed(command.project)) return null
 
     // Use references to get filenames, take care not to resolve the references because this method is called during resolving them so that would be a loop. This line will take a very long time for large projects, as it has to do a lot of recursive navigation in the psi tree in order to get the text required for building the reference keys.
     val references = command.references.filterIsInstance<InputFileReference>()
@@ -50,6 +39,20 @@ fun searchFileByImportPaths(command: LatexCommands): PsiFile? {
     }
 
     return null
+}
+
+fun isImportPackageUsed(project: Project): Boolean {
+    val allRelativeImportCommands = LatexIncludesIndex.Util.getCommandsByNames(
+        CommandMagic.relativeImportCommands,
+        project,
+        GlobalSearchScope.projectScope(project)
+    )
+    val allAbsoluteImportCommands = LatexIncludesIndex.Util.getCommandsByNames(
+        CommandMagic.absoluteImportCommands,
+        project,
+        GlobalSearchScope.projectScope(project)
+    )
+    return allAbsoluteImportCommands.isNotEmpty() || allRelativeImportCommands.isNotEmpty()
 }
 
 /**

--- a/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/LatexPackageLocationCache.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.runBlocking
 import nl.hannahsten.texifyidea.settings.sdk.LatexSdkUtil
 import nl.hannahsten.texifyidea.settings.sdk.TectonicSdk
 import nl.hannahsten.texifyidea.util.Log
-import nl.hannahsten.texifyidea.util.files.ReferencedFileSetCache.Cache
 import nl.hannahsten.texifyidea.util.runCommandNonBlocking
 import java.io.File
 
@@ -30,7 +29,7 @@ object LatexPackageLocationCache {
      * Note: this can take a long time.
      */
     suspend fun fillCacheWithKpsewhich(project: Project) {
-        if (Cache.isCacheFillInProgress.getAndSet(true)) return
+        if (isCacheFillInProgress.getAndSet(true)) return
 
         try {
             // We will get all search paths that kpsewhich has, expand them and find all files

--- a/src/nl/hannahsten/texifyidea/util/files/ReferencedFileSetCache.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/ReferencedFileSetCache.kt
@@ -116,21 +116,23 @@ class ReferencedFileSetCache {
         }
 
         for (fileset in filesets.values) {
+            val validFiles = fileset.mapNotNull {
+                smartReadAction(requestedFile.project) {
+                    if (it.isValid) it.createSmartPointer() else null
+                }
+            }.toSet()
             for (file in fileset) {
-                newFileSetCache[file.virtualFile.path] = fileset.mapNotNull {
-                    smartReadAction(requestedFile.project) {
-                        if (it.isValid) it.createSmartPointer() else null
-                    }
-                }.toSet()
+                newFileSetCache[file.virtualFile.path] = validFiles
             }
 
             val rootFiles = requestedFile.findRootFilesWithoutCache(fileset)
+            val validRootFiles = rootFiles.mapNotNull {
+                smartReadAction(requestedFile.project) {
+                    if (it.isValid) it.createSmartPointer() else null
+                }
+            }.toSet()
             for (file in fileset) {
-                newRootFilesCache[file.virtualFile.path] = rootFiles.mapNotNull {
-                    smartReadAction(requestedFile.project) {
-                        if (it.isValid) it.createSmartPointer() else null
-                    }
-                }.toSet()
+                newRootFilesCache[file.virtualFile.path] = validRootFiles
             }
         }
 


### PR DESCRIPTION
If there are a few hundred root files, the refresh could take 30 seconds, now it only takes a few seconds.