### PR TITLE
Fix relative path not working in `InsertGraphicWizardAction`.

### DIFF
--- a/src/nl/hannahsten/texifyidea/action/wizard/graphic/InsertGraphicWizardAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/wizard/graphic/InsertGraphicWizardAction.kt
@@ -9,14 +9,17 @@ import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.util.io.toNioPathOrNull
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.toNioPathOrNull
 import com.intellij.psi.PsiFile
 import nl.hannahsten.texifyidea.lang.LatexPackage
 import nl.hannahsten.texifyidea.lang.graphic.CaptionLocation
 import nl.hannahsten.texifyidea.util.*
 import nl.hannahsten.texifyidea.util.files.*
 import java.io.File
+import kotlin.io.path.invariantSeparatorsPathString
 
 /**
  * Action that shows a dialog with a graphic insertion wizard, and inserts the graphic as latex at the location of the
@@ -148,24 +151,23 @@ class InsertGraphicWizardAction(private val initialFile: File? = null) : AnActio
     }
 
     private fun InsertGraphicData.convertFilePath(project: Project, absoluteFilePath: String, rootFile: PsiFile?): String {
+        val absPath = absoluteFilePath.toNioPathOrNull() ?: return absoluteFilePath
         val rootManager = ProjectRootManager.getInstance(project)
 
         val filePath = if (relativePath) {
             // We need to match the path given by the user (from e.g. the file chooser dialog) to the root file
-            val imageFile = LocalFileSystem.getInstance().findFileByPath(absoluteFilePath)
-
-            val default = rootManager.relativizePath(absoluteFilePath) ?: absoluteFilePath
+            val imageFile = LocalFileSystem.getInstance().findFileByNioFile(absPath)
             if (rootFile != null && imageFile != null) {
-                FileUtil.pathRelativeTo(rootFile.virtualFile.parent.path + "/", imageFile.path) ?: default
+                FileUtil.pathRelativeTo(rootFile.virtualFile.toNioPathOrNull()?.parent, imageFile.toNioPathOrNull())?.invariantSeparatorsPathString
             }
             else {
-                default
+                rootManager.relativizePath(absoluteFilePath)
             }
         }
         else absoluteFilePath
 
         // LaTeX cannot handle backslashes in path, always replace them
-        return filePath.removeFileExtension().replace("\\", "/")
+        return filePath ?: absoluteFilePath
     }
 
     private fun InsertGraphicData.captionCommand() = buildString {

--- a/src/nl/hannahsten/texifyidea/util/files/Files.kt
+++ b/src/nl/hannahsten/texifyidea/util/files/Files.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.io.FileUtilRt
+import com.intellij.openapi.util.io.toNioPathOrNull
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiDocumentManager
@@ -69,10 +70,12 @@ object FileUtil {
      */
     @JvmStatic
     fun pathRelativeTo(rootPath: String, filePath: String): String? {
-        if (!filePath.startsWith(rootPath)) {
-            return null
-        }
-        return filePath.substring(rootPath.length)
+        return pathRelativeTo(rootPath.toNioPathOrNull(), filePath.toNioPathOrNull())?.pathString
+    }
+
+    fun pathRelativeTo(rootPath: Path?, filePath: Path?): Path? {
+        if (rootPath == null || filePath == null) return null
+        return runCatching { rootPath.relativize(filePath) }.getOrNull()
     }
 }
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #4148: If we have the main file `sub/main.tex` and a figure `fig/one.pdf`, then `InsertGraphicWizardAction` should produce `\includegraphics{../fig/one.pdf}` but not the absolute path.

#### Summary of additions and changes

* Use `Path#relativize(Path)` instead to obtain the relative path.

#### How to test this pull request

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary