### PR TITLE
Add support for multiple paths (comma-separated) in TEXMFHOME environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add support for acronym package to missing aronym references inspection
 * Automatically reload pdf when using latexmk continuous update
 * Support no-break space character in parser
+* Add support for multiple paths (comma-separated) in TEXMFHOME environment variables
 
 ### Fixed
 

--- a/src/nl/hannahsten/texifyidea/util/SystemEnvironment.kt
+++ b/src/nl/hannahsten/texifyidea/util/SystemEnvironment.kt
@@ -138,7 +138,9 @@ fun getTexinputsPaths(
 
     // Most files are searched for in subdirectories of tex/generic or tex/latex, see kpsewhich -help-format | grep -1 sty
     (configurationTexmfhomeVariables + systemTexmfhome)
-        .mapNotNull { it?.trim('\'', '/')?.replaceFirst("~", System.getProperty("user.home")) }
+        .filterNotNull()
+        .flatMap { it.split(",") }
+        .map { it.trim('\'', '/').replaceFirst("~", System.getProperty("user.home")) }
         .mapNotNull { LocalFileSystem.getInstance().findFileByPath("$it/tex") }
         .forEach { parent ->
             searchPaths.addAll(


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #4207