### PR TITLE
Always use forward slashes for inserted path in InsertGraphicWizardAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Fixed
+* Fix incorrect slashes in path on Windows after pasting image
 * Fix exception #4116
 
 ## [0.10.4] - 2025-07-01

--- a/src/nl/hannahsten/texifyidea/action/wizard/graphic/InsertGraphicWizardAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/wizard/graphic/InsertGraphicWizardAction.kt
@@ -164,7 +164,8 @@ class InsertGraphicWizardAction(private val initialFile: File? = null) : AnActio
         }
         else absoluteFilePath
 
-        return filePath.removeFileExtension()
+        // LaTeX cannot handle backslashes in path, always replace them
+        return filePath.removeFileExtension().replace("\\", "/")
     }
 
     private fun InsertGraphicData.captionCommand() = buildString {


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #4108

Backslashes are never valid I think, always replace them.