### PR TITLE
Do not trigger auto-compilation when non-physical files are saved

### DIFF
--- a/src/nl/hannahsten/texifyidea/editor/autocompile/AutoCompileVfsListener.kt
+++ b/src/nl/hannahsten/texifyidea/editor/autocompile/AutoCompileVfsListener.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.application.EDT
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.vfs.AsyncFileListener
 import com.intellij.openapi.vfs.AsyncFileListener.ChangeApplier
+import com.intellij.openapi.vfs.NonPhysicalFileSystem
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent
 import com.intellij.openapi.wm.WindowManager
 import kotlinx.coroutines.Dispatchers
@@ -20,7 +21,7 @@ import nl.hannahsten.texifyidea.util.TexifyCoroutine
 class AutoCompileVfsListener : AsyncFileListener {
 
     override fun prepareChange(events: MutableList<out VFileEvent>): ChangeApplier? {
-        if (TexifySettings.getState().autoCompileOption != TexifySettings.AutoCompile.AFTER_DOCUMENT_SAVE || !events.any { it.file?.fileType == LatexFileType }) return null
+        if (TexifySettings.getState().autoCompileOption != TexifySettings.AutoCompile.AFTER_DOCUMENT_SAVE || !events.any { it.file?.fileType == LatexFileType && it.file?.fileSystem !is NonPhysicalFileSystem }) return null
         return object : ChangeApplier {
             override fun afterVfsChange() {
                 super.afterVfsChange()


### PR DESCRIPTION
Since staging is performed via virtual files, it can trigger auto-compilation, which is incorrect as no files on disk actually change. This commit filters out non-physical files to ensure that compilation is performed only when necessary.

Fixes #4235