### PR TITLE
Fix extra whitespace when inserting commands in math mode

### DIFF
--- a/src/nl/hannahsten/texifyidea/completion/handlers/LatexMathInsertHandler.kt
+++ b/src/nl/hannahsten/texifyidea/completion/handlers/LatexMathInsertHandler.kt
@@ -11,6 +11,7 @@ import nl.hannahsten.texifyidea.lang.commands.Argument
 class LatexMathInsertHandler(val arguments: List<Argument>?) : InsertHandler<LookupElement> {
 
     override fun handleInsert(context: InsertionContext, item: LookupElement) {
+        LatexNoMathInsertHandler.removeWhiteSpaces(context)
         LatexCommandArgumentInsertHandler(arguments).handleInsert(context, item)
         LatexCommandPackageIncludeHandler().handleInsert(context, item)
         RightInsertHandler().handleInsert(context, item)

--- a/src/nl/hannahsten/texifyidea/completion/handlers/LatexNoMathInsertHandler.kt
+++ b/src/nl/hannahsten/texifyidea/completion/handlers/LatexNoMathInsertHandler.kt
@@ -33,9 +33,11 @@ class LatexNoMathInsertHandler(val arguments: List<Argument>? = null) : InsertHa
             LatexGenericRegularCommand.BEGIN.command -> {
                 insertBegin(context)
             }
+
             in TypographyMagic.pseudoCodeBeginEndOpposites -> {
                 insertPseudocodeEnd(command.command, context)
             }
+
             else -> {
                 LatexCommandArgumentInsertHandler(arguments).handleInsert(context, item)
             }
@@ -94,19 +96,23 @@ class LatexNoMathInsertHandler(val arguments: List<Argument>? = null) : InsertHa
             .startTemplate(context.editor, parameterTemplate)
     }
 
-    /**
-     * Remove whitespaces and everything after that that was inserted by the lookup text.
-     */
-    private fun removeWhiteSpaces(context: InsertionContext) {
-        val editor = context.editor
-        val document = editor.document
-        val offset = editor.caretModel.offset
-        // context.startOffset is the offset of the start of the just inserted text.
-        val insertedText = document.text.substring(context.startOffset, offset)
-        val indexFirstSpace = insertedText.indexOfFirst { it == ' ' }
-        if (indexFirstSpace == -1) return
-        document.deleteString(context.startOffset + indexFirstSpace, offset)
+
+    companion object {
+        /**
+         * Remove whitespaces and everything after that that was inserted by the lookup text.
+         */
+        internal fun removeWhiteSpaces(context: InsertionContext) {
+            val editor = context.editor
+            val document = editor.document
+            val offset = editor.caretModel.offset
+            // context.startOffset is the offset of the start of the just inserted text.
+            val insertedText = document.text.substring(context.startOffset, offset)
+            val indexFirstSpace = insertedText.indexOfFirst { it == ' ' }
+            if (indexFirstSpace == -1) return
+            document.deleteString(context.startOffset + indexFirstSpace, offset)
+        }
     }
+
 
     /**
      * Makes sure environments get imported if required.

--- a/src/nl/hannahsten/texifyidea/completion/handlers/LatexNoMathInsertHandler.kt
+++ b/src/nl/hannahsten/texifyidea/completion/handlers/LatexNoMathInsertHandler.kt
@@ -96,7 +96,6 @@ class LatexNoMathInsertHandler(val arguments: List<Argument>? = null) : InsertHa
             .startTemplate(context.editor, parameterTemplate)
     }
 
-
     companion object {
         /**
          * Remove whitespaces and everything after that that was inserted by the lookup text.
@@ -112,7 +111,6 @@ class LatexNoMathInsertHandler(val arguments: List<Argument>? = null) : InsertHa
             document.deleteString(context.startOffset + indexFirstSpace, offset)
         }
     }
-
 
     /**
      * Makes sure environments get imported if required.


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #4051

#### Summary of additions and changes

- Add calling `removeWhiteSpaces`  also in `LatexMathInsertHandler`.

##### Details:

After inspecting the codes, it seems that the extra spaces are introduced because `LatexMathInsertHandler` does not remove the placeholder spaces inserted by the lookup text, but `LatexNoMathInsertHandler` does it correctly by calling `removeWhiteSpaces` at the first place. 

Therefore, the issue is resolved by calling `removeWhiteSpaces`  also in `LatexMathInsertHandler`.




- [x] No documentation update necessary
- [x] No tests necessary