### PR TITLE
Avoid nulls in concurrenthashmap in CommandRunner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Fixed
+* Fix exception #4116
 
 ## [0.10.4] - 2025-07-01
 

--- a/src/nl/hannahsten/texifyidea/util/CommandRunner.kt
+++ b/src/nl/hannahsten/texifyidea/util/CommandRunner.kt
@@ -40,7 +40,7 @@ suspend fun runCommandNonBlocking(
         Log.debug("isEDT=${SwingUtilities.isEventDispatchThread()} Executing in ${workingDirectory ?: "current working directory"} ${GeneralCommandLine(*commands).commandLineString}")
 
         // where/which commands occur often but do not change since the output depends on PATH, so can be cached
-        val isExecutableLocationCommand = commands.size == 2 && listOf("where", "which").contains(commands[0])
+        val isExecutableLocationCommand = commands.size == 2 && listOf("where", "which").contains(commands[0]) && commands.getOrNull(1).isNullOrBlank().not()
         val cachedExecutableLocation = SystemEnvironment.executableLocationCache[commands[1]]
         if (isExecutableLocationCommand && cachedExecutableLocation != null) {
             Log.debug("Retrieved output of $commands from cache: $cachedExecutableLocation")
@@ -82,7 +82,7 @@ suspend fun runCommandNonBlocking(
 
             // Update cache of where/which output
             if (isExecutableLocationCommand) {
-                SystemEnvironment.executableLocationCache[commands[1]] = result.standardOutput
+                SystemEnvironment.executableLocationCache[commands[1]] = result.standardOutput ?: ""
             }
 
             return@withContext result


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #4116

Concurrenthashmap does not support null keys or values