### PR TITLE
Do not override hardcoded command definitions 

### DIFF
--- a/src/nl/hannahsten/texifyidea/completion/LatexLabelReferenceProvider.kt
+++ b/src/nl/hannahsten/texifyidea/completion/LatexLabelReferenceProvider.kt
@@ -7,9 +7,11 @@ import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.psi.search.GlobalSearchScope
 import nl.hannahsten.texifyidea.TexifyIcons
 import nl.hannahsten.texifyidea.completion.handlers.LatexReferenceInsertHandler
+import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.index.FilesetData
 import nl.hannahsten.texifyidea.index.LatexProjectStructure
 import nl.hannahsten.texifyidea.index.NewLabelsIndex
+import nl.hannahsten.texifyidea.index.restrictedByFileTypes
 
 object LatexLabelReferenceProvider : LatexContextAgnosticCompletionProvider() {
 
@@ -57,7 +59,7 @@ object LatexLabelReferenceProvider : LatexContextAgnosticCompletionProvider() {
 
         val rs = result.withPrefixMatcher(PlainPrefixMatcher(result.prefixMatcher.prefix, false))
         // the label names are not necessarily camel case, so we use a plain prefix matcher
-        addCompletionsUnderFileset(parameters, rs, filesetData.filesetScope)
+        addCompletionsUnderFileset(parameters, rs, filesetData.filesetScope.restrictedByFileTypes(LatexFileType))
         addExternalDocumentCompletions(parameters, rs, filesetData)
     }
 }

--- a/src/nl/hannahsten/texifyidea/index/LatexDefinitionService.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexDefinitionService.kt
@@ -395,7 +395,7 @@ class WorkingFilesetDefinitionBundle(
      * Overwrite the definition for a custom command or environment.
      */
     fun addCustomDefinition(def: SourcedDefinition) {
-        // if we find that nothing is parsed for a user-defined command, we try to merge it anyway
+        // override if user-defined
         if (def.source == DefinitionSource.UserDefined) {
             allNameLookup[def.entity.name] = def
         }

--- a/src/nl/hannahsten/texifyidea/index/LatexDefinitionService.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexDefinitionService.kt
@@ -395,8 +395,13 @@ class WorkingFilesetDefinitionBundle(
      * Overwrite the definition for a custom command or environment.
      */
     fun addCustomDefinition(def: SourcedDefinition) {
-        // always overwrite for user-defined commands
-        allNameLookup[def.entity.name] = def
+        // if we find that nothing is parsed for a user-defined command, we try to merge it anyway
+        if (def.source == DefinitionSource.UserDefined) {
+            allNameLookup[def.entity.name] = def
+        }
+        else {
+            allNameLookup.merge(def.entity.name, def, LatexDefinitionUtil::mergeDefinition)
+        }
     }
 
     override fun sourcedDefinitions(): Collection<SourcedDefinition> {

--- a/src/nl/hannahsten/texifyidea/index/LatexDefinitionUtil.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexDefinitionUtil.kt
@@ -241,6 +241,7 @@ object LatexDefinitionUtil {
     }
 
     private fun parseCommandDefNameOnlyUnderCtx(defCommand: LatexCommands, requiredCtx: LContextSet? = null): LSemanticCommand? {
+        // note that requiredCtx == null means applicable in all contexts
         val declaredName = defCommand.requiredParameterText(0) ?: return null
         return LSemanticCommand(declaredName.removePrefix("\\"), LatexLib.CUSTOM, requiredCtx)
     }
@@ -386,6 +387,7 @@ object LatexDefinitionUtil {
     }
 
     private fun parseEnvDefNameOnlyUnderCtx(defCommand: LatexCommands, requiredCtx: LContextSet? = null): LSemanticEnv? {
+        // note that requiredCtx == null means applicable in all contexts
         val declaredName = defCommand.requiredParameterText(0) ?: return null
         return LSemanticEnv(declaredName, LatexLib.CUSTOM, requiredCtx)
     }

--- a/src/nl/hannahsten/texifyidea/index/LatexDefinitionUtil.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexDefinitionUtil.kt
@@ -240,7 +240,7 @@ object LatexDefinitionUtil {
         }
     }
 
-    private fun parseCommandDefNameOnlyUnderCtx(defCommand: LatexCommands, requiredCtx: LContextSet = emptySet()): LSemanticCommand? {
+    private fun parseCommandDefNameOnlyUnderCtx(defCommand: LatexCommands, requiredCtx: LContextSet? = null): LSemanticCommand? {
         val declaredName = defCommand.requiredParameterText(0) ?: return null
         return LSemanticCommand(declaredName.removePrefix("\\"), LatexLib.CUSTOM, requiredCtx)
     }
@@ -290,7 +290,7 @@ object LatexDefinitionUtil {
     private fun buildCommandSemantics(
         project: Project, lookup: LatexSemanticsLookup,
         rawName: String, codeRawText: String?, argSignature: List<LArgumentType>
-    ): LSemanticCommand? {
+    ): LSemanticCommand {
         val name = rawName.removePrefix("\\") // remove the leading backslash
         codeRawText ?: return LSemanticCommand(name, LatexLib.CUSTOM)
         val codeText = codeRawText.trim()
@@ -319,7 +319,7 @@ object LatexDefinitionUtil {
     }
 
     private fun guessApplicableContexts(definitionElement: PsiElement?, lookup: LatexSemanticsLookup): LContextSet? {
-        definitionElement ?: return emptySet()
+        definitionElement ?: return null
         val applicableContexts = mutableSetOf<LatexContext>()
         LatexPsiUtil.traverseRecordingContextIntro(definitionElement, lookup) { e, introList ->
             val requiredContext: LContextSet? = when (e) {
@@ -348,7 +348,7 @@ object LatexDefinitionUtil {
             if (!e.textContains('#')) return@traverse
             parameterPlaceholderRegex.findAll(e.text).forEach { match ->
                 val paramIndex = match.value.removePrefix("#").toIntOrNull() ?: return@forEach
-                if (paramIndex < 1 || paramIndex > argCount) return@forEach
+                if (paramIndex !in 1..argCount) return@forEach
                 val reducedIntro = LatexContextIntro.composeList(introList)
                 val prevIntro = contextIntroArr[paramIndex - 1]
                 contextIntroArr[paramIndex - 1] = prevIntro?.let { LatexContextIntro.union(it, reducedIntro) } ?: reducedIntro
@@ -385,7 +385,7 @@ object LatexDefinitionUtil {
         }
     }
 
-    private fun parseEnvDefNameOnlyUnderCtx(defCommand: LatexCommands, requiredCtx: LContextSet = emptySet()): LSemanticEnv? {
+    private fun parseEnvDefNameOnlyUnderCtx(defCommand: LatexCommands, requiredCtx: LContextSet? = null): LSemanticEnv? {
         val declaredName = defCommand.requiredParameterText(0) ?: return null
         return LSemanticEnv(declaredName, LatexLib.CUSTOM, requiredCtx)
     }


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #4220.

#### Summary of additions and changes

* Do not override hardcoded commands even if we see a redefinition in user-provided `.sty` files.
* Some other minor fixes.

- [x] Updated the documentation, or no update necessary
- [x] Added tests, or no tests necessary