### PR TITLE
Make read action in LatexRunConfiguration smart

### DIFF
--- a/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
+++ b/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
@@ -29,7 +29,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
         override fun createCommand(
             runConfig: LatexRunConfiguration,
             auxilPath: String?,
-            outputPath: String?,
+            outputPath: String,
             moduleRoot: VirtualFile?,
             moduleRoots: Array<VirtualFile>
         ): MutableList<String> {
@@ -66,7 +66,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
         override fun createCommand(
             runConfig: LatexRunConfiguration,
             auxilPath: String?,
-            outputPath: String?,
+            outputPath: String,
             moduleRoot: VirtualFile?,
             moduleRoots: Array<VirtualFile>
         ): MutableList<String> {
@@ -104,7 +104,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
         override fun createCommand(
             runConfig: LatexRunConfiguration,
             auxilPath: String?,
-            outputPath: String?,
+            outputPath: String,
             moduleRoot: VirtualFile?,
             moduleRoots: Array<VirtualFile>
         ): MutableList<String> {
@@ -149,7 +149,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
         override fun createCommand(
             runConfig: LatexRunConfiguration,
             auxilPath: String?,
-            outputPath: String?,
+            outputPath: String,
             moduleRoot: VirtualFile?,
             moduleRoots: Array<VirtualFile>
         ): MutableList<String> {
@@ -195,7 +195,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
         override fun createCommand(
             runConfig: LatexRunConfiguration,
             auxilPath: String?,
-            outputPath: String?,
+            outputPath: String,
             moduleRoot: VirtualFile?,
             moduleRoots: Array<VirtualFile>
         ): MutableList<String> {
@@ -211,9 +211,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
             // commands can be passed to those compilers with the arguments flag, however apparently IntelliJ cannot handle quotes so we cannot pass multiple arguments to pdflatex.
             // Fortunately, -synctex=1 and -interaction=nonstopmode are on by default in texliveonfly
             // Since adding one will work without any quotes, we choose the output directory.
-            if (outputPath != null) {
-                command.add("--arguments=--output-directory=$outputPath")
-            }
+            command.add("--arguments=--output-directory=$outputPath")
 
             return command
         }
@@ -230,7 +228,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
         override fun createCommand(
             runConfig: LatexRunConfiguration,
             auxilPath: String?,
-            outputPath: String?,
+            outputPath: String,
             moduleRoot: VirtualFile?,
             moduleRoots: Array<VirtualFile>
         ): MutableList<String> {
@@ -243,9 +241,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
 
                 command.add("--outfmt=${runConfig.outputFormat.name.lowercase(Locale.getDefault())}")
 
-                if (outputPath != null) {
-                    command.add("--outdir=$outputPath")
-                }
+                command.add("--outdir=$outputPath")
             }
             else {
                 command.add("-X")
@@ -267,7 +263,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
         override fun createCommand(
             runConfig: LatexRunConfiguration,
             auxilPath: String?,
-            outputPath: String?,
+            outputPath: String,
             moduleRoot: VirtualFile?,
             moduleRoots: Array<VirtualFile>
         ): MutableList<String> {
@@ -318,7 +314,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
             "/out"
         }
         else {
-            runConfig.outputPath.getAndCreatePath()?.path?.toWslPathIfNeeded(runConfig.getLatexDistributionType())
+            (runConfig.outputPath.getAndCreatePath() ?: mainFile.parent ).path.toWslPathIfNeeded(runConfig.getLatexDistributionType())
         }
 
         val auxilPath = if (runConfig.getLatexDistributionType() == LatexDistributionType.DOCKER_MIKTEX) {
@@ -450,7 +446,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
     protected open fun createCommand(
         runConfig: LatexRunConfiguration,
         auxilPath: String?,
-        outputPath: String?,
+        outputPath: String,
         moduleRoot: VirtualFile?,
         moduleRoots: Array<VirtualFile>
     ): MutableList<String> = error("Not implemented for $this")

--- a/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
+++ b/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
@@ -285,7 +285,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
     fun getCommand(runConfig: LatexRunConfiguration, project: Project): List<String>? {
         val mainFile = runConfig.mainFile ?: return null
         // Getting the content root is an expensive operation (See WorkspaceFileIndexDataImpl#ensureIsUpToDate), and since it probably won't change often we reuse a cached value
-        val moduleRoot = runConfig.outputPath.contentRoot
+        val moduleRoot = runConfig.outputPath.getMainFileContentRoot(runConfig.mainFile)
         // For now we disable module roots with Docker
         // Could be improved by mounting them to the right directory
         val moduleRoots = if (runConfig.getLatexDistributionType().isDocker()) {
@@ -314,7 +314,7 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
             "/out"
         }
         else {
-            (runConfig.outputPath.getAndCreatePath() ?: mainFile.parent ).path.toWslPathIfNeeded(runConfig.getLatexDistributionType())
+            (runConfig.outputPath.getAndCreatePath() ?: mainFile.parent).path.toWslPathIfNeeded(runConfig.getLatexDistributionType())
         }
 
         val auxilPath = if (runConfig.getLatexDistributionType() == LatexDistributionType.DOCKER_MIKTEX) {

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexOutputPath.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexOutputPath.kt
@@ -9,7 +9,9 @@ import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import nl.hannahsten.texifyidea.settings.sdk.LatexSdkUtil
-import nl.hannahsten.texifyidea.util.files.*
+import nl.hannahsten.texifyidea.util.files.FileUtil
+import nl.hannahsten.texifyidea.util.files.allChildDirectories
+import nl.hannahsten.texifyidea.util.files.createExcludedDir
 import java.io.File
 
 /**
@@ -22,7 +24,7 @@ import java.io.File
  *
  * @param variant: out or auxil
  */
-class LatexOutputPath(private val variant: String, var contentRoot: VirtualFile?, var mainFile: VirtualFile?, private val project: Project) {
+class LatexOutputPath(private val variant: String, var mainFile: VirtualFile?, private val project: Project) {
 
     companion object {
 
@@ -31,7 +33,7 @@ class LatexOutputPath(private val variant: String, var contentRoot: VirtualFile?
     }
 
     fun clone(): LatexOutputPath {
-        return LatexOutputPath(variant, contentRoot, mainFile, project).apply { if (this@LatexOutputPath.pathString.isNotBlank()) this.pathString = this@LatexOutputPath.pathString }
+        return LatexOutputPath(variant, mainFile, project).apply { if (this@LatexOutputPath.pathString.isNotBlank()) this.pathString = this@LatexOutputPath.pathString }
     }
 
     // Acts as a sort of cache
@@ -60,7 +62,7 @@ class LatexOutputPath(private val variant: String, var contentRoot: VirtualFile?
     }
 
     private fun getPath(): VirtualFile? {
-        // When we previously made the mistake of calling findRelativePath with an empty string, the output path will be set to thee /bin folder of IntelliJ. Fix that here, to be sure
+        // When we previously made the mistake of calling findRelativePath with an empty string, the output path will be set to the /bin folder of IntelliJ. Fix that here, to be sure
         if (virtualFile?.path?.endsWith("/bin") == true) {
             virtualFile = null
         }
@@ -69,6 +71,7 @@ class LatexOutputPath(private val variant: String, var contentRoot: VirtualFile?
             return virtualFile!!
         }
         else {
+            val contentRoot = getMainFileContentRoot(mainFile)
             val pathString = if (pathString.contains(PROJECT_DIR_STRING)) {
                 if (contentRoot == null) return if (mainFile != null) mainFile?.parent else null
                 pathString.replace(PROJECT_DIR_STRING, contentRoot?.path ?: return null)
@@ -100,6 +103,17 @@ class LatexOutputPath(private val variant: String, var contentRoot: VirtualFile?
             }
 
             return null
+        }
+    }
+
+    /**
+     * Get the content root of the main file.
+     */
+    fun getMainFileContentRoot(mainFile: VirtualFile?): VirtualFile? {
+        if (mainFile == null) return null
+        if (!project.isInitialized) return null
+        return runReadAction {
+            ProjectRootManager.getInstance(project).fileIndex.getContentRootForFile(mainFile)
         }
     }
 

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexRunConfiguration.kt
@@ -115,9 +115,9 @@ class LatexRunConfiguration(
     suspend fun setMainFile(mainFile: VirtualFile?) {
         this.mainFile = mainFile
         this.outputPath.mainFile = mainFile
-        this.outputPath.contentRoot = getMainFileContentRoot()
+        this.outputPath.contentRoot = getMainFileContentRoot(mainFile)
         this.auxilPath.mainFile = mainFile
-        this.auxilPath.contentRoot = getMainFileContentRoot()
+        this.auxilPath.contentRoot = getMainFileContentRoot(mainFile)
     }
 
     // Save the psifile which can be used to check whether to create a bibliography based on which commands are in the psifile
@@ -322,10 +322,10 @@ class LatexRunConfiguration(
             val outputPathString = parent.getChildText(OUTPUT_PATH)
             if (outputPathString != null) {
                 if (outputPathString.endsWith("/bin")) {
-                    this.outputPath = LatexOutputPath("out", getMainFileContentRoot(), mainFile, project)
+                    this.outputPath = LatexOutputPath("out", getMainFileContentRoot(mainFile), mainFile, project)
                 }
                 else {
-                    this.outputPath = LatexOutputPath("out", getMainFileContentRoot(), mainFile, project)
+                    this.outputPath = LatexOutputPath("out", getMainFileContentRoot(mainFile), mainFile, project)
                     this.outputPath.pathString = outputPathString
                 }
             }
@@ -333,7 +333,7 @@ class LatexRunConfiguration(
             // Read auxil path
             val auxilPathString = parent.getChildText(AUXIL_PATH)
             if (auxilPathString != null) {
-                this.auxilPath = LatexOutputPath("auxil", getMainFileContentRoot(), mainFile, project)
+                this.auxilPath = LatexOutputPath("auxil", getMainFileContentRoot(mainFile), mainFile, project)
                 this.auxilPath.pathString = auxilPathString
             }
         }
@@ -636,11 +636,11 @@ class LatexRunConfiguration(
     /**
      * Get the content root of the main file.
      */
-    suspend fun getMainFileContentRoot(): VirtualFile? {
+    suspend fun getMainFileContentRoot(mainFile: VirtualFile?): VirtualFile? {
         if (mainFile == null) return null
         if (!project.isInitialized) return null
         return smartReadAction(project) {
-            ProjectRootManager.getInstance(project).fileIndex.getContentRootForFile(mainFile!!)
+            ProjectRootManager.getInstance(project).fileIndex.getContentRootForFile(mainFile)
         }
     }
 

--- a/src/nl/hannahsten/texifyidea/run/latex/ui/LatexSettingsEditor.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/ui/LatexSettingsEditor.kt
@@ -33,6 +33,7 @@ import nl.hannahsten.texifyidea.run.makeindex.MakeindexRunConfigurationType
 import nl.hannahsten.texifyidea.run.pdfviewer.PdfViewer
 import nl.hannahsten.texifyidea.run.pdfviewer.SumatraViewer
 import nl.hannahsten.texifyidea.settings.sdk.LatexSdkUtil
+import nl.hannahsten.texifyidea.util.runInBackgroundWithoutProgress
 import java.awt.Cursor
 import java.awt.event.ItemEvent
 import java.awt.event.MouseAdapter
@@ -213,7 +214,9 @@ class LatexSettingsEditor(private var project: Project) : SettingsEditor<LatexRu
         val txtFile = mainFile.component as TextFieldWithBrowseButton
         val filePath = txtFile.text
 
-        runConfiguration.setMainFile(filePath)
+        runInBackgroundWithoutProgress {
+            runConfiguration.setMainFile(filePath)
+        }
 
         val outputPathTextField = outputPath.component as TextFieldWithBrowseButton
         if (!outputPathTextField.text.endsWith("/bin")) {

--- a/src/nl/hannahsten/texifyidea/run/latex/ui/LatexSettingsEditor.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/ui/LatexSettingsEditor.kt
@@ -33,7 +33,6 @@ import nl.hannahsten.texifyidea.run.makeindex.MakeindexRunConfigurationType
 import nl.hannahsten.texifyidea.run.pdfviewer.PdfViewer
 import nl.hannahsten.texifyidea.run.pdfviewer.SumatraViewer
 import nl.hannahsten.texifyidea.settings.sdk.LatexSdkUtil
-import nl.hannahsten.texifyidea.util.runInBackgroundWithoutProgress
 import java.awt.Cursor
 import java.awt.event.ItemEvent
 import java.awt.event.MouseAdapter
@@ -214,9 +213,7 @@ class LatexSettingsEditor(private var project: Project) : SettingsEditor<LatexRu
         val txtFile = mainFile.component as TextFieldWithBrowseButton
         val filePath = txtFile.text
 
-        runInBackgroundWithoutProgress {
-            runConfiguration.setMainFile(filePath)
-        }
+        runConfiguration.setMainFile(filePath)
 
         val outputPathTextField = outputPath.component as TextFieldWithBrowseButton
         if (!outputPathTextField.text.endsWith("/bin")) {

--- a/test/nl/hannahsten/texifyidea/run/LatexOutputPathTest.kt
+++ b/test/nl/hannahsten/texifyidea/run/LatexOutputPathTest.kt
@@ -23,7 +23,7 @@ class LatexOutputPathTest : BasePlatformTestCase() {
         runConfig.psiFile = mainFile.createSmartPointer()
         runBlocking {
             runConfig.setMainFile("main.tex")
-            val outPath = LatexOutputPath("out", runConfig.getMainFileContentRoot(), runConfig.mainFile, project)
+            val outPath = LatexOutputPath("out", runConfig.getMainFileContentRoot(runConfig.mainFile), runConfig.mainFile, project)
             // Cannot mkdirs in test, so will default to src
             assertEquals("/src", outPath.getAndCreatePath()?.path)
         }

--- a/test/nl/hannahsten/texifyidea/run/LatexOutputPathTest.kt
+++ b/test/nl/hannahsten/texifyidea/run/LatexOutputPathTest.kt
@@ -23,7 +23,7 @@ class LatexOutputPathTest : BasePlatformTestCase() {
         runConfig.psiFile = mainFile.createSmartPointer()
         runBlocking {
             runConfig.setMainFile("main.tex")
-            val outPath = LatexOutputPath("out", runConfig.getMainFileContentRoot(runConfig.mainFile), runConfig.mainFile, project)
+            val outPath = LatexOutputPath("out", runConfig.mainFile, project)
             // Cannot mkdirs in test, so will default to src
             assertEquals("/src", outPath.getAndCreatePath()?.path)
         }

--- a/test/nl/hannahsten/texifyidea/run/LatexOutputPathTest.kt
+++ b/test/nl/hannahsten/texifyidea/run/LatexOutputPathTest.kt
@@ -2,6 +2,7 @@ package nl.hannahsten.texifyidea.run
 
 import com.intellij.psi.createSmartPointer
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import kotlinx.coroutines.runBlocking
 import nl.hannahsten.texifyidea.run.latex.LatexOutputPath
 import nl.hannahsten.texifyidea.run.latex.LatexRunConfiguration
 import nl.hannahsten.texifyidea.run.latex.LatexRunConfigurationProducer
@@ -20,9 +21,11 @@ class LatexOutputPathTest : BasePlatformTestCase() {
         )
         val runConfig = LatexRunConfiguration(myFixture.project, LatexRunConfigurationProducer().configurationFactory, "Test run config")
         runConfig.psiFile = mainFile.createSmartPointer()
-        runConfig.setMainFile("main.tex")
-        val outPath = LatexOutputPath("out", runConfig.getMainFileContentRoot(), runConfig.mainFile, project)
-        // Cannot mkdirs in test, so will default to src
-        assertEquals("/src", outPath.getAndCreatePath()?.path)
+        runBlocking {
+            runConfig.setMainFile("main.tex")
+            val outPath = LatexOutputPath("out", runConfig.getMainFileContentRoot(), runConfig.mainFile, project)
+            // Cannot mkdirs in test, so will default to src
+            assertEquals("/src", outPath.getAndCreatePath()?.path)
+        }
     }
 }

--- a/test/nl/hannahsten/texifyidea/run/LatexRunConfigurationTest.kt
+++ b/test/nl/hannahsten/texifyidea/run/LatexRunConfigurationTest.kt
@@ -2,6 +2,7 @@ package nl.hannahsten.texifyidea.run
 
 import com.intellij.psi.createSmartPointer
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import kotlinx.coroutines.runBlocking
 import nl.hannahsten.texifyidea.run.bibtex.BibtexRunConfiguration
 import nl.hannahsten.texifyidea.run.compiler.LatexCompiler
 import nl.hannahsten.texifyidea.run.latex.LatexOutputPath
@@ -38,7 +39,9 @@ class LatexRunConfigurationTest : BasePlatformTestCase() {
         )
         val runConfig = LatexRunConfiguration(myFixture.project, LatexRunConfigurationProducer().configurationFactory, "Test run config")
         runConfig.psiFile = mainFile.createSmartPointer()
-        runConfig.setMainFile("main.tex")
+        runBlocking {
+            runConfig.setMainFile("main.tex")
+        }
         runConfig.generateBibRunConfig()
         assertTrue(runConfig.bibRunConfigs.isNotEmpty())
         assertEquals(mainFile.virtualFile, (runConfig.bibRunConfigs.first().configuration as BibtexRunConfiguration).mainFile)


### PR DESCRIPTION
Similar to #4131 I encountered a UI freeze, and found one more read action. However this one is actually needed, so I set the main file in the background and hope that works.

- [x] Fix case when creating new run config from context