### PR TITLE
Correct quickfix for missing acronym reference for acronym package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+* Add support for acronym package to missing aronym references inspection
 * Automatically reload pdf when using latexmk continuous update
 * Support no-break space character in parser
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -264,7 +264,7 @@ tasks.test {
     useJUnitPlatform()
     // Show test results
     testLogging {
-        events(TestLogEvent.FAILED, TestLogEvent.SKIPPED, TestLogEvent.PASSED)
+        events(TestLogEvent.FAILED, TestLogEvent.SKIPPED)
         exceptionFormat = TestExceptionFormat.FULL
     }
 

--- a/test/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexMissingGlossaryReferenceInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexMissingGlossaryReferenceInspectionTest.kt
@@ -7,7 +7,7 @@ import nl.hannahsten.texifyidea.updateFilesets
 class LatexMissingGlossaryReferenceInspectionTest : TexifyInspectionTestBase(LatexMissingGlossaryReferenceInspection()) {
 
     fun testMissingReference() {
-        myFixture.configureByText(LatexFileType, """\newglossaryentry{sample}{name={sample},description={an example}} \gls{sample} \Glslink{sample} <warning descr="Missing glossary reference">sample</warning>""")
+        myFixture.configureByText(LatexFileType, """\newglossaryentry{sample}{name={sample},description={an example}} \gls{sample} \Glslink{sample} <warning descr="Missing glossary or acronym reference">sample</warning>""")
         myFixture.checkHighlighting()
     }
 
@@ -96,7 +96,7 @@ class LatexMissingGlossaryReferenceInspectionTest : TexifyInspectionTestBase(Lat
             
             \begin{document}
                 A \gls{sample}.
-                <warning descr="Missing glossary reference">sample</warning>
+                <warning descr="Missing glossary or acronym reference">sample</warning>
             \end{document}
             """.trimIndent()
         )

--- a/test/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexMissingGlossaryReferenceInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/typesetting/LatexMissingGlossaryReferenceInspectionTest.kt
@@ -103,4 +103,30 @@ class LatexMissingGlossaryReferenceInspectionTest : TexifyInspectionTestBase(Lat
         myFixture.updateFilesets()
         myFixture.checkHighlighting()
     }
+
+    fun testAcronym() {
+        testQuickFix(
+            """
+            \documentclass{article}
+            \usepackage{acronym}
+            \begin{document}
+            	\begin{acronym}
+            		\acro{CD}{Compact Disc}
+            	\end{acronym}
+            	Play CD.
+            \end{document}
+            """.trimIndent(),
+            """
+            \documentclass{article}
+            \usepackage{acronym}
+            \begin{document}
+            	\begin{acronym}
+            		\acro{CD}{Compact Disc}
+            	\end{acronym}
+                Play \ac{CD}.
+            \end{document}
+            """.trimIndent(),
+            updateCommand = true,
+        )
+    }
 }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #4201

Seems unnecessary to create a separate inspection as glossaries also provides acronyms in the same way.