### PR TITLE
robustness improvement, refactor Java and Kotlin source compatibility versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ import org.jetbrains.changelog.Changelog
 import org.jetbrains.grammarkit.tasks.GenerateLexerTask
 import org.jetbrains.grammarkit.tasks.GenerateParserTask
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 fun properties(key: String) = project.findProperty(key).toString()
 
@@ -60,12 +61,16 @@ sourceSets {
     }
 }
 
+val targetVersion = "21"
+
 // Java target version
-java.sourceCompatibility = JavaVersion.VERSION_21
+java.sourceCompatibility = JavaVersion.toVersion(targetVersion)
+val kotlinJvmTarget = JvmTarget.fromTarget(targetVersion)
 
 // Specify the right jvm target for Kotlin
 tasks.compileKotlin {
     compilerOptions {
+        jvmTarget.set(kotlinJvmTarget)
         freeCompilerArgs = listOf("-Xjvm-default=all")
     }
 }
@@ -73,6 +78,7 @@ tasks.compileKotlin {
 // Same for Kotlin tests
 tasks.compileTestKotlin {
     compilerOptions {
+        jvmTarget.set(kotlinJvmTarget)
         freeCompilerArgs = listOf("-Xjvm-default=all")
     }
 }


### PR DESCRIPTION
I found that when compiling the project with a higher version of the JDK, the compilation would fail due to a mismatch between the Java version and the Kotlin JDK target. Therefore, I made some changes to build.gradle.kts. Below is the original commit message:

- **Updated Java version**: Changed `JavaVersion.VERSION_21` to `JavaVersion.toVersion("21")`.
- **Added Kotlin JVM target**: Introduced a variable `kotlinJvmTarget` using `JvmTarget.fromTarget("21")`.
- **Set JVM targets in Kotlin tasks**: Applied the new Kotlin JVM target to compileKotlin and compileTestKotlin tasks.

This refactoring ensures consistency across Java and Kotlin source versions, improving build compatibility and performance.

<!-- The issue that is fixed by this PR, if applicable: -->
Fix #

#### Summary of additions and changes

* 

#### How to test this pull request

```latex

```

- [ ] Updated the documentation, or no update necessary
- [ ] Added tests, or no tests necessary