### PR TITLE
Fix documentation popup showing obsolete information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+* Fix a bug where the documentation popup would not update correctly
 * Fix a few bugs related to the root files cache
 * Fix an issue with the file set cache when opening multiple projects
 * Fix auto compilation not rerunning correctly, by @Ezrnest

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.10.4-alpha.8
+pluginVersion = 0.10.4-alpha.9
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/editor/typedhandlers/LatexEnterHandler.kt
+++ b/src/nl/hannahsten/texifyidea/editor/typedhandlers/LatexEnterHandler.kt
@@ -6,6 +6,7 @@ import com.intellij.formatting.ChildAttributes
 import com.intellij.formatting.Indent
 import com.intellij.lang.ASTNode
 import nl.hannahsten.texifyidea.formatting.LatexBlock
+import nl.hannahsten.texifyidea.lang.DefaultEnvironment
 import nl.hannahsten.texifyidea.psi.LatexEnvironment
 import nl.hannahsten.texifyidea.psi.LatexTypes
 import nl.hannahsten.texifyidea.psi.getEnvironmentName
@@ -21,7 +22,7 @@ object LatexEnterHandler {
     fun getChildAttributes(newChildIndex: Int, node: ASTNode, subBlocks: MutableList<Block>): ChildAttributes {
         val shouldIndentDocumentEnvironment = CodeStyle.getCustomSettings(node.psi.containingFile, LatexCodeStyleSettings::class.java).INDENT_DOCUMENT_ENVIRONMENT
         val shouldIndentEnvironments = CodeStyle.getCustomSettings(node.psi.containingFile, LatexCodeStyleSettings::class.java).INDENT_ENVIRONMENTS
-        val isDocumentEnvironment = node.elementType === LatexTypes.ENVIRONMENT && (node.psi as? LatexEnvironment)?.getEnvironmentName() == "document"
+        val isDocumentEnvironment = node.elementType === LatexTypes.ENVIRONMENT && (node.psi as? LatexEnvironment)?.getEnvironmentName() == DefaultEnvironment.DOCUMENT.environmentName
         val shouldIndentEnvironment = when {
             node.elementType !== LatexTypes.ENVIRONMENT -> false
             isDocumentEnvironment -> shouldIndentDocumentEnvironment

--- a/src/nl/hannahsten/texifyidea/formatting/LatexBlock.kt
+++ b/src/nl/hannahsten/texifyidea/formatting/LatexBlock.kt
@@ -8,6 +8,7 @@ import com.intellij.psi.codeStyle.CodeStyleSettings
 import com.intellij.psi.formatter.common.AbstractBlock
 import com.intellij.psi.util.prevLeaf
 import nl.hannahsten.texifyidea.editor.typedhandlers.LatexEnterHandler
+import nl.hannahsten.texifyidea.lang.DefaultEnvironment
 import nl.hannahsten.texifyidea.lang.commands.LatexCommand
 import nl.hannahsten.texifyidea.psi.*
 import nl.hannahsten.texifyidea.settings.codestyle.LatexCodeStyleSettings
@@ -149,7 +150,7 @@ class LatexBlock(
         val shouldIndentEnvironments = latexSettings.INDENT_ENVIRONMENTS
         val isDocumentEnvironment = myNode.elementType === LatexTypes.ENVIRONMENT_CONTENT &&
             (myNode.psi as LatexEnvironmentContent)
-                .firstParentOfType(LatexEnvironment::class)?.getEnvironmentName() == "document"
+                .firstParentOfType(LatexEnvironment::class)?.getEnvironmentName() == DefaultEnvironment.DOCUMENT.environmentName
         val shouldIndentEnvironment = when {
             myNode.elementType !== LatexTypes.ENVIRONMENT_CONTENT -> false
             isDocumentEnvironment -> shouldIndentDocumentEnvironment

--- a/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexDocumentclassNotInRootInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexDocumentclassNotInRootInspection.kt
@@ -6,6 +6,8 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.inspections.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
+import nl.hannahsten.texifyidea.lang.DefaultEnvironment
+import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexEnvironment
 import nl.hannahsten.texifyidea.psi.getEnvironmentName
@@ -29,11 +31,11 @@ class LatexDocumentclassNotInRootInspection : TexifyInspectionBase() {
         // file - content - no_math_content - commands
         val documentClass = file.traverseTyped<LatexCommands>(depth = 3)
             .firstOrNull {
-                it.name == "\\documentclass"
+                it.name == LatexGenericRegularCommand.DOCUMENTCLASS.commandWithSlash
             } ?: return emptyList()
 
         val hasDocumentEnvironment = file.traverseTyped<LatexEnvironment>(depth = 3).any {
-            it.getEnvironmentName() == "document"
+            it.getEnvironmentName() == DefaultEnvironment.DOCUMENT.environmentName
         }
 
         if (!hasDocumentEnvironment) {

--- a/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexTooLargeSectionInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/codestyle/LatexTooLargeSectionInspection.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.inspections.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
+import nl.hannahsten.texifyidea.lang.DefaultEnvironment
 import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexCommands
@@ -69,7 +70,7 @@ open class LatexTooLargeSectionInspection : TexifyInspectionBase() {
 
             // If no command was found, find the end of the document.
             return command.containingFile.traverseReversed().filterIsInstance<LatexEndCommand>().firstOrNull {
-                it.environmentName() == "document"
+                it.environmentName() == DefaultEnvironment.DOCUMENT.environmentName
             }
         }
     }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexMissingDocumentEnvironmentInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexMissingDocumentEnvironmentInspection.kt
@@ -10,6 +10,7 @@ import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
+import nl.hannahsten.texifyidea.lang.DefaultEnvironment
 import nl.hannahsten.texifyidea.lang.magic.MagicCommentScope
 import nl.hannahsten.texifyidea.psi.LatexBeginCommand
 import nl.hannahsten.texifyidea.psi.environmentName
@@ -45,7 +46,7 @@ open class LatexMissingDocumentEnvironmentInspection : TexifyInspectionBase() {
 
         for (referencedFile in file.referencedFileSet()) {
             val hasBeginCommand = referencedFile.traverseTyped<LatexBeginCommand>()
-                .any { it.environmentName() == "document" }
+                .any { it.environmentName() == DefaultEnvironment.DOCUMENT.environmentName }
             if (hasBeginCommand) {
                 return descriptors
             }

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/packages/LatexPackageNameDoesNotMatchFileNameInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/packages/LatexPackageNameDoesNotMatchFileNameInspection.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.inspections.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
+import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexPsiHelper
 import nl.hannahsten.texifyidea.util.parser.collectSubtreeTyped
@@ -26,7 +27,7 @@ class LatexPackageNameDoesNotMatchFileNameInspection : TexifyInspectionBase() {
     override fun inspectFile(file: PsiFile, manager: InspectionManager, isOntheFly: Boolean): List<ProblemDescriptor> {
         val descriptors = descriptorList()
 
-        val commands = file.collectSubtreeTyped<LatexCommands> { it.name == "\\ProvidesPackage" }
+        val commands = file.collectSubtreeTyped<LatexCommands> { it.name == LatexGenericRegularCommand.PROVIDESPACKAGE.commandWithSlash }
 
         for (command in commands) {
             val providesName = command.getRequiredParameters().firstOrNull()?.split("/")?.last()

--- a/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/packages/LatexPackageSubdirectoryInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/probablebugs/packages/LatexPackageSubdirectoryInspection.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.inspections.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
+import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexPsiHelper
 import nl.hannahsten.texifyidea.util.files.findRootFile
@@ -33,7 +34,7 @@ class LatexPackageSubdirectoryInspection : TexifyInspectionBase() {
         val rootDir = file.findRootFile(useIndexCache = false).containingDirectory ?: return emptyList()
         val subDir = dir.toString().removePrefix(rootDir.toString()).removePrefix(File.separator).replace(File.separatorChar, '/')
 
-        val commands = file.collectSubtreeTyped<LatexCommands> { it.name == "\\ProvidesPackage" }
+        val commands = file.collectSubtreeTyped<LatexCommands> { it.name == LatexGenericRegularCommand.PROVIDESPACKAGE.commandWithSlash }
 
         val descriptors = mutableListOf<ProblemDescriptor>()
 

--- a/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexQedHereInspection.kt
+++ b/src/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexQedHereInspection.kt
@@ -10,6 +10,8 @@ import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.inspections.InsightGroup
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionBase
+import nl.hannahsten.texifyidea.lang.DefaultEnvironment
+import nl.hannahsten.texifyidea.lang.commands.LatexGenericRegularCommand
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexDisplayMath
 import nl.hannahsten.texifyidea.psi.LatexEnvironment
@@ -32,9 +34,9 @@ open class LatexQedHereInspection : TexifyInspectionBase() {
 
         // Only proof environments
         val displayMaths = file.traverseTyped<LatexEnvironment>()
-            .filter { it.getEnvironmentName() == "proof" }
+            .filter { it.getEnvironmentName() == DefaultEnvironment.PROOF.environmentName }
             // With no \qedhere command already present
-            .filterNot { it.traverseTyped<LatexCommands>().any { cmd -> cmd.name == "\\qedhere" } }
+            .filterNot { it.traverseTyped<LatexCommands>().any { cmd -> cmd.name == LatexGenericRegularCommand.QEDHERE.commandWithSlash } }
             // Ending in a displaymath environment
             .mapNotNull { it.environmentContent?.lastChild?.firstChild?.firstChild as? LatexDisplayMath }
 

--- a/src/nl/hannahsten/texifyidea/lang/DefaultEnvironment.kt
+++ b/src/nl/hannahsten/texifyidea/lang/DefaultEnvironment.kt
@@ -152,6 +152,7 @@ enum class DefaultEnvironment(
     LUACODE(environmentName = "luacode", dependency = LatexPackage.LUACODE),
     LUACODE_STAR(environmentName = "luacode*", dependency = LatexPackage.LUACODE),
     MINTED(environmentName = "minted", dependency = LatexPackage.MINTED),
+    PROOF(environmentName = "proof", dependency = LatexPackage.AMSTHM),
     PYCODE(environmentName = "pycode", dependency = LatexPackage.PYTHONTEX),
     PYSUB(environmentName = "pysub", dependency = LatexPackage.PYTHONTEX),
     PYVERBATIM(environmentName = "pyverbatim", dependency = LatexPackage.PYTHONTEX),

--- a/src/nl/hannahsten/texifyidea/lang/LatexPackage.kt
+++ b/src/nl/hannahsten/texifyidea/lang/LatexPackage.kt
@@ -34,6 +34,7 @@ open class LatexPackage @JvmOverloads constructor(
         val ALGPSEUDOCODE = LatexPackage("algpseudocode")
         val AMSFONTS = LatexPackage("amsfonts")
         val AMSMATH = LatexPackage("amsmath")
+        val AMSTHM = LatexPackage("amsthm")
         val AMSSYMB = LatexPackage("amssymb")
         val BIBLATEX = LatexPackage("biblatex")
         val BLINDTEXT = LatexPackage("blindtext")

--- a/src/nl/hannahsten/texifyidea/lang/commands/LatexGenericRegularCommand.kt
+++ b/src/nl/hannahsten/texifyidea/lang/commands/LatexGenericRegularCommand.kt
@@ -2,6 +2,7 @@ package nl.hannahsten.texifyidea.lang.commands
 
 import nl.hannahsten.texifyidea.lang.LatexPackage
 import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.AMSMATH
+import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.AMSTHM
 import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.BIBLATEX
 import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.CLEVEREF
 import nl.hannahsten.texifyidea.lang.LatexPackage.Companion.COLOR
@@ -249,6 +250,7 @@ enum class LatexGenericRegularCommand(
     PRINTNOIDXGLOSSARIES("printnoidxglossaries", dependency = GLOSSARIES),
     PROVIDESCLASS("ProvidesClass"),
     PROVIDESPACKAGE("ProvidesPackage"),
+    QEDHERE("qedhere", dependency = AMSTHM),
     R("r", display = "˚ (accent)"),
     RBRACK("rbrack", display = "]"),
     RPAREN("rparen", display = ")", dependency = MATHTOOLS),

--- a/src/nl/hannahsten/texifyidea/util/Commands.kt
+++ b/src/nl/hannahsten/texifyidea/util/Commands.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.search.GlobalSearchScope
 import nl.hannahsten.texifyidea.index.LatexCommandsIndex
 import nl.hannahsten.texifyidea.index.LatexDefinitionIndex
+import nl.hannahsten.texifyidea.lang.DefaultEnvironment
 import nl.hannahsten.texifyidea.lang.commands.*
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.LatexParameter
@@ -18,7 +19,6 @@ import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.magic.EnvironmentMagic
 import nl.hannahsten.texifyidea.util.magic.cmd
 import nl.hannahsten.texifyidea.util.parser.*
-import nl.hannahsten.texifyidea.util.parser.traverseTyped
 import java.util.stream.Collectors
 
 /**
@@ -59,7 +59,7 @@ fun insertCommandDefinition(file: PsiFile, commandText: String, newCommandName: 
         else if (cmd.name == LatexGenericRegularCommand.USEPACKAGE.cmd) {
             last = cmd
         }
-        else if (cmd.name == LatexGenericRegularCommand.BEGIN.cmd && cmd.requiredParameter(0) == "document") {
+        else if (cmd.name == LatexGenericRegularCommand.BEGIN.cmd && cmd.requiredParameter(0) == DefaultEnvironment.DOCUMENT.environmentName) {
             last = cmd
             break
         }

--- a/src/nl/hannahsten/texifyidea/util/parser/LatexPsiUtil.kt
+++ b/src/nl/hannahsten/texifyidea/util/parser/LatexPsiUtil.kt
@@ -5,6 +5,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiRecursiveElementVisitor
 import nl.hannahsten.texifyidea.file.LatexFile
+import nl.hannahsten.texifyidea.lang.DefaultEnvironment
 import nl.hannahsten.texifyidea.lang.Environment
 import nl.hannahsten.texifyidea.lang.LatexPackage
 import nl.hannahsten.texifyidea.lang.commands.LatexCommand
@@ -46,7 +47,7 @@ fun LatexBeginCommand.requiredParameters(): List<LatexRequiredParam> {
  */
 fun LatexBeginCommand.isEntryPoint(): Boolean {
     // Currently: only allowing `\begin{document}`.
-    return this.environmentName() == "document"
+    return this.environmentName() == DefaultEnvironment.DOCUMENT.environmentName
 }
 
 /**


### PR DESCRIPTION
Before, when asking for documentation for e.g. a command, it would reset the lookup item but only do it once, so if you then asked for docs on another command it would show docs for the first one. Setting the lookup item should only be done when viewing documentation during autocompletion.